### PR TITLE
Link OpenSSL statically on Windows to simplify distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ endif()
 # Platform link libraries
 # ----------------------------------------------------------------------------
 if(WIN32)
-    set(PLATFORM_LIBS ws2_32 m)
+    # crypt32 is required by OpenSSL's static libcrypto on Windows.
+    set(PLATFORM_LIBS ws2_32 crypt32 m)
 else()
     set(PLATFORM_LIBS m dl)
 endif()
@@ -26,6 +27,11 @@ endif()
 find_package(Threads REQUIRED)
 
 # OpenSSL (hard dependency for the http/https standard library)
+# On Windows, prefer static OpenSSL so libcrypto-3-x64.dll / libssl-3-x64.dll
+# do not need to ship alongside cando.exe and libcando.dll.
+if(WIN32)
+    set(OPENSSL_USE_STATIC_LIBS TRUE)
+endif()
 find_package(OpenSSL REQUIRED)
 
 # ----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -266,18 +266,26 @@ CFLAGS_WIN  = -std=c11 -Wall -Wextra -DCANDO_PLATFORM_WINDOWS -D_WIN32_WINNT=0x0
 CFLAGS_EXE_WIN = -std=c11 -Wall -Wextra -DCANDO_PLATFORM_WINDOWS -D_WIN32_WINNT=0x0600 \
                  -iquote source -iquote source/core -Iinclude
 
-LDFLAGS_WIN = -lm -lws2_32 -lssl -lcrypto -static-libgcc
+# OpenSSL is linked statically into libcando.dll so the only files needed
+# at runtime are cando.exe and libcando.dll (no libcrypto-3-x64.dll, etc.).
+# crypt32 is required by OpenSSL's static libcrypto on Windows.
+LDFLAGS_LIB_WIN = -static-libgcc \
+                  -Wl,-Bstatic -lssl -lcrypto -Wl,-Bdynamic \
+                  -lws2_32 -lcrypt32 -lm
+
+# The executable links against libcando.dll only — no OpenSSL needed here.
+LDFLAGS_EXE_WIN = -static-libgcc -lws2_32 -lm
 
 libcando.dll: $(CANDO_LIB_SRCS) $(CANDO_WIN_EXTRA)
-	$(MINGW_CC) $(CFLAGS_WIN) -shared $^ -o $@ $(LDFLAGS_WIN) \
-	    -Wl,--out-implib,libcando.lib
+	$(MINGW_CC) $(CFLAGS_WIN) -shared $^ -o $@ \
+	    -Wl,--out-implib,libcando.lib $(LDFLAGS_LIB_WIN)
 
 icon.res: source/icon.rc assets/icon.ico
 	cd source && $(WINDRES) icon.rc -O coff -o ../icon.res
 
 cando.exe: source/main.c libcando.dll icon.res
 	$(MINGW_CC) $(CFLAGS_EXE_WIN) source/main.c icon.res \
-	    -L. -lcando -o $@ $(LDFLAGS_WIN)
+	    -L. -lcando -o $@ $(LDFLAGS_EXE_WIN)
 
 # ---------------------------------------------------------------------------
 # Clean


### PR DESCRIPTION
## Summary
This change modifies the Windows build configuration to statically link OpenSSL into `libcando.dll`, eliminating the need to distribute separate OpenSSL DLLs (`libcrypto-3-x64.dll`, `libssl-3-x64.dll`, etc.) alongside the executable.

## Key Changes
- **Makefile**: Split `LDFLAGS_WIN` into two separate variables:
  - `LDFLAGS_LIB_WIN`: Statically links OpenSSL (`-Wl,-Bstatic -lssl -lcrypto -Wl,-Bdynamic`) and includes `crypt32` (required by static libcrypto on Windows)
  - `LDFLAGS_EXE_WIN`: Links only against `libcando.dll` without OpenSSL dependencies
  
- **CMakeLists.txt**: 
  - Added `crypt32` to `PLATFORM_LIBS` for Windows (required by OpenSSL's static libcrypto)
  - Set `OPENSSL_USE_STATIC_LIBS=TRUE` for Windows builds to prefer static OpenSSL libraries

## Implementation Details
- OpenSSL is now embedded in `libcando.dll` on Windows, reducing runtime dependencies to just `cando.exe` and `libcando.dll`
- The executable (`cando.exe`) links against the DLL only, avoiding redundant OpenSSL linkage
- `crypt32` is a Windows system library required by OpenSSL's static libcrypto implementation
- Both Makefile and CMake build systems are updated consistently

https://claude.ai/code/session_01UCEsq6tBb8ybhJmHkpBza6