### PR TITLE
Redesign CLASS as callable constructors with __constructor + __call

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -392,35 +392,92 @@ their own `pipe` binding.
 
 ## Classes
 
-`CLASS` defines an object whose methods are stored as fields and
-accessible via the `__index` prototype chain.  Method calls with `:`
-pass the receiver as the first argument (`self`).
-
-A factory method should call `object.setPrototype(inst, ClassName)` so
-that instances inherit the class methods:
+`CLASS` defines a callable table.  Calling the class
+(`Vector(1, 2, 3)`) produces a fresh instance whose `__index` points back
+at the class so methods are reachable via the prototype chain.  The body
+between the braces is the **constructor body**; the parameter list comes
+right after the `=` sign:
 
 ```cando
-CLASS Point {
-    FUNCTION make(x, y) {
-        VAR p = { x: x, y: y };
-        object.setPrototype(p, Point);    // p.__index = Point
-        RETURN p;
-    }
-    FUNCTION dist(self) {
-        RETURN math.sqrt(self.x * self.x + self.y * self.y);
-    }
+CLASS Vector = (self, x, y, z) {
+    self.x = x;
+    self.y = y;
+    self.z = z;
 }
 
-print(type(Point));        // Point  (__type set by CLASS)
-VAR p = Point.make(3, 4);
-print(p:dist());           // 5
+VAR v = Vector(1, 2, 3);
+print(type(v));            // Vector
+print(v.x, v.y, v.z);      // 1 2 3
 ```
 
-`CLASS` automatically sets `__type` to the class name (immutable).
-Method declarations inside a class body may be preceded by `STATIC`
-and/or `PRIVATE`, which are accepted by the parser as field-flag hints.
-See [metamethods.md](metamethods.md) for the full prototype system and
-all available meta-keys.
+Methods, including operator metamethods, are added afterwards as ordinary
+field assignments on the class:
+
+```cando
+Vector.__add = FUNCTION(a, b) {
+    RETURN Vector(a.x + b.x, a.y + b.y, a.z + b.z);
+};
+Vector.length = FUNCTION(self) {
+    RETURN math.sqrt(self.x * self.x +
+                     self.y * self.y +
+                     self.z * self.z);
+};
+
+VAR sum = Vector(1, 2, 3) + Vector(4, 5, 6);
+print(sum:length());       // ~10.49
+```
+
+### Three forms
+
+```cando
+// Statement form -- declares a global named after the class.
+//   - The leading `=` is required.
+//   - __type is set to the class name.
+class Vector = (self, x, y, z) { ... }
+
+// Anonymous expression form -- no __type is set.
+var Vector = class (self, x, y, z) { ... };
+
+// Named expression form -- __type = "Vector".
+var Vector = class Vector (self, x, y, z) { ... };
+```
+
+The parameter list is optional; `class Foo = { }` declares an empty
+class with no constructor arguments.
+
+### Inheritance
+
+`EXTENDS` records a parent class so that field lookups fall through the
+parent when a key is not present on the child or its instance.  Use the
+parent's class object directly (via `Child.__index`) to call a parent
+method explicitly -- there is no `super` keyword:
+
+```cando
+class Animal = (self, name) { self.name = name; }
+Animal.speak = FUNCTION(self) { RETURN self.name + " says hello"; };
+
+class Dog extends Animal = (self, name, breed) {
+    Animal.__constructor(self, name);   // call the parent constructor
+    self.breed = breed;
+}
+Dog.bark = FUNCTION(self) {
+    // Dog.__index points at Animal.
+    RETURN Dog.__index.speak(self) + " (woof, " + self.breed + ")";
+};
+
+VAR rex = Dog("Rex", "labrador");
+print(rex:bark());     // Rex says hello (woof, labrador)
+```
+
+### Keyword case
+
+CanDo keywords are case-insensitive but reject mixed-case spellings.
+`class`, `CLASS`, `var`, `VAR`, `extends`, `EXTENDS` etc. all work; a
+mixed-case form like `Class` or `eXtEnDs` is treated as an ordinary
+identifier.
+
+See [metamethods.md](metamethods.md) for the full prototype system,
+the desugaring of `class`, and all available meta-keys.
 
 ## Threads
 

--- a/docs/metamethods.md
+++ b/docs/metamethods.md
@@ -30,7 +30,8 @@ All meta-key strings are pre-interned at startup.  The corresponding global
 | `__pow`       | `g_meta_pow`       | `a ^ b`                                  |
 | `__unm`       | `g_meta_unm`       | Unary `-obj`                             |
 | `__idiv`      | `g_meta_idiv`      | Integer division (reserved)              |
-| `__call`      | `g_meta_call`      | Reserved — not yet dispatched            |
+| `__call`      | `g_meta_call`      | `obj(...)` when `obj` is not a function  |
+| `__constructor` | `g_meta_constructor` | Run by the default class `__call`       |
 
 Metamethods can be **native** C functions, inline **script** functions
 (number PC offsets), or **OBJ_FUNCTION** closures.  The VM dispatcher
@@ -108,77 +109,112 @@ print(type(vec));    // Vec3
 
 ---
 
-## `CLASS` — prototype-based class declarations
+## `CLASS` — callable class objects
 
-`CLASS` is syntactic sugar that creates a plain object whose methods are
-stored as fields.  Instances are created manually by a factory method that
-sets `__index` back to the class so field lookups traverse the method table.
+`CLASS` produces a plain object that is **callable**.  Calling the class
+runs a default `__call` wrapper that allocates a fresh instance, links it
+to the class via `__index`, and runs the class's `__constructor` on the
+new instance.  The body between the braces is the constructor body; its
+parameters come right after the `=` sign.
 
 ```cando
-CLASS Point {
-    FUNCTION make(x, y) {
-        VAR p = { x: x, y: y };
-        object.setPrototype(p, Point);   // p.__index = Point
-        RETURN p;
-    }
-    FUNCTION dist(self) {
-        RETURN math.sqrt(self.x * self.x + self.y * self.y);
-    }
-    FUNCTION sum(self) {
-        RETURN self.x + self.y;
-    }
+CLASS Point = (self, x, y) {
+    self.x = x;
+    self.y = y;
 }
+Point.dist = FUNCTION(self) {
+    RETURN math.sqrt(self.x * self.x + self.y * self.y);
+};
+Point.sum = FUNCTION(self) {
+    RETURN self.x + self.y;
+};
 
 print(type(Point));           // Point  (__type set by CLASS)
-
-VAR p = Point.make(3, 4);
+VAR p = Point(3, 4);
 print(p:dist());              // 5
 print(p:sum());               // 7
 ```
 
-`STATIC` before a method name is accepted by the parser but has no special
-VM effect — static methods are simply regular fields on the class object.
+### What a class is, exactly
+
+`class Vector = (self, x, y, z) { BODY }` desugars to roughly:
 
 ```cando
-CLASS MathUtil {
-    STATIC FUNCTION square(n) { RETURN n * n; }
-}
-print(MathUtil.square(7));    // 49
+VAR Vector = { __type: "Vector" };
+Vector.__constructor = FUNCTION(self, x, y, z) { BODY };
+Vector.__call = <vm-supplied default-call wrapper>;
 ```
+
+When the class is invoked --  `Vector(1, 2, 3)`  --  `OP_CALL` follows
+`__call` to the default wrapper, which:
+
+1. Allocates a new object (the instance).
+2. Sets `instance.__index = Vector` so methods on the class are reachable
+   from the instance via the prototype chain.
+3. If the class has a `__constructor` field, calls it with
+   `(instance, args…)`.  The constructor's return value is discarded.
+4. Returns the instance.
+
+This means an instance is just a plain object whose `__index` points back
+at the class.  All method lookups (`obj:method()`, operator metamethods,
+`__type`, `__tostring`) flow through that link.
+
+### Three forms
+
+```cando
+class Vector = (self, x, y, z) { ... }                  // statement
+var Vector = class (self, x, y, z) { ... };             // anonymous expr
+var Vector = class Vector (self, x, y, z) { ... };      // named expr
+class Empty = { }                                       // params optional
+```
+
+The statement form requires the leading `=`; both expression forms drop
+it.  Naming is optional in the expression form -- if absent, the class
+has no `__type`.
 
 ### How `CLASS` compiles
 
-The parser emits:
+For `class Vector = (self, x, y, z) { BODY }` the parser emits:
 
-1. `OP_NEW_CLASS name_idx` — allocates a plain object with `__type` set to
-   the class name, pushes it onto the stack.
-2. For each `FUNCTION`:  `OP_CONST pc_idx` then `OP_BIND_METHOD meth_idx` —
-   pops the method PC and rawsets it as a field on the class (class stays on
-   top of stack).
-3. `OP_DEF_GLOBAL name_idx` — pops the class and stores it as a global.
+1. `OP_NEW_CLASS Vector` (or `OP_NEW_OBJECT` for the anonymous form) --
+   allocates the class object, sets `__type` to the class name when
+   present, and pushes it onto the stack.
+2. (If `extends Parent` was given) `OP_LOAD_GLOBAL Parent` is emitted
+   *before* the class object so the stack reads `[..., parent, class]`,
+   followed by `OP_INHERIT` which sets `class.__index = parent` and pops
+   the parent.
+3. The constructor body is compiled inline as a closure: a forward
+   `OP_JUMP` over the body, the body itself ending in `OP_RETURN`, then
+   `OP_CLOSURE` to push the closure value, then
+   `OP_BIND_METHOD __constructor`.
+4. `OP_BIND_DEFAULT_CALL` -- sets `class.__call` to the VM's
+   built-in default-constructor native.
+5. (Statement form only) `OP_DEF_GLOBAL Vector` binds the class as a
+   global.
 
