### PR TITLE
fix: allow grouped multi-equality comparison inside function args

### DIFF
--- a/source/parser/parser.c
+++ b/source/parser/parser.c
@@ -321,7 +321,13 @@ static void parse_grouping(CandoParser *p, bool can_assign)
         return;
     }
 
+    /* Explicit parens allow multi-comparison (e.g. (i == 1, 3, 5)) even
+     * inside comma-separated contexts like function arguments.  Zero
+     * call_depth so MULTI_CMP can consume the comma list, then restore. */
+    u32 saved_depth = p->call_depth;
+    p->call_depth = 0;
     parse_expression(p);
+    p->call_depth = saved_depth;
     consume(p, TOK_RPAREN, "expected ')' after expression");
 }
 

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -336,6 +336,19 @@ TEST(test_comparison_operators)
     }
 }
 
+TEST(test_grouped_multi_eq)
+{
+    /* (x == 1, 3, 5) inside a function arg must emit OP_EQ_STACK, not error */
+    CandoChunk *c = compile_ok("foo((x == 1, 3, 5));");
+    EXPECT_TRUE(find_op(c, OP_EQ_STACK) >= 0);
+    cando_chunk_free(c);
+
+    /* Same pattern at top level should also work */
+    c = compile_ok("(x == 2, 4, 6);");
+    EXPECT_TRUE(find_op(c, OP_EQ_STACK) >= 0);
+    cando_chunk_free(c);
+}
+
 TEST(test_logical_and)
 {
     /* AND uses OP_AND_JUMP for short-circuit */
@@ -790,6 +803,7 @@ int main(void)
 
     printf("\n-- comparison / logical --\n");
     run_test("comparison operators",           test_comparison_operators);
+    run_test("grouped multi-equality (==)",    test_grouped_multi_eq);
     run_test("logical AND short-circuit",      test_logical_and);
     run_test("logical OR short-circuit",       test_logical_or);
 


### PR DESCRIPTION
(i == 1, 3, 5, 7) inside a call like print(..., (i == 1, 3, 5, 7)) was failing with "expected ')' after expression" because call_depth > 0 prevented MULTI_CMP from consuming the comma list.

parse_grouping now saves and zeros call_depth before parsing the inner expression, then restores it. This lets explicit parentheses act as a scope boundary for multi-comparison regardless of the surrounding context.

https://claude.ai/code/session_01J5PXT7rYHNVsFqfVGWnfzN