-### Inheritance
+### Inheritance with `EXTENDS`
 
-Two-level inheritance works via prototype chaining:
+`EXTENDS` chains two classes together by setting the child class's
+`__index` to the parent.  Inside a method, parent dispatch is done
+directly through `Child.__index` -- there is no `super` keyword.
 
 ```cando
-CLASS Animal {
-    FUNCTION speak(self) { RETURN self.name + " makes a sound"; }
-}
+class Animal = (self, name) { self.name = name; }
+Animal.speak = FUNCTION(self) { RETURN self.name + " says hello"; };
 
-CLASS Dog {
-    FUNCTION make(name) {
-        VAR inst = { name: name };
-        object.setPrototype(inst, Dog);
-        RETURN inst;
-    }
-    FUNCTION fetch(self) { RETURN self.name + " fetches!"; }
+class Dog extends Animal = (self, name, breed) {
+    Animal.__constructor(self, name);   // delegate to parent ctor
+    self.breed = breed;
 }
-object.setPrototype(Dog, Animal);    // Dog.__index = Animal
+Dog.bark = FUNCTION(self) {
+    RETURN Dog.__index.speak(self) +     // -> Animal.speak
+           " (woof, " + self.breed + ")";
+};
 
-VAR d = Dog.make("Rex");
-print(d:fetch());    // Rex fetches!
-print(d:speak());    // Rex makes a sound  (found on Animal)
+VAR rex = Dog("Rex", "labrador");
+print(type(rex));           // Dog
+print(rex:speak());         // Rex says hello   (inherited from Animal)
+print(rex:bark());          // Rex says hello (woof, labrador)
 ```
 
 ---
@@ -190,17 +226,14 @@ called with the object as the sole argument and should return a string.  If
 absent, `toString` falls back to the default representation.
 
 ```cando
-CLASS Vec {
-    FUNCTION make(x, y) {
-        VAR v = { x: x, y: y };
-        object.setPrototype(v, Vec);
-        RETURN v;
-    }
+CLASS Vec = (self, x, y) {
+    self.x = x;
+    self.y = y;
 }
 Vec.__tostring = FUNCTION(v) {
     RETURN "Vec(" + toString(v.x) + "," + toString(v.y) + ")";
 };
-print(toString(Vec.make(3, 4)));   // Vec(3,4)
+print(toString(Vec(3, 4)));   // Vec(3,4)
 ```
 
 ---

--- a/docs/object-system.md
+++ b/docs/object-system.md
@@ -167,9 +167,12 @@ CdoObject *cdo_class_new(const char *type_name, u32 name_len);
 ```
 
 Creates a `CdoObject` with `__type` pre-set to the given name. Used by the
-`OP_NEW_CLASS` opcode. The `__call` meta-method serves as the constructor and
-is expected to return a new instance whose `__index` points back to the class
-object.
+`OP_NEW_CLASS` opcode.  The compiler additionally binds `__call` on every
+class to a VM-supplied default-constructor native (`OP_BIND_DEFAULT_CALL`),
+which on invocation allocates a fresh instance, sets its `__index` to the
+class, runs `class.__constructor(instance, args…)` if the class declares
+one, and returns the instance.  User code may override `__call` with its
+own function to take full control of construction.
 
 ## CdoString (`source/object/string.h`)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -427,32 +427,33 @@ print(evens);            // [2, 4]
 
 ## Classes
 
-`CLASS` creates a prototype-based object:
+A `CLASS` is a callable table.  Calling it builds a fresh instance whose
+`__index` points back at the class.  The body between the braces is the
+constructor body; methods are added afterwards as field assignments.
 
 ```cando
-CLASS Point {
-    FUNCTION make(x, y) {
-        RETURN { x: x, y: y };
-    }
-
-    FUNCTION dist(self) {
-        RETURN math.sqrt(self.x ^ 2 + self.y ^ 2);
-    }
-
-    FUNCTION add(self, other) {
-        RETURN Point.make(self.x + other.x, self.y + other.y);
-    }
+CLASS Point = (self, x, y) {
+    self.x = x;
+    self.y = y;
 }
 
-VAR a = Point.make(3, 0);
-VAR b = Point.make(0, 4);
+Point.dist = FUNCTION(self) {
+    RETURN math.sqrt(self.x ^ 2 + self.y ^ 2);
+};
+Point.add = FUNCTION(self, other) {
+    RETURN Point(self.x + other.x, self.y + other.y);
+};
+
+VAR a = Point(3, 0);
+VAR b = Point(0, 4);
 VAR c = a:add(b);
 print(c:dist());         // 5
-print(c.x, c.y);        // 3 4
+print(c.x, c.y);         // 3 4
 ```
 
 Methods called with `:` receive the object as the first argument (`self`
-by convention).
+by convention).  See [metamethods.md](metamethods.md) for the full
+desugaring, the `extends` clause, and operator metamethods.
 
 ## Threads
 

--- a/docs/vm-internals.md
+++ b/docs/vm-internals.md
@@ -338,9 +338,24 @@ and filter (`~!>`) operators.
 
 ### Band 16 — Classes
 
-`OP_NEW_CLASS` (A) — create class object named `constants[A]`.
-`OP_BIND_METHOD` (A) — bind method `constants[A]` to class on TOS.
-`OP_INHERIT` — set `__index` on child to parent.
+`OP_NEW_CLASS` (A) — create class object named `constants[A]`, push it.
+`OP_BIND_METHOD` (A) — pop a value and bind it to `constants[A]` on the
+class on TOS (class stays on TOS).
+`OP_INHERIT` — pop parent and child, set `child.__index = parent`, push
+the child back.  Used to wire up `EXTENDS Parent`.
+`OP_BIND_DEFAULT_CALL` — set the `__call` field on the class on TOS to
+the VM-wide default constructor native (`vm->default_class_call`).
+This is what makes a `CLASS` invokable as `ClassName(args)`.
+
+The default `__call` native receives `(class, args…)` from `OP_CALL`,
+allocates a new instance, sets `instance.__index = class`, then
+invokes `class.__constructor(instance, args…)` if the class declares
+one, and finally returns the instance.
+
+`OP_CALL` itself learned to follow `__call` when its callee is an
+object that is neither an `OBJ_FUNCTION` nor a native sentinel: the
+original callee is spliced in as the new first argument and dispatch
+is retried with `__call` as the new callee.
 
 ### Band 17 — Masks
 

--- a/source/natives.c
+++ b/source/natives.c
@@ -74,10 +74,11 @@ int cando_native_type(CandoVM *vm, int argc, CandoValue *args)
     if (argc < 1) {
         cando_vm_push(vm, cando_null());
     } else if (cando_is_object(args[0]) && g_meta_type) {
-        /* If object has __type field, return it as the type name. */
+        /* Follow the prototype (__index) chain so a class instance whose
+         * class declares __type reports that class as its type. */
         CdoObject *obj = cando_bridge_resolve(vm, args[0].as.handle);
         CdoValue type_val;
-        if (cdo_object_rawget(obj, g_meta_type, &type_val)) {
+        if (cdo_object_get(obj, g_meta_type, &type_val)) {
             cando_vm_push(vm, cando_bridge_to_cando(vm, type_val));
         } else {
             const char *name = cando_value_type_name((TypeTag)args[0].tag);

--- a/source/object/object.c
+++ b/source/object/object.c
@@ -49,6 +49,7 @@ CdoString *g_meta_unm      = NULL;
 CdoString *g_meta_idiv     = NULL;
 CdoString *g_meta_len      = NULL;
 CdoString *g_meta_newindex = NULL;
+CdoString *g_meta_constructor = NULL;
 
 /* -----------------------------------------------------------------------
  * Global initialisation
@@ -76,6 +77,7 @@ void cdo_object_init(void) {
     INTERN_META(g_meta_idiv,     META_IDIV);
     INTERN_META(g_meta_len,      META_LEN);
     INTERN_META(g_meta_newindex, META_NEWINDEX);
+    INTERN_META(g_meta_constructor, META_CONSTRUCTOR);
 
 #undef INTERN_META
 }
@@ -98,6 +100,7 @@ void cdo_object_destroy_globals(void) {
     cdo_string_release(g_meta_idiv);     g_meta_idiv     = NULL;
     cdo_string_release(g_meta_len);      g_meta_len      = NULL;
     cdo_string_release(g_meta_newindex); g_meta_newindex = NULL;
+    cdo_string_release(g_meta_constructor); g_meta_constructor = NULL;
 
     cdo_intern_destroy();
 }

--- a/source/object/object.h
+++ b/source/object/object.h
@@ -50,6 +50,7 @@
 #define META_IDIV      "__idiv"
 #define META_LEN       "__len"
 #define META_NEWINDEX  "__newindex"
+#define META_CONSTRUCTOR "__constructor"
 
 /* -----------------------------------------------------------------------
  * Native function signature
@@ -238,5 +239,6 @@ extern CdoString *g_meta_unm;
 extern CdoString *g_meta_idiv;
 extern CdoString *g_meta_len;
 extern CdoString *g_meta_newindex;
+extern CdoString *g_meta_constructor;
 
 #endif /* CDO_OBJECT_H */

--- a/source/parser/lexer.c
+++ b/source/parser/lexer.c
@@ -41,6 +41,7 @@ const char *cando_token_type_name(CandoTokenType t)
     case TOK_FOR:            return "FOR";
     case TOK_FUNCTION:       return "FUNCTION";
     case TOK_CLASS:          return "CLASS";
+    case TOK_EXTENDS:        return "EXTENDS";
     case TOK_RETURN:         return "RETURN";
     case TOK_THROW:          return "THROW";
     case TOK_TRY:            return "TRY";
@@ -139,6 +140,7 @@ static const KeywordEntry KEYWORDS[] = {
     { "FOR",      3,  TOK_FOR      },
     { "FUNCTION", 8,  TOK_FUNCTION },
     { "CLASS",    5,  TOK_CLASS    },
+    { "EXTENDS",  7,  TOK_EXTENDS  },
     { "RETURN",   6,  TOK_RETURN   },
     { "THROW",    5,  TOK_THROW    },
     { "TRY",      3,  TOK_TRY      },

--- a/source/parser/parser.c
+++ b/source/parser/parser.c
@@ -58,6 +58,7 @@ static void        parse_precedence(CandoParser *p, Precedence min_prec);
 static void        parse_statement(CandoParser *p);
 static void        parse_block(CandoParser *p);
 static void        parse_function_expr(CandoParser *p, bool can_assign);
+static void        parse_class_expr(CandoParser *p, bool can_assign);
 static const ParseRule *get_rule(CandoTokenType t);
 
 /* ---- chunk shortcut --------------------------------------------------- */
@@ -1139,6 +1140,7 @@ static const ParseRule RULES[TOK_COUNT] = {
     [TOK_LBRACKET]       = { parse_array_literal,  parse_subscript,  PREC_CALL_PREC  },
     [TOK_LBRACE]         = { parse_object_literal, NULL,             PREC_NONE       },
     [TOK_FUNCTION]       = { parse_function_expr,  NULL,             PREC_NONE       },
+    [TOK_CLASS]          = { parse_class_expr,     NULL,             PREC_NONE       },
     [TOK_THREAD]         = { parse_thread_expr,    NULL,             PREC_NONE       },
     [TOK_AWAIT]          = { parse_await_expr,     NULL,             PREC_NONE       },
 
@@ -1726,100 +1728,193 @@ static void parse_function(CandoParser *p)
 #undef MAX_PARAMS
 }
 
-/* --- CLASS declaration --------------------------------------------------
- * Syntax:  CLASS Name { [FUNCTION method(params) { block }]* }
- */
+/* --- CLASS expression body ----------------------------------------------
+ *
+ * Both the statement form (`class Name = (params) { body }`) and the
+ * expression forms (`class [Name] (params) { body }`) share the same body
+ * compilation: a constructor function whose params and body are written
+ * exactly like `function(params) { body }`, plus the bookkeeping that
+ * makes the class callable.
+ *
+ * Preconditions when this helper is invoked:
+ *   - The class object is already on top of the stack (created by either
+ *     OP_NEW_CLASS — for a named class — or OP_NEW_OBJECT — for the
+ *     anonymous expression form).
+ *   - If `extends Parent` was parsed, the parent expression has been
+ *     compiled BEFORE the class object so the stack reads
+ *     [..., parent, class] and a single OP_INHERIT pops the parent and
+ *     records `class.__index = parent`.
+ *
+ * Emits, with the class still on TOS at the end:
+ *   1. (optional) OP_INHERIT
+ *   2. Constructor body compiled inline + OP_CLOSURE pushing the function
+ *      value, then OP_BIND_METHOD __constructor.
+ *   3. OP_BIND_DEFAULT_CALL — wires the class's __call to the VM's
+ *      default constructor wrapper.
+ * ----------------------------------------------------------------------- */
+static void emit_class_body(CandoParser *p, bool has_extends)
+{
+    if (has_extends) {
+        /* Stack: [..., parent, class] -> [..., class] */
+        emit_op(p, OP_INHERIT);
+    }
+
+    /* Parameter list is optional: `class Foo = { }` is shorthand for
+     * `class Foo = () { }` (an empty constructor that ignores any args). */
+#define MAX_PARAMS 64
+    const char *param_names[MAX_PARAMS];
+    u32         param_lens[MAX_PARAMS];
+    u16 arity = 0;
+
+    if (match(p, TOK_LPAREN)) {
+        if (!check(p, TOK_RPAREN)) {
+            do {
+                if (check(p, TOK_RPAREN)) break;
+                if (match(p, TOK_VARARG)) break;
+                consume(p, TOK_IDENT, "expected parameter name");
+                if (arity >= MAX_PARAMS) {
+                    error(p, "too many parameters");
+                    break;
+                }
+                param_names[arity] = p->previous.start;
+                param_lens[arity]  = p->previous.length;
+                arity++;
+            } while (match(p, TOK_COMMA));
+        }
+        consume(p, TOK_RPAREN, "expected ')' after class parameters");
+    }
+    consume(p, TOK_LBRACE, "expected '{' before class body");
+
+    /* Compile the constructor body inline with the same shape as a
+     * `function(params) { ... }` expression so the resulting closure can
+     * be called via cando_vm_call_value() from the default __call native. */
+    u32 skip_body = emit_jump(p, OP_JUMP);
+    u32 fn_start  = cur(p)->code_len;
+
+    CandoLocal saved_locals[CANDO_LOCAL_MAX];
+    u32        saved_count = p->local_count;
+    int        saved_depth = p->scope_depth;
+    memcpy(saved_locals, p->locals, sizeof(CandoLocal) * saved_count);
+
+    p->local_count = 0;
+    p->scope_depth = 1;
+
+    declare_local(p, "", 0, false); /* slot 0: call frame sentinel */
+    for (u16 i = 0; i < arity; i++)
+        declare_local(p, param_names[i], param_lens[i], false);
+
+    parse_block(p);
+
+    emit_op(p, OP_NULL);
+    emit_op_a(p, OP_RETURN, 1);
+
+    p->local_count = saved_count;
+    p->scope_depth = saved_depth;
+    memcpy(p->locals, saved_locals, sizeof(CandoLocal) * saved_count);
+
+    patch_jump(p, skip_body);
+
+    /* Build the constructor closure (an OBJ_FUNCTION) and bind it to
+     * the class as `__constructor`.  Using OP_CLOSURE rather than the
+     * inline-PC trick lets cando_vm_call_value() invoke it from C.       */
+    u16 ctor_pc_idx   = cando_chunk_add_const(cur(p),
+                                              cando_number((f64)fn_start));
+    emit_op_a(p, OP_CLOSURE, ctor_pc_idx);
+    static const char kCtorName[] = "__constructor";
+    u16 ctor_name_idx = str_const(p, kCtorName,
+                                  (u32)(sizeof(kCtorName) - 1));
+    emit_op_a(p, OP_BIND_METHOD, ctor_name_idx);
+
+    /* Make the class callable: class.__call = vm->default_class_call. */
+    emit_op(p, OP_BIND_DEFAULT_CALL);
+#undef MAX_PARAMS
+}
+
+/* Optional `extends Parent` clause.
+ * When present, push the parent expression onto the stack BEFORE the class
+ * object so OP_INHERIT (emitted later by emit_class_body) can pop it.
+ * Returns true if an EXTENDS clause was consumed.
+ * ----------------------------------------------------------------------- */
+static bool parse_class_extends(CandoParser *p)
+{
+    if (!match(p, TOK_EXTENDS)) return false;
+    consume(p, TOK_IDENT, "expected parent class name after EXTENDS");
+    u16 parent_idx = prev_name_const(p);
+    /* Look up the parent at the global scope; classes live in globals. */
+    emit_op_a(p, OP_LOAD_GLOBAL, parent_idx);
+    return true;
+}
+
+/* --- CLASS declaration (statement form) ---------------------------------
+ * Syntax:  class Name [extends Parent] = [(params)] { body }
+ *
+ * Desugars to: var Name = class Name [extends Parent] [(params)] { body }
+ * The class is bound as a global; its __type meta-key is set to Name.
+ * ----------------------------------------------------------------------- */
 static void parse_class(CandoParser *p)
 {
     consume(p, TOK_IDENT, "expected class name");
     u16 name_idx = prev_name_const(p);
 
-    /* Optional superclass / constructor parameters */
-    if (match(p, TOK_LPAREN)) {
-        u32 depth = 1;
-        while (!check(p, TOK_EOF) && depth > 0) {
-            if (match(p, TOK_LPAREN))      depth++;
-            else if (match(p, TOK_RPAREN)) depth--;
-            else                            advance(p);
-        }
-    }
+    bool has_extends = parse_class_extends(p);
+    /* Stack now: [..., parent?]  (nothing yet for the class).            */
 
-    consume(p, TOK_LBRACE, "expected '{' before class body");
+    /* The `=` is mandatory in the statement form -- it is what
+     * distinguishes `class Foo = (...) {...}` from a stray expression.
+     * Allow both `class Foo = (params) { body }` (with params) and
+     * `class Foo = { body }` (constructor takes no args).                */
+    consume(p, TOK_ASSIGN, "expected '=' in class declaration");
+
+    /* Now create the class object on TOS and (if needed) wire __index. */
     emit_op_a(p, OP_NEW_CLASS, name_idx);
 
-    while (!check(p, TOK_RBRACE) && !check(p, TOK_EOF)) {
-        match(p, TOK_STATIC);
-        match(p, TOK_PRIVATE);
+    emit_class_body(p, has_extends);
 
-        if (match(p, TOK_FUNCTION)) {
-            consume(p, TOK_IDENT, "expected method name");
-            u16 meth_idx = prev_name_const(p);
+    /* Statement form: bind the class as a global. */
+    emit_op_a(p, OP_DEF_GLOBAL, name_idx);
+}
 
-#define MAX_METH_PARAMS 64
-            const char *param_names[MAX_METH_PARAMS];
-            u32         param_lens[MAX_METH_PARAMS];
-            u16 arity = 0;
+/* --- CLASS expression ---------------------------------------------------
+ * Pratt prefix handler for `TOK_CLASS`.
+ *
+ * Forms:
+ *   class                (params) { body }   -- anonymous, no __type
+ *   class Name           (params) { body }   -- named, __type = "Name"
+ *   class [Name] extends Parent (params) { body }
+ *
+ * Distinguishing the expression form from the statement form is done by
+ * the caller: parse_statement matches TOK_CLASS first and dispatches to
+ * parse_class (the statement form) before parse_expr_stmt has a chance to
+ * route through this Pratt prefix.  Inside expressions (e.g. on the RHS of
+ * a `var x = ...`), this handler runs.
+ * ----------------------------------------------------------------------- */
+static void parse_class_expr(CandoParser *p, bool can_assign)
+{
+    (void)can_assign;
 
-            consume(p, TOK_LPAREN, "expected '(' after method name");
-            if (!check(p, TOK_RPAREN)) {
-                do {
-                    if (check(p, TOK_RPAREN)) break;
-                    if (match(p, TOK_VARARG)) break;
-                    consume(p, TOK_IDENT, "expected parameter name");
-                    if (arity < MAX_METH_PARAMS) {
-                        param_names[arity] = p->previous.start;
-                        param_lens[arity]  = p->previous.length;
-                        arity++;
-                    }
-                } while (match(p, TOK_COMMA));
-            }
-            consume(p, TOK_RPAREN, "expected ')' after method parameters");
-            consume(p, TOK_LBRACE, "expected '{' before method body");
-
-            u32 skip = emit_jump(p, OP_JUMP);
-            u32 meth_start = cur(p)->code_len;
-
-            /* Save and reset scope for method body (mirrors parse_function). */
-            CandoLocal saved_locals[CANDO_LOCAL_MAX];
-            u32        saved_count = p->local_count;
-            int        saved_depth = p->scope_depth;
-            memcpy(saved_locals, p->locals,
-                   sizeof(CandoLocal) * saved_count);
-
-            p->local_count = 0;
-            p->scope_depth = 1;
-
-            declare_local(p, "", 0, false); /* slot 0: call frame sentinel */
-            for (u16 i = 0; i < arity; i++)
-                declare_local(p, param_names[i], param_lens[i], false);
-
-            parse_block(p);
-
-            /* Restore outer scope. */
-            p->local_count = saved_count;
-            p->scope_depth = saved_depth;
-            memcpy(p->locals, saved_locals,
-                   sizeof(CandoLocal) * saved_count);
-
-            emit_op(p, OP_NULL);
-            emit_op_a(p, OP_RETURN, 1);
-            patch_jump(p, skip);
-#undef MAX_METH_PARAMS
-
-            /* Push method PC as number, then bind to the class on TOS.  */
-            u16 pc_idx = cando_chunk_add_const(cur(p),
-                                               cando_number((f64)meth_start));
-            emit_op_a(p, OP_CONST, pc_idx);
-            emit_op_a(p, OP_BIND_METHOD, meth_idx);
-        } else {
-            advance(p);  /* skip unknown token */
-        }
+    bool has_name = check(p, TOK_IDENT);
+    u16  name_idx = 0;
+    if (has_name) {
+        advance(p);
+        name_idx = prev_name_const(p);
     }
 
-    consume(p, TOK_RBRACE, "expected '}' after class body");
+    bool has_extends = parse_class_extends(p);
 
-    /* Store the class object as a global variable with the class name. */
-    emit_op_a(p, OP_DEF_GLOBAL, name_idx);
+    /* Push the class object: named classes get __type via OP_NEW_CLASS;
+     * anonymous classes use OP_NEW_OBJECT so __type is left unset.        */
+    if (has_name)
+        emit_op_a(p, OP_NEW_CLASS, name_idx);
+    else
+        emit_op(p, OP_NEW_OBJECT);
+
+    emit_class_body(p, has_extends);
+
+    /* The class is now on TOS as a value -- the surrounding expression
+     * (e.g. `var X = class ...`) will assign or use it.                   */
+    p->last_expr_was_call   = false;
+    p->last_expr_was_unpack = false;
+    p->last_multi_push      = 1;
 }
 
 /* --- RETURN ------------------------------------------------------------- */

--- a/source/parser/token.h
+++ b/source/parser/token.h
@@ -37,6 +37,7 @@ typedef enum {
     TOK_FOR,
     TOK_FUNCTION,
     TOK_CLASS,
+    TOK_EXTENDS,
     TOK_RETURN,
     TOK_THROW,
     TOK_TRY,
@@ -143,8 +144,9 @@ const char *cando_token_type_name(CandoTokenType t);
  * cando_keyword_type -- if the given identifier lexeme (length `len`) is a
  * reserved keyword, return its keyword token type; otherwise return TOK_IDENT.
  *
- * The comparison is case-sensitive: Cando keywords are all upper-case
- * ("IF", "WHILE", ...) except for "pipe" which is lower-case.
+ * The comparison is case-insensitive but rejects mixed-case lexemes: only
+ * pure upper-case ("CLASS") and pure lower-case ("class") match.  Mixed
+ * spellings ("Class", "cLaSs") are returned as plain identifiers.
  * ------------------------------------------------------------------------ */
 CandoTokenType cando_keyword_type(const char *ident, u32 len);
 

--- a/source/vm/opcodes.c
+++ b/source/vm/opcodes.c
@@ -125,9 +125,10 @@ static const char *const s_opcode_names[OP_COUNT] = {
     [OP_YIELD]            = "OP_YIELD",
     [OP_THREAD]           = "OP_THREAD",
     /* Band 16: classes */
-    [OP_NEW_CLASS]        = "OP_NEW_CLASS",
-    [OP_BIND_METHOD]      = "OP_BIND_METHOD",
-    [OP_INHERIT]          = "OP_INHERIT",
+    [OP_NEW_CLASS]         = "OP_NEW_CLASS",
+    [OP_BIND_METHOD]       = "OP_BIND_METHOD",
+    [OP_INHERIT]           = "OP_INHERIT",
+    [OP_BIND_DEFAULT_CALL] = "OP_BIND_DEFAULT_CALL",
     /* Band 17: mask/selector */
     [OP_MASK_PASS]        = "OP_MASK_PASS",
     [OP_MASK_SKIP]        = "OP_MASK_SKIP",
@@ -267,9 +268,10 @@ static const CandoOpFmt s_opcode_fmts[OP_COUNT] = {
     [OP_YIELD]            = OPFMT_NONE,
     [OP_THREAD]           = OPFMT_NONE,
     /* Band 16: classes */
-    [OP_NEW_CLASS]        = OPFMT_A,
-    [OP_BIND_METHOD]      = OPFMT_A,
-    [OP_INHERIT]          = OPFMT_NONE,
+    [OP_NEW_CLASS]         = OPFMT_A,
+    [OP_BIND_METHOD]       = OPFMT_A,
+    [OP_INHERIT]           = OPFMT_NONE,
+    [OP_BIND_DEFAULT_CALL] = OPFMT_NONE,
     /* Band 17: mask/selector */
     [OP_MASK_PASS]        = OPFMT_NONE,
     [OP_MASK_SKIP]        = OPFMT_NONE,

--- a/source/vm/opcodes.h
+++ b/source/vm/opcodes.h
@@ -179,9 +179,10 @@ typedef enum {
                            push CdoThread handle                          */
 
     /* ===== Band 16: Class sugar ========================================= */
-    OP_NEW_CLASS,       /* create class obj; A = name constant index      */
-    OP_BIND_METHOD,     /* bind method at constants[A] to class on TOS    */
-    OP_INHERIT,         /* set __index on child class to parent class     */
+    OP_NEW_CLASS,         /* create class obj; A = name constant index      */
+    OP_BIND_METHOD,       /* bind method at constants[A] to class on TOS    */
+    OP_INHERIT,           /* set __index on child class to parent; pops parent */
+    OP_BIND_DEFAULT_CALL, /* set __call on class on TOS to vm default ctor  */
 
     /* ===== Band 17: Mask / selector operators =========================== */
     /* These implement the ~ (consume/pass) and . (skip) selector prefixes.

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -53,6 +53,8 @@ static bool           vm_is_truthy_meta(CandoVM *vm, CandoValue v, bool *ok);
 static u32            vm_global_hash(const char *str, u32 len);
 static void           vm_call_closure_with_args(CandoVM *vm, CdoObject *fn_obj,
                                                  CandoValue *args, u32 argc);
+static int            vm_native_class_default_call(CandoVM *vm, int argc,
+                                                    CandoValue *args);
 
 /* =========================================================================
  * VM lifecycle
@@ -82,6 +84,7 @@ void cando_vm_init(CandoVM *vm, CandoMemCtrl *mem) {
     for (u32 i = 0; i < CANDO_MAX_THROW_ARGS; i++) vm->thread_results[i] = cando_null();
     vm->string_proto    = cando_null();
     vm->array_proto     = cando_null();
+    vm->default_class_call = cando_null();
 
     /* Module cache — initially empty. */
     vm->module_cache       = NULL;
@@ -110,6 +113,10 @@ void cando_vm_init(CandoVM *vm, CandoMemCtrl *mem) {
                                        64 * sizeof(CandoGlobalEntry));
     memset(vm->globals_owned->entries, 0, 64 * sizeof(CandoGlobalEntry));
     vm->globals = vm->globals_owned;
+
+    /* Register the default class __call wrapper as an unnamed native. */
+    vm->default_class_call =
+        cando_vm_add_native(vm, vm_native_class_default_call);
 }
 
 void cando_vm_init_child(CandoVM *child, const CandoVM *parent) {
@@ -136,6 +143,7 @@ void cando_vm_init_child(CandoVM *child, const CandoVM *parent) {
     for (u32 i = 0; i < CANDO_MAX_THROW_ARGS; i++) child->thread_results[i] = cando_null();
     child->string_proto    = cando_value_copy(parent->string_proto);
     child->array_proto     = cando_value_copy(parent->array_proto);
+    child->default_class_call = parent->default_class_call;
 
     /* Module cache: child VMs do not cache modules independently. */
     child->module_cache       = NULL;
@@ -418,6 +426,89 @@ CandoValue cando_vm_add_native(CandoVM *vm, CandoNativeFn fn) {
     u32 idx = vm->native_count++;
     vm->native_fns[idx] = fn;
     return cando_number(-(f64)(idx + 1));
+}
+
+/* =========================================================================
+ * Default class __call wrapper
+ *
+ * Bound as the __call metamethod of every CLASS object.  When the class is
+ * invoked --  Vector(1, 2, 3)  --  OP_CALL routes the call here with:
+ *     args[0]      = the class object itself
+ *     args[1..N-1] = the user-supplied constructor arguments
+ *
+ * Behaviour:
+ *   1. Allocate a fresh instance object.
+ *   2. Set instance.__index = class so methods on the class are reachable
+ *      via the prototype chain.
+ *   3. If the class has a __constructor field, invoke it with
+ *      (instance, args[1..N-1]).  Discard its return values.
+ *   4. Push the instance onto the value stack and return 1.
+ * ===================================================================== */
+static int vm_native_class_default_call(CandoVM *vm, int argc, CandoValue *args)
+{
+    if (argc < 1 || !cando_is_object(args[0])) {
+        vm_runtime_error(vm, "class __call: missing class receiver");
+        return -1;
+    }
+
+    CandoValue cls_val  = args[0];
+    CdoObject *cls_obj  = cando_bridge_resolve(vm, cls_val.as.handle);
+    if (!cls_obj) {
+        vm_runtime_error(vm, "class __call: invalid class handle");
+        return -1;
+    }
+
+    /* 1. Allocate the instance. */
+    CandoValue inst_val = cando_bridge_new_object(vm);
+    CdoObject *inst_obj = cando_bridge_resolve(vm, inst_val.as.handle);
+
+    /* 2. instance.__index = class. */
+    if (g_meta_index) {
+        CdoValue cls_cdo = cando_bridge_to_cdo(vm, cls_val);
+        cdo_object_rawset(inst_obj, g_meta_index, cls_cdo, FIELD_NONE);
+        cdo_value_release(cls_cdo);
+    }
+
+    /* 3. Look up __constructor on the class (raw, no proto traversal: a
+     * subclass declares its own constructor and we don't want to silently
+     * borrow the parent's body when none is given). */
+    CdoValue ctor_cdo = cdo_null();
+    bool has_ctor = false;
+    if (g_meta_constructor) {
+        has_ctor = cdo_object_rawget(cls_obj, g_meta_constructor, &ctor_cdo);
+    }
+
+    if (has_ctor) {
+        CandoValue ctor_val = cando_bridge_to_cando(vm, ctor_cdo);
+        cdo_value_release(ctor_cdo);
+
+        /* Build the constructor argument list:
+         *   ctor_args[0]      = the new instance
+         *   ctor_args[1..]    = the original user args
+         */
+        u32 ctor_argc = (u32)argc;  /* same total: replace cls with instance */
+        CandoValue *ctor_args = (CandoValue *)cando_alloc(
+            ctor_argc * sizeof(CandoValue));
+        ctor_args[0] = inst_val;
+        for (int i = 1; i < argc; i++) ctor_args[i] = args[i];
+
+        int ret = cando_vm_call_value(vm, ctor_val, ctor_args, ctor_argc);
+        cando_value_release(ctor_val);
+        cando_free(ctor_args);
+
+        if (vm->has_error) {
+            cando_value_release(inst_val);
+            return -1;
+        }
+        /* Pop and discard any return values from the constructor; the
+         * instance, not the body's return value, is what __call yields. */
+        for (int i = 0; i < ret; i++)
+            cando_value_release(cando_vm_pop(vm));
+    }
+
+    /* 4. Push the instance as the result of the call. */
+    cando_vm_push(vm, inst_val);
+    return 1;
 }
 
 /* =========================================================================
@@ -1228,9 +1319,10 @@ static CandoVMResult vm_run(CandoVM *vm) {
         [OP_AWAIT]            = &&lbl_OP_AWAIT,
         [OP_YIELD]            = &&lbl_OP_YIELD,
         [OP_THREAD]           = &&lbl_OP_THREAD,
-        [OP_NEW_CLASS]        = &&lbl_OP_NEW_CLASS,
-        [OP_BIND_METHOD]      = &&lbl_OP_BIND_METHOD,
-        [OP_INHERIT]          = &&lbl_OP_INHERIT,
+        [OP_NEW_CLASS]         = &&lbl_OP_NEW_CLASS,
+        [OP_BIND_METHOD]       = &&lbl_OP_BIND_METHOD,
+        [OP_INHERIT]           = &&lbl_OP_INHERIT,
+        [OP_BIND_DEFAULT_CALL] = &&lbl_OP_BIND_DEFAULT_CALL,
         [OP_MASK_PASS]        = &&lbl_OP_MASK_PASS,
         [OP_MASK_SKIP]        = &&lbl_OP_MASK_SKIP,
         [OP_MASK_APPLY]       = &&lbl_OP_MASK_APPLY,
@@ -2270,6 +2362,7 @@ static CandoVMResult vm_run(CandoVM *vm) {
             /* The function value sits just below the arguments. */
             CandoValue callee = *(vm->stack_top - arg_count - 1);
 
+        op_call_dispatch:
             /* Native function: negative-number sentinel convention. */
             if (IS_NATIVE_FN(callee)) {
                 u32 ni = NATIVE_INDEX(callee);
@@ -2382,6 +2475,42 @@ static CandoVMResult vm_run(CandoVM *vm) {
                     }
                     LOAD_FRAME();
                     DISPATCH();
+                }
+
+                /* __call meta-method: invoking a non-function object whose
+                 * __call is a callable.  Splice the original receiver in as
+                 * the first argument and re-enter dispatch with the meta
+                 * function as the new callee.  Used by CLASS objects: every
+                 * class binds vm->default_class_call to its __call.        */
+                if (fn_obj && g_meta_call) {
+                    CdoValue meta_val;
+                    if (cdo_object_get(fn_obj, g_meta_call, &meta_val)) {
+                        if (vm->stack_top >= vm->stack + CANDO_STACK_MAX) {
+                            vm_runtime_error(vm,
+                                "stack overflow in __call dispatch");
+                            goto handle_error;
+                        }
+                        CandoValue meta_callee =
+                            cando_bridge_to_cando(vm, meta_val);
+                        /* Layout before splice (arg_count = N):
+                         *     base[0]   = callee
+                         *     base[1..N] = args
+                         *     stack_top = base + N + 1
+                         * Layout after splice (new arg_count = N+1):
+                         *     base[0]   = meta_callee
+                         *     base[1]   = original callee (now first arg)
+                         *     base[2..N+1] = original args
+                         *     stack_top = base + N + 2
+                         */
+                        CandoValue *base = vm->stack_top - arg_count - 1;
+                        for (int i = (int)arg_count; i >= 0; i--)
+                            base[i + 1] = base[i];
+                        base[0] = meta_callee;
+                        vm->stack_top++;
+                        arg_count++;
+                        callee = meta_callee;
+                        goto op_call_dispatch;
+                    }
                 }
             }
 
@@ -3317,11 +3446,12 @@ static CandoVMResult vm_run(CandoVM *vm) {
         }
         OP_CASE(OP_INHERIT): {
             /* Stack: [..., parent_class, child_class]
-             * Set child.__index = parent so instances find methods on both. */
+             * Set child.__index = parent and leave only child on TOS. */
             CandoValue child_val  = POP();
-            CandoValue parent_val = PEEK(0);
+            CandoValue parent_val = POP();
             if (!cando_is_object(child_val) || !cando_is_object(parent_val)) {
                 cando_value_release(child_val);
+                cando_value_release(parent_val);
                 vm_runtime_error(vm, "INHERIT: expected class objects");
                 goto handle_error;
             }
@@ -3331,7 +3461,25 @@ static CandoVMResult vm_run(CandoVM *vm) {
                 cdo_object_rawset(child, g_meta_index, pv, FIELD_NONE);
                 cdo_value_release(pv);
             }
+            cando_value_release(parent_val);
             PUSH(child_val);
+            DISPATCH();
+        }
+        OP_CASE(OP_BIND_DEFAULT_CALL): {
+            /* Stack: [..., class_obj]
+             * Set class.__call to the VM-wide default constructor wrapper.
+             * Class stays on TOS so further bindings can proceed.          */
+            CandoValue cls_val = PEEK(0);
+            if (!cando_is_object(cls_val)) {
+                vm_runtime_error(vm, "BIND_DEFAULT_CALL: expected class object");
+                goto handle_error;
+            }
+            if (g_meta_call) {
+                CdoObject *cls = cando_bridge_resolve(vm, cls_val.as.handle);
+                CdoValue   cv  = cando_bridge_to_cdo(vm, vm->default_class_call);
+                cdo_object_rawset(cls, g_meta_call, cv, FIELD_NONE);
+                cdo_value_release(cv);
+            }
             DISPATCH();
         }
 

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -277,6 +277,13 @@ struct CandoVM {
     CandoValue     string_proto;    /* string method table (or null)        */
     CandoValue     array_proto;     /* array method table (or null)         */
 
+    /* Default constructor wrapper ------------------------------------- */
+    /* Native sentinel value bound to __call on every CLASS object.       */
+    /* When a class is invoked (Vector(...)), OP_CALL dispatches via      */
+    /* __call, which lands in this native and runs the default ctor      */
+    /* protocol: allocate {__index=cls}, run cls.__constructor on it.     */
+    CandoValue     default_class_call;
+
     /* Module cache (used by include()) --------------------------------- */
     CandoModuleEntry *module_cache;       /* heap array of cached entries   */
     u32               module_cache_count; /* number of entries used         */

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -125,7 +125,7 @@ run_test "lib_array" "$SCRIPTS/lib_array.cdo" \
     "$(printf '3\n4\n4\n3\n2\n4\n6\n4\n6\n6')"
 
 run_test "metamethods" "$SCRIPTS/metamethods.cdo" \
-    "$(printf '10\n20\nhello\n99\n10\nfrom_a\nproto\nVec3\nnumber\nstring\nnull\nbool\n3\n4\nstring\nAnimal\nRex says hello\nRex\nPoint\n5\n7\n49\n27\n3\n11\n3\noverridden\nbase greet\n4\n6\n7\n15\n6\n20\n5\n5\n1\n1\n8\n9\n-5\n3\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\ntrue\ntrue\n35\nVec(7,8)\nset:foo')"
+    "$(printf '10\n20\nhello\n99\n10\nfrom_a\nproto\nVec3\nnumber\nstring\nnull\nbool\n3\n4\nstring\nAnimal\nRex says hello\nRex\nPoint\n5\n7\n49\n27\n3\n11\n3\noverridden\nbase greet\n4\n6\n7\n15\n6\n20\n5\n5\n1\n1\n8\n9\n-5\n3\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\ntrue\ntrue\n35\nVec(7,8)\nDog\nRex says hello\nRex says hello (woof, labrador)\nset:foo')"
 
 run_test "lib_object" "$SCRIPTS/lib_object.cdo" \
     "$(printf '1\n99\n2\n1\n2\n3\n10\n99\n30\n20\nalice\nbob\nhello\nc\na\nb\n3\n1\n2\nfalse\ntrue\nfalse')"

--- a/tests/scripts/metamethods.cdo
+++ b/tests/scripts/metamethods.cdo
@@ -52,90 +52,73 @@ VAR ts = toString(plain);
 print(type(ts));         // string
 
 /* ----- CLASS: basic ------------------------------------------------------- */
-CLASS Animal {
-    FUNCTION make(name) {
-        VAR inst = { name: name };
-        object.setPrototype(inst, Animal);
-        RETURN inst;
-    }
-    FUNCTION speak(self) {
-        RETURN self.name + " says hello";
-    }
-    FUNCTION getName(self) {
-        RETURN self.name;
-    }
+CLASS Animal = (self, name) {
+    self.name = name;
 }
+Animal.speak = FUNCTION(self) {
+    RETURN self.name + " says hello";
+};
+Animal.getName = FUNCTION(self) {
+    RETURN self.name;
+};
 
 print(type(Animal));         // Animal
-VAR dog = Animal.make("Rex");
+VAR dog = Animal("Rex");
 print(dog:speak());          // Rex says hello
 print(dog:getName());        // Rex
 
 /* ----- CLASS: __type propagation ------------------------------------------ */
-CLASS Point {
-    FUNCTION make(x, y) {
-        VAR p = { x: x, y: y };
-        object.setPrototype(p, Point);
-        RETURN p;
-    }
-    FUNCTION dist(self) {
-        RETURN math.sqrt(self.x * self.x + self.y * self.y);
-    }
-    FUNCTION sum(self) {
-        RETURN self.x + self.y;
-    }
+CLASS Point = (self, x, y) {
+    self.x = x;
+    self.y = y;
 }
+Point.dist = FUNCTION(self) {
+    RETURN math.sqrt(self.x * self.x + self.y * self.y);
+};
+Point.sum = FUNCTION(self) {
+    RETURN self.x + self.y;
+};
 
 print(type(Point));          // Point
-VAR p = Point.make(3, 4);
+VAR p = Point(3, 4);
 print(p:dist());             // 5
 print(p:sum());              // 7
 
-/* ----- CLASS: static method ----------------------------------------------- */
-CLASS MathUtil {
-    STATIC FUNCTION square(n) {
-        RETURN n * n;
-    }
-    STATIC FUNCTION cube(n) {
-        RETURN n * n * n;
-    }
-}
+/* ----- CLASS: static-style methods (just plain fields) -------------------- */
+CLASS MathUtil = { }
+MathUtil.square = FUNCTION(n) { RETURN n * n; };
+MathUtil.cube   = FUNCTION(n) { RETURN n * n * n; };
 
 print(MathUtil.square(7));   // 49
 print(MathUtil.cube(3));     // 27
 
 /* ----- CLASS: instance isolation ------------------------------------------ */
-CLASS Counter {
-    FUNCTION new(start) {
-        VAR inst = { count: start };
-        object.setPrototype(inst, Counter);
-        RETURN inst;
-    }
-    FUNCTION increment(self) {
-        self.count = self.count + 1;
-    }
-    FUNCTION value(self) {
-        RETURN self.count;
-    }
+CLASS Counter = (self, start) {
+    self.count = start;
 }
+Counter.increment = FUNCTION(self) {
+    self.count = self.count + 1;
+};
+Counter.value = FUNCTION(self) {
+    RETURN self.count;
+};
 
-VAR c1 = Counter.new(0);
+VAR c1 = Counter(0);
 c1:increment();
 c1:increment();
 c1:increment();
 print(c1:value());           // 3
 
-VAR c2 = Counter.new(10);
+VAR c2 = Counter(10);
 c2:increment();
 print(c2:value());           // 11
 print(c1:value());           // 3
 
 /* ----- CLASS: method shadowing -------------------------------------------- */
-CLASS Base {
-    FUNCTION greet(self) {
-        RETURN "base greet";
-    }
-}
+CLASS Base = (self) { }
+Base.greet = FUNCTION(self) {
+    RETURN "base greet";
+};
 VAR inst = { greet: FUNCTION(self) { RETURN "overridden"; } };
 object.setPrototype(inst, Base);
 print(inst:greet());         // overridden
@@ -145,102 +128,112 @@ object.setPrototype(inst2, Base);
 print(inst2:greet());        // base greet
 
 /* ----- __add -------------------------------------------------------------- */
-CLASS Vec {
-    FUNCTION make(x, y) {
-        VAR v = { x: x, y: y };
-        object.setPrototype(v, Vec);
-        RETURN v;
-    }
+CLASS Vec = (self, x, y) {
+    self.x = x;
+    self.y = y;
 }
-Vec.__add = FUNCTION(a, b) { RETURN Vec.make(a.x + b.x, a.y + b.y); };
-VAR v1 = Vec.make(1, 2);
-VAR v2 = Vec.make(3, 4);
+Vec.__add = FUNCTION(a, b) { RETURN Vec(a.x + b.x, a.y + b.y); };
+VAR v1 = Vec(1, 2);
+VAR v2 = Vec(3, 4);
 VAR v3 = v1 + v2;
 print(v3.x);                // 4
 print(v3.y);                // 6
 
 /* ----- __sub -------------------------------------------------------------- */
-Vec.__sub = FUNCTION(a, b) { RETURN Vec.make(a.x - b.x, a.y - b.y); };
-VAR v4 = Vec.make(10, 20);
-VAR v5 = Vec.make(3, 5);
+Vec.__sub = FUNCTION(a, b) { RETURN Vec(a.x - b.x, a.y - b.y); };
+VAR v4 = Vec(10, 20);
+VAR v5 = Vec(3, 5);
 VAR v6 = v4 - v5;
 print(v6.x);                // 7
 print(v6.y);                // 15
 
 /* ----- __mul -------------------------------------------------------------- */
-Vec.__mul = FUNCTION(a, b) { RETURN Vec.make(a.x * b.x, a.y * b.y); };
-VAR v7 = Vec.make(3, 4);
-VAR v8 = Vec.make(2, 5);
+Vec.__mul = FUNCTION(a, b) { RETURN Vec(a.x * b.x, a.y * b.y); };
+VAR v7 = Vec(3, 4);
+VAR v8 = Vec(2, 5);
 VAR v9 = v7 * v8;
 print(v9.x);                // 6
 print(v9.y);                // 20
 
 /* ----- __div -------------------------------------------------------------- */
-Vec.__div = FUNCTION(a, b) { RETURN Vec.make(a.x / b.x, a.y / b.y); };
-VAR v10 = Vec.make(10, 20);
-VAR v11 = Vec.make(2, 4);
+Vec.__div = FUNCTION(a, b) { RETURN Vec(a.x / b.x, a.y / b.y); };
+VAR v10 = Vec(10, 20);
+VAR v11 = Vec(2, 4);
 VAR v12 = v10 / v11;
 print(v12.x);               // 5
 print(v12.y);               // 5
 
 /* ----- __mod -------------------------------------------------------------- */
-Vec.__mod = FUNCTION(a, b) { RETURN Vec.make(a.x % b.x, a.y % b.y); };
-VAR v13 = Vec.make(10, 7);
-VAR v14 = Vec.make(3, 2);
+Vec.__mod = FUNCTION(a, b) { RETURN Vec(a.x % b.x, a.y % b.y); };
+VAR v13 = Vec(10, 7);
+VAR v14 = Vec(3, 2);
 VAR v15 = v13 % v14;
 print(v15.x);               // 1
 print(v15.y);               // 1
 
 /* ----- __pow -------------------------------------------------------------- */
-Vec.__pow = FUNCTION(a, b) { RETURN Vec.make(a.x ^ b.x, a.y ^ b.y); };
-VAR v16 = Vec.make(2, 3);
-VAR v17 = Vec.make(3, 2);
+Vec.__pow = FUNCTION(a, b) { RETURN Vec(a.x ^ b.x, a.y ^ b.y); };
+VAR v16 = Vec(2, 3);
+VAR v17 = Vec(3, 2);
 VAR v18 = v16 ^ v17;
 print(v18.x);               // 8
 print(v18.y);               // 9
 
 /* ----- __unm (unary minus) ------------------------------------------------ */
-Vec.__unm = FUNCTION(v) { RETURN Vec.make(-v.x, -v.y); };
-VAR v19 = Vec.make(5, -3);
+Vec.__unm = FUNCTION(v) { RETURN Vec(-v.x, -v.y); };
+VAR v19 = Vec(5, -3);
 VAR v20 = -v19;
 print(v20.x);               // -5
 print(v20.y);               // 3
 
 /* ----- __eq --------------------------------------------------------------- */
 Vec.__eq = FUNCTION(a, b) { RETURN a.x == b.x && a.y == b.y; };
-VAR eq1 = Vec.make(1, 2);
-VAR eq2 = Vec.make(1, 2);
-VAR eq3 = Vec.make(1, 3);
+VAR eq1 = Vec(1, 2);
+VAR eq2 = Vec(1, 2);
+VAR eq3 = Vec(1, 3);
 print(eq1 == eq2);          // true
 print(eq1 == eq3);          // false
 print(eq1 != eq3);          // true
 
 /* ----- __lt --------------------------------------------------------------- */
 Vec.__lt = FUNCTION(a, b) { RETURN (a.x * a.x + a.y * a.y) < (b.x * b.x + b.y * b.y); };
-VAR lt1 = Vec.make(1, 1);
-VAR lt2 = Vec.make(3, 4);
+VAR lt1 = Vec(1, 1);
+VAR lt2 = Vec(3, 4);
 print(lt1 < lt2);           // true
 print(lt2 < lt1);           // false
 print(lt2 > lt1);           // true
 
 /* ----- __le --------------------------------------------------------------- */
 Vec.__le = FUNCTION(a, b) { RETURN (a.x * a.x + a.y * a.y) <= (b.x * b.x + b.y * b.y); };
-VAR le1 = Vec.make(3, 4);
-VAR le2 = Vec.make(3, 4);
-VAR le3 = Vec.make(1, 1);
+VAR le1 = Vec(3, 4);
+VAR le2 = Vec(3, 4);
+VAR le3 = Vec(1, 1);
 print(le1 <= le2);          // true
 print(le3 <= le1);          // true
 print(le1 >= le3);          // true
 
 /* ----- __len -------------------------------------------------------------- */
 Vec.__len = FUNCTION(v) { RETURN v.x + v.y; };
-VAR vlen = Vec.make(10, 25);
+VAR vlen = Vec(10, 25);
 print(#vlen);                // 35
 
 /* ----- __tostring --------------------------------------------------------- */
 Vec.__tostring = FUNCTION(v) { RETURN "Vec(" + toString(v.x) + "," + toString(v.y) + ")"; };
-VAR vts = Vec.make(7, 8);
+VAR vts = Vec(7, 8);
 print(toString(vts));        // Vec(7,8)
+
+/* ----- CLASS: extends + parent dispatch ----------------------------------- */
+CLASS Dog EXTENDS Animal = (self, name, breed) {
+    Animal.__constructor(self, name);
+    self.breed = breed;
+}
+Dog.bark = FUNCTION(self) {
+    RETURN Dog.__index.speak(self) + " (woof, " + self.breed + ")";
+};
+VAR rex = Dog("Rex", "labrador");
+print(type(rex));            // Dog
+print(rex:speak());          // Rex says hello
+print(rex:bark());           // Rex says hello (woof, labrador)
 
 /* ----- __newindex --------------------------------------------------------- */
 VAR log_obj = {};

--- a/tests/test_lexer.c
+++ b/tests/test_lexer.c
@@ -632,13 +632,43 @@ TEST(test_try_catch_finaly)
 
 TEST(test_class_snippet)
 {
-    /* CLASS Foo(x) { FUNCTION self.bar() { } }
-     * [0]=CLASS [1]=Foo [2]=( [3]=x [4]=) [5]={ [6]=FUNCTION ... */
+    /* New class syntax:
+     *   CLASS Foo = (self, x) { self.x = x; }
+     * [0]=CLASS [1]=Foo [2]== [3]=( [4]=self [5]=, [6]=x [7]=) [8]={ ...
+     */
     u32 count;
-    CandoToken *toks = lex_all("CLASS Foo(x) { FUNCTION self.bar() { } }", &count);
+    CandoToken *toks = lex_all(
+        "CLASS Foo = (self, x) { self.x = x; }", &count);
     EXPECT_EQ(toks[0].type, TOK_CLASS);
-    EXPECT_EQ(toks[1].type, TOK_IDENT);   /* Foo */
-    EXPECT_EQ(toks[6].type, TOK_FUNCTION);
+    EXPECT_EQ(toks[1].type, TOK_IDENT);    /* Foo */
+    EXPECT_EQ(toks[2].type, TOK_ASSIGN);   /* =  */
+    EXPECT_EQ(toks[3].type, TOK_LPAREN);   /* (  */
+    free(toks);
+}
+
+TEST(test_class_extends_snippet)
+{
+    /* CLASS Dog EXTENDS Animal = (self, name) { ... } */
+    u32 count;
+    CandoToken *toks = lex_all(
+        "CLASS Dog EXTENDS Animal = (self, name) { }", &count);
+    EXPECT_EQ(toks[0].type, TOK_CLASS);
+    EXPECT_EQ(toks[1].type, TOK_IDENT);    /* Dog */
+    EXPECT_EQ(toks[2].type, TOK_EXTENDS);
+    EXPECT_EQ(toks[3].type, TOK_IDENT);    /* Animal */
+    EXPECT_EQ(toks[4].type, TOK_ASSIGN);
+    free(toks);
+}
+
+TEST(test_class_lowercase_snippet)
+{
+    /* Pure lowercase keywords are treated identically to uppercase.       */
+    u32 count;
+    CandoToken *toks = lex_all(
+        "class Foo = (self) { self.x = 1; }", &count);
+    EXPECT_EQ(toks[0].type, TOK_CLASS);
+    EXPECT_EQ(toks[1].type, TOK_IDENT);    /* Foo (mixed case identifier) */
+    EXPECT_EQ(toks[2].type, TOK_ASSIGN);
     free(toks);
 }
 
@@ -712,6 +742,8 @@ int main(void)
     run_test("mask operators",            test_mask_operators);
     run_test("try/catch/finaly",          test_try_catch_finaly);
     run_test("class snippet",             test_class_snippet);
+    run_test("class extends snippet",     test_class_extends_snippet);
+    run_test("class lowercase snippet",   test_class_lowercase_snippet);
 
     printf("\n=== Results: %d/%d passed ===\n",
            g_tests_passed, g_tests_run);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -630,14 +630,56 @@ TEST(test_range_desc)
  * ------------------------------------------------------------------------ */
 TEST(test_class_declaration)
 {
-    CandoChunk *c = compile_ok("CLASS Dog { FUNCTION bark() { RETURN NULL; } }");
+    /* New class syntax:  the body between '{' and '}' is the constructor
+     * body, methods are added later as field assignments.                 */
+    CandoChunk *c = compile_ok(
+        "CLASS Dog = (self, name) { self.name = name; }");
     EXPECT_TRUE(find_op(c, OP_NEW_CLASS) >= 0);
-    EXPECT_TRUE(find_op(c, OP_BIND_METHOD) >= 0);
-    bool found = false;
+    EXPECT_TRUE(find_op(c, OP_CLOSURE) >= 0);            /* ctor closure   */
+    EXPECT_TRUE(find_op(c, OP_BIND_METHOD) >= 0);        /* __constructor  */
+    EXPECT_TRUE(find_op(c, OP_BIND_DEFAULT_CALL) >= 0);  /* default __call */
+    EXPECT_TRUE(find_op(c, OP_DEF_GLOBAL) >= 0);
+    bool dog_const = false, ctor_const = false;
     for (u32 i = 0; i < c->const_count; i++) {
-        if (const_is_string(c, i, "Dog")) { found = true; break; }
+        if (const_is_string(c, i, "Dog"))           dog_const  = true;
+        if (const_is_string(c, i, "__constructor")) ctor_const = true;
     }
-    EXPECT_TRUE(found);
+    EXPECT_TRUE(dog_const);
+    EXPECT_TRUE(ctor_const);
+    cando_chunk_free(c);
+}
+
+TEST(test_class_extends)
+{
+    CandoChunk *c = compile_ok(
+        "CLASS Animal = (self, name) { self.name = name; }\n"
+        "CLASS Dog EXTENDS Animal = (self, name, breed) {\n"
+        "    Animal.__constructor(self, name);\n"
+        "    self.breed = breed;\n"
+        "}");
+    EXPECT_TRUE(find_op(c, OP_INHERIT) >= 0);
+    EXPECT_TRUE(find_op(c, OP_BIND_DEFAULT_CALL) >= 0);
+    cando_chunk_free(c);
+}
+
+TEST(test_class_expression_form)
+{
+    /* Anonymous class assigned to a variable. */
+    CandoChunk *c = compile_ok(
+        "VAR Counter = class (self) { self.count = 0; };");
+    EXPECT_TRUE(find_op(c, OP_NEW_OBJECT) >= 0);  /* anon -> NEW_OBJECT  */
+    EXPECT_TRUE(find_op(c, OP_BIND_DEFAULT_CALL) >= 0);
+    EXPECT_TRUE(find_op(c, OP_DEF_GLOBAL) >= 0);
+    cando_chunk_free(c);
+}
+
+TEST(test_class_lowercase_keywords)
+{
+    /* The lexer treats pure lowercase keywords identically.              */
+    CandoChunk *c = compile_ok(
+        "class Vec = (self, x, y) { self.x = x; self.y = y; }");
+    EXPECT_TRUE(find_op(c, OP_NEW_CLASS) >= 0);
+    EXPECT_TRUE(find_op(c, OP_BIND_DEFAULT_CALL) >= 0);
     cando_chunk_free(c);
 }
 
@@ -915,6 +957,9 @@ int main(void)
 
     printf("\n-- classes --\n");
     run_test("class declaration",              test_class_declaration);
+    run_test("class extends",                  test_class_extends);
+    run_test("class expression (anon)",        test_class_expression_form);
+    run_test("class lowercase keywords",       test_class_lowercase_keywords);
 
     printf("\n-- compound --\n");
     run_test("nested if/while",                test_nested_if_while);

--- a/tests/test_vm.c
+++ b/tests/test_vm.c
@@ -1112,7 +1112,7 @@ static int spread_test_native(CandoVM *vm, int argc, CandoValue *args) {
     return 0;
 }
 
-static void build_spread_ret(CandoChunk *c) {
+static void build_spread_ret(CandoChunk *c, f64 outer_native_sentinel) {
     /* Jump past inner function body */
     u32 skip = cando_chunk_emit_jump(c, OP_JUMP, 1);
 
@@ -1125,8 +1125,8 @@ static void build_spread_ret(CandoChunk *c) {
 
     /* Main code */
     cando_chunk_patch_jump(c, skip);
-    /* outer_native is at index 0 → sentinel -1.0 */
-    u16 outer_idx = cando_chunk_add_const(c, cando_number(-1.0));
+    /* outer_native sentinel encodes its index in the VM native table.    */
+    u16 outer_idx = cando_chunk_add_const(c, cando_number(outer_native_sentinel));
     u16 inner_idx = cando_chunk_add_const(c, cando_number(3.0));  /* fn PC */
     u16 c100     = cando_chunk_add_const(c, cando_number(100.0));
 
@@ -1143,9 +1143,13 @@ TEST(test_exec_spread_ret) {
     g_spread_test_argc = -1;
     CandoVM vm;
     cando_vm_init(&vm, NULL);
+    /* cando_vm_init already registers the default class __call native, so
+     * spread_outer's index is whatever native_count is at this point.    */
+    u32 sentinel_idx = vm.native_count;
     cando_vm_register_native(&vm, "spread_outer", spread_test_native);
+    f64 outer_sentinel = -(f64)(sentinel_idx + 1);
     CandoChunk *c = cando_chunk_new("spread_ret", 0, false);
-    build_spread_ret(c);
+    build_spread_ret(c, outer_sentinel);
     CandoVMResult r = cando_vm_exec(&vm, c);
     EXPECT_EQ(r, VM_HALT);
     /* outer native received 3 args (5, 7 from spread + 100) */


### PR DESCRIPTION
Classes are now plain tables that are invokable. `Vector(1, 2, 3)` runs a default `__call` wrapper that allocates a new instance, links it to the class via `__index`, and runs `class.__constructor(instance, args...)`. Methods, including operator metamethods like `__add`, are added after declaration as ordinary field assignments.

New surface syntax (all three forms equivalent up to whether `__type` is set and which name the class is bound to):

    class Vector = (self, x, y, z) { self.x = x; ... }   // statement
    var Vector  = class (self, x, y, z) { ... };          // anon expr
    var Vector  = class Vector (self, x, y, z) { ... };   // named expr
    class Empty = { }                                     // empty params
    class Dog extends Animal = (self, name) { ... }       // inheritance

Parent dispatch is via `Child.__index.method(self)` -- no `super` keyword.

Implementation:

* Lexer: add `EXTENDS` keyword.  Keyword lookup was already case-insensitive (rejecting mixed-case spellings); the doc comment is updated to reflect that.
* Parser: rewrite `parse_class` for the statement form and add `parse_class_expr` as a Pratt prefix handler so `class ...` is also a first-class expression.  The constructor body is compiled inline as an `OP_CLOSURE` so `cando_vm_call_value` can invoke it from C.
* Opcodes: add `OP_BIND_DEFAULT_CALL`.  `OP_INHERIT` now actually pops the parent (it had previously left it on the stack).
* VM:
    - Pre-intern `__constructor` as `g_meta_constructor`.
    - Register a built-in default-class-call native at VM init time and stash its sentinel in `vm->default_class_call`.
    - `OP_BIND_DEFAULT_CALL` writes that sentinel to `class.__call`.
    - `OP_CALL` learned to follow `__call` when invoking a non-function object: the original callee is spliced in as the new first arg and dispatch is retried with `__call` as the new callee.
    - `type(obj)` now follows `__index`, so a class instance reports its class's `__type`.
* Tests:
    - `tests/scripts/metamethods.cdo` rewritten to the new syntax; adds an `EXTENDS` exercise.  Expected output in run_tests.sh updated accordingly.
    - `test_parser.c`: rewrite `test_class_declaration`; add coverage for `EXTENDS`, the anonymous expression form, and lowercase keywords.
    - `test_lexer.c`: rewrite `test_class_snippet`; add `EXTENDS` and lowercase-keyword snippets.
    - `test_vm.c`: `test_exec_spread_ret` no longer hard-codes native sentinel `-1.0`; it now derives the sentinel from `vm.native_count` at registration time, since the default class call native now occupies an early native slot.
* Docs: `language-reference.md`, `metamethods.md`, `vm-internals.md`, `object-system.md`, and `user-guide.md` rewritten for the new class shape, including the desugaring, the three forms, the `extends` clause, and the `__call` / `__constructor` runtime contract.

https://claude.ai/code/session_01HThsPEY7JQ9YaMANBHNhpy