### PR TITLE
Add global `_meta` registry for extensible built-in object prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set(LIB_SRCS
     source/lib/httputil.c
     source/lib/http.c
     source/lib/https.c
+    source/lib/meta.c
 )
 
 # Windows compatibility shim (POSIX regex replacement)

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ CANDO_LIB_SRCS = \
     source/lib/httputil.c         \
     source/lib/http.c             \
     source/lib/https.c            \
+    source/lib/meta.c             \
     source/cando_lib.c
 
 # Windows compatibility shim added on Windows

--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -69,6 +69,7 @@ void cando_open_evallib(CandoVM *vm);             /* eval()                */
 void cando_open_includelib(CandoVM *vm);          /* include()             */
 void cando_open_httplib(CandoVM *vm);             /* http.* + fetch()      */
 void cando_open_httpslib(CandoVM *vm);            /* https.*               */
+void cando_open_metalib(CandoVM *vm);             /* `_meta` registry      */
 ```
 
 Each opener is idempotent.  `cando_openlibs` registers the libraries

--- a/docs/metamethods.md
+++ b/docs/metamethods.md
@@ -361,6 +361,32 @@ for `cdo_class_new`.
 
 ---
 
+## The `_meta` global registry
+
+Native libraries that hand out instance objects (HTTP request/response,
+servers, etc.) wire them up to a shared prototype stored at `_meta.<name>`.
+Because `_meta` is an ordinary writable global, user code can attach new
+methods that propagate to every instance through the `__index` chain:
+
+```cando
+_meta.http_response.write = FUNCTION(self, data) {
+    self.body = self.body + data;
+};
+```
+
+Each subtable is created lazily; its `__type` is stamped as a `FIELD_STATIC`
+constant equal to the type name (`"http_response"` for example), so
+`type(instance)` reflects the tag.  Default native methods are inserted with
+`FIELD_NONE` flags so user code may override them.
+
+You can register your own meta tables and use them as prototypes with
+`object.setPrototype` for any type you control.
+
+See [standard-library.md `#_meta`](standard-library.md#meta-global-meta-registry)
+for the list of built-in subtables and their default methods.
+
+---
+
 ## Further reading
 
 - [object-system.md](object-system.md) — `CdoObject` internals, field flags,

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -143,10 +143,24 @@ Subtables registered by the standard library:
 
 | Subtable | Used by |
 |---|---|
+| `_meta.string` | Same table as the global `string` and `vm->string_proto` -- the prototype consulted whenever a method is called on a string. |
+| `_meta.array` | Same table as `array` / `vm->array_proto` -- consulted for methods on array receivers. |
+| `_meta.object` | Same table as `object`.  Not auto-applied to plain objects; use `object.setPrototype(o, _meta.object)` to opt in. |
+| `_meta.thread` | Per-instance methods for thread receivers (`t:done()`, `t:join()`, `t:state()`, `t:then(fn)`, …).  Aliased onto the same native sentinels exposed via `thread.<name>`. |
 | `_meta.http_request` | Server-side request objects passed into `http.createServer`'s handler. |
 | `_meta.http_response` | Server-side response objects.  Default methods: `status`, `setHeader`, `send`, `json`. |
 | `_meta.http_server` | Server objects returned by `createServer`.  Default methods: `listen`, `close`. |
 | `_meta.http_client_response` | Response objects returned by `http.get`, `https.get`, `fetch`, etc. |
+
+For `string`, `array`, `object`, and `thread` the meta table is the same
+underlying CdoObject as the like-named global, so writing through either
+name is observable through the other:
+
+```cando
+_meta.string.shout = FUNCTION(self) { RETURN self:toUpper() + "!"; };
+print("hi":shout());        // HI!
+print(string.shout("yes")); // YES!  -- same table, same method
+```
 
 You may also attach your own subtables at runtime (`_meta.foo = { ... }`)
 and use them as prototypes via `object.setPrototype(instance, _meta.foo)`.
@@ -291,6 +305,21 @@ provides:
 | `thread.current()` | Current thread handle, or `NULL` on the main thread. |
 | `thread.then(t, fn)` | Register a success callback; called with `t`'s return values. |
 | `thread.catch(t, fn)` | Register an error callback; called with the thrown value. |
+
+Every per-thread function (`done`, `join`, `cancel`, `state`, `error`,
+`then`, `catch`) is also reachable through the `_meta.thread` prototype as
+a method on the thread receiver itself:
+
+```cando
+VAR t = thread { RETURN 42; };
+print(t:state());   // running | done
+print(await t);     // 42
+print(t:done());    // true
+```
+
+Because `_meta.thread` aliases the same native sentinels as `thread.<name>`,
+both forms call the same underlying implementation -- and overrides applied
+under either name take effect for both.
 
 The language-level `thread { … }` expression and `await` operator are
 described in [language-reference.md](language-reference.md).

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -112,6 +112,47 @@ Array values answer to these methods via `:`.  Indices are 0-based.
 
 ---
 
+## `_meta` (global meta registry) {#meta-global-meta-registry}
+
+`_meta` is a writable global object that holds **meta tables** — prototype
+objects for built-in types.  Native libraries register a subtable per type
+and stamp every instance they create with `instance.__index = _meta.<type>`,
+so user code can attach methods that immediately become callable on every
+instance.
+
+```cando
+print(type(_meta));                       // object
+print(type(_meta.http_response));         // http_response
+
+_meta.http_response.write = FUNCTION(self, data) {
+    self.body = self.body + data;
+};
+
+http.createServer(FUNCTION(req, res) {
+    res:write("Hello, world!");
+    res:send();
+});
+```
+
+The `_meta.<name>` subtable's `__type` field is stamped immutably (`FIELD_STATIC`)
+to the type name, so `type(instance)` returns the type tag.  Method slots
+(`status`, `send`, `listen`, …) use ordinary `FIELD_NONE` flags so user code
+may override them.
+
+Subtables registered by the standard library:
+
+| Subtable | Used by |
+|---|---|
+| `_meta.http_request` | Server-side request objects passed into `http.createServer`'s handler. |
+| `_meta.http_response` | Server-side response objects.  Default methods: `status`, `setHeader`, `send`, `json`. |
+| `_meta.http_server` | Server objects returned by `createServer`.  Default methods: `listen`, `close`. |
+| `_meta.http_client_response` | Response objects returned by `http.get`, `https.get`, `fetch`, etc. |
+
+You may also attach your own subtables at runtime (`_meta.foo = { ... }`)
+and use them as prototypes via `object.setPrototype(instance, _meta.foo)`.
+
+---
+
 ## `object`
 
 Utilities for manipulating objects.  All take the object as the first
@@ -271,8 +312,9 @@ the same implementation but requires OpenSSL and uses TLS.
 | `https.request(options) → response` | TLS equivalent. |
 | `fetch(url, options*) → response` | Scheme-aware global; picks http vs https from the URL. |
 
-The response object has fields `status`, `statusText`, `headers` (object), and `body` (string), plus a
-`:json()` method that parses `body` using `json.parse`.
+Client responses inherit from `_meta.http_client_response`; the instance
+itself carries `status`, `ok`, `body`, and `headers` fields and methods are
+attached on the meta table so user code can extend it (see [`_meta`](#meta-global-meta-registry) below).
 
 ### Server
 
@@ -282,6 +324,52 @@ The response object has fields `status`, `statusText`, `headers` (object), and `
 | `https.createServer(handler, keyPath, certPath)` | TLS equivalent. |
 | `server:listen(port, host*)` | Start accepting connections. |
 | `server:close()` | Stop accepting new connections and let in-flight ones finish. |
+
+Server `req` / `res` objects inherit from `_meta.http_request` and
+`_meta.http_response`; `server` objects inherit from `_meta.http_server`.
+The default response methods are:
+
+| Method | Description |
+|---|---|
+| `res:status(code)` | Set the status code (returns the receiver for chaining). |
+| `res:setHeader(name, value)` | Add a response header. |
+| `res:send(body*)` | Flush the response.  If `body` is omitted, the receiver's `body` field (a string accumulator that defaults to `""`) is used. |
+| `res:json(value)` | JSON-encode `value` and send it with `Content-Type: application/json`. |
+
+`res:send()` may be invoked **synchronously from the handler**, or
+**asynchronously from any other thread**.  The connection thread keeps the
+TCP/TLS socket open after the handler returns and waits for `:send()` before
+cleaning up.  Stash `res` on a global, hand it to a `thread { ... }`, or push
+it into a queue — the response is only flushed once `:send()` runs.
+
+```cando
+VAR pending = NULL;
+http.createServer(FUNCTION(req, res) {
+    pending = res;            // defer
+});
+thread {
+    thread.sleep(50);
+    pending:send("delayed");  // sends from another thread
+};
+```
+
+### Extending request and response objects
+
+Because `req` and `res` follow the prototype chain, any function attached to
+`_meta.http_response` (or `_meta.http_request`) becomes a method on every
+instance.  This is the recommended way to build response helpers:
+
+```cando
+_meta.http_response.write = FUNCTION(self, data) {
+    self.body = self.body + data;
+};
+
+http.createServer(FUNCTION(req, res) {
+    res:write("Hello, ");
+    res:write("world!");
+    res:send();               // sends the accumulated body
+});
+```
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -615,9 +615,9 @@ VAR res2 = fetch("https://httpbin.org/post", {
 
 ```cando
 VAR server = http.createServer(FUNCTION(req, res) {
-    res.status = 200;
-    res.headers["Content-Type"] = "text/plain";
-    res.body = `Hello! You requested ${req.path}`;
+    res:status(200);
+    res:setHeader("Content-Type", "text/plain");
+    res:send(`Hello! You requested ${req.path}`);
 });
 
 server:listen(8080);
@@ -625,6 +625,33 @@ print("listening on :8080");
 ```
 
 Each request runs on its own thread.  Call `server:close()` to shut down.
+
+`res` follows the prototype chain to `_meta.http_response`, so you can add
+helpers globally:
+
+```cando
+_meta.http_response.write = FUNCTION(self, data) {
+    self.body = self.body + data;
+};
+
+http.createServer(FUNCTION(req, res) {
+    res:write("Hello, ");
+    res:write("world!");
+    res:send();           // sends the accumulated `body`
+});
+```
+
+`res:send()` does **not** have to run inside the handler.  Stash `res` and
+call `:send()` later from another thread:
+
+```cando
+VAR pending = NULL;
+http.createServer(FUNCTION(req, res) { pending = res; });
+thread {
+    thread.sleep(100);
+    pending:send("delayed");
+};
+```
 
 ## Crypto
 

--- a/include/cando.h
+++ b/include/cando.h
@@ -156,6 +156,7 @@ CANDO_API void cando_open_evallib(CandoVM *vm);      /**< eval()            */
 CANDO_API void cando_open_includelib(CandoVM *vm);   /**< include()         */
 CANDO_API void cando_open_httplib(CandoVM *vm);      /**< http.* + fetch()  */
 CANDO_API void cando_open_httpslib(CandoVM *vm);     /**< https.*           */
+CANDO_API void cando_open_metalib(CandoVM *vm);      /**< _meta registry    */
 
 /* =========================================================================
  * Load and execute

--- a/source/cando_lib.c
+++ b/source/cando_lib.c
@@ -53,6 +53,7 @@
 #include "lib/net.h"
 #include "lib/http.h"
 #include "lib/https.h"
+#include "lib/meta.h"
 
 /* cando.h error codes and CANDO_API */
 #include "../include/cando.h"
@@ -153,6 +154,10 @@ CANDO_API void cando_close(CandoVM *vm)
 
 CANDO_API void cando_openlibs(CandoVM *vm)
 {
+    /* `_meta` is registered first so any other library can populate its
+     * subtables during its own registration. */
+    cando_lib_meta_register(vm);
+
     cando_lib_math_register(vm);
     cando_lib_file_register(vm);
     cando_lib_eval_register(vm);
@@ -191,6 +196,7 @@ CANDO_API void cando_open_evallib(CandoVM *vm)     { cando_lib_eval_register(vm)
 CANDO_API void cando_open_includelib(CandoVM *vm)  { cando_lib_include_register(vm);  }
 CANDO_API void cando_open_httplib(CandoVM *vm)     { cando_lib_http_register(vm);     }
 CANDO_API void cando_open_httpslib(CandoVM *vm)    { cando_lib_https_register(vm);    }
+CANDO_API void cando_open_metalib(CandoVM *vm)     { cando_lib_meta_register(vm);     }
 
 /* =========================================================================
  * Internal: compile source into a chunk

--- a/source/lib/array.c
+++ b/source/lib/array.c
@@ -6,6 +6,7 @@
 
 #include "array.h"
 #include "libutil.h"
+#include "meta.h"
 #include "../vm/bridge.h"
 #include "../object/object.h"
 #include "../object/array.h"
@@ -337,4 +338,9 @@ void cando_lib_array_register(CandoVM *vm)
 
     cando_vm_set_global(vm, "array", proto_val, true);
     vm->array_proto = proto_val;
+
+    /* Mirror onto `_meta.array` so user scripts can extend the prototype
+     * via either name (`array.foo = ...` or `_meta.array.foo = ...`). */
+    cando_lib_meta_register(vm);
+    cando_lib_meta_set(vm, "array", proto);
 }

--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -1040,23 +1040,6 @@ static int http_create_server_fn(CandoVM *vm, int argc, CandoValue *args)
  * ===================================================================== */
 
 /*
- * meta_define_method -- like libutil_set_method but a no-op if the slot is
- * already populated.  Keeps http_register_meta_tables idempotent so both http
- * and https registration paths can call it without exhausting the per-VM
- * native function table.
- */
-static void meta_define_method(CandoVM *vm, CdoObject *obj,
-                               const char *name, CandoNativeFn fn)
-{
-    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
-    CdoValue   existing = cdo_null();
-    bool       have     = cdo_object_rawget(obj, key, &existing);
-    cdo_string_release(key);
-    if (have && !cdo_is_null(existing)) return;
-    libutil_set_method(vm, obj, name, fn);
-}
-
-/*
  * http_register_meta_tables -- populate the user-extensible `_meta` tables
  * for HTTP/HTTPS objects with their default native methods.  Idempotent and
  * safe to call from both http and https registration so either library may
@@ -1068,10 +1051,10 @@ void http_register_meta_tables(CandoVM *vm)
 
     CdoObject *res_meta = cando_lib_meta_table(vm, "http_response");
     if (res_meta) {
-        meta_define_method(vm, res_meta, "status",    res_status_fn);
-        meta_define_method(vm, res_meta, "setHeader", res_setHeader_fn);
-        meta_define_method(vm, res_meta, "send",      res_send_fn);
-        meta_define_method(vm, res_meta, "json",      res_json_fn);
+        cando_lib_meta_define(vm, res_meta, "status",    res_status_fn);
+        cando_lib_meta_define(vm, res_meta, "setHeader", res_setHeader_fn);
+        cando_lib_meta_define(vm, res_meta, "send",      res_send_fn);
+        cando_lib_meta_define(vm, res_meta, "json",      res_json_fn);
     }
     /* http_request currently has no native methods.  The table is created
      * eagerly so user code can attach methods reliably at script startup. */
@@ -1080,8 +1063,8 @@ void http_register_meta_tables(CandoVM *vm)
 
     CdoObject *server_meta = cando_lib_meta_table(vm, "http_server");
     if (server_meta) {
-        meta_define_method(vm, server_meta, "listen", server_listen_fn);
-        meta_define_method(vm, server_meta, "close",  server_close_fn);
+        cando_lib_meta_define(vm, server_meta, "listen", server_listen_fn);
+        cando_lib_meta_define(vm, server_meta, "close",  server_close_fn);
     }
 }
 

--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -18,6 +18,7 @@
 #include "http.h"
 #include "httputil.h"
 #include "libutil.h"
+#include "meta.h"
 #include "../vm/bridge.h"
 #include "../vm/vm.h"
 #include "../object/object.h"
@@ -69,11 +70,16 @@ typedef struct HttpServer {
 } HttpServer;
 
 typedef struct HttpResCtx {
-    HttpConn     conn;
-    int          status_code;
-    HttpHeaders  headers;
-    bool         sent;
-    bool         active;
+    HttpConn      conn;
+    int           status_code;
+    HttpHeaders   headers;
+    bool          sent;
+    bool          active;
+    /* Wakes the connection thread once the response has been written so it
+     * can clean up the connection.  Necessary because res:send() may run from
+     * a different thread (e.g. one spawned inside the request handler). */
+    cando_mutex_t mu;
+    cando_cond_t  cv;
 } HttpResCtx;
 
 static HttpServer    g_servers[HTTP_MAX_SERVERS];
@@ -129,6 +135,8 @@ static int res_alloc(void)
             memset(&g_res_pool[i], 0, sizeof(HttpResCtx));
             http_conn_init(&g_res_pool[i].conn);
             http_headers_init(&g_res_pool[i].headers);
+            cando_os_mutex_init(&g_res_pool[i].mu);
+            cando_os_cond_init(&g_res_pool[i].cv);
             g_res_pool[i].active = true;
             g_res_pool[i].status_code = 200;
             idx = i;
@@ -144,6 +152,8 @@ static void res_free(int idx)
     if (idx < 0 || idx >= HTTP_MAX_ACTIVE_RESPONSES) return;
     cando_os_mutex_lock(&g_res_pool_mutex);
     http_headers_free(&g_res_pool[idx].headers);
+    cando_os_mutex_destroy(&g_res_pool[idx].mu);
+    cando_os_cond_destroy(&g_res_pool[idx].cv);
     g_res_pool[idx].active = false;
     cando_os_mutex_unlock(&g_res_pool_mutex);
 }
@@ -439,6 +449,10 @@ int http_do_request_native(CandoVM *vm, int argc, CandoValue *args,
     }
     set_obj_field(result, "headers", hdrs);
 
+    /* Attach the user-extensible meta table so script code can add helper
+     * methods via `_meta.http_client_response.<name> = FUNCTION(...) { ... }`. */
+    cando_lib_meta_attach(vm, result, "http_client_response");
+
     http_response_free(&resp);
 
     cando_vm_push(vm, result_val);
@@ -490,9 +504,22 @@ static HttpResCtx *res_get_ctx_from(CandoVM *vm, CandoValue receiver)
     return &g_res_pool[idx];
 }
 
-/* Build and send a complete response on ctx->conn. */
+/*
+ * res_send_impl -- write the complete HTTP response on ctx->conn, mark it as
+ * sent, and wake any thread (typically the connection thread) blocked in
+ * res_wait_until_sent waiting for cleanup.
+ *
+ * Caller must NOT hold ctx->mu; this function acquires it internally so the
+ * write is serialised against itself if invoked concurrently.
+ */
 static bool res_send_impl(HttpResCtx *ctx, const char *body, usize body_len)
 {
+    cando_os_mutex_lock(&ctx->mu);
+    if (ctx->sent) {
+        cando_os_mutex_unlock(&ctx->mu);
+        return false;
+    }
+
     HttpBuf out;
     httpbuf_init(&out);
 
@@ -524,7 +551,22 @@ static bool res_send_impl(HttpResCtx *ctx, const char *body, usize body_len)
     bool ok = http_conn_write_all(&ctx->conn, out.data, out.len);
     httpbuf_free(&out);
     ctx->sent = true;
+    cando_os_cond_broadcast(&ctx->cv);
+    cando_os_mutex_unlock(&ctx->mu);
     return ok;
+}
+
+/*
+ * res_wait_until_sent -- block until ctx->sent becomes true.  Used by the
+ * connection thread to keep the socket and response context alive after the
+ * request handler returns so res:send() may be invoked from another thread.
+ */
+static void res_wait_until_sent(HttpResCtx *ctx)
+{
+    cando_os_mutex_lock(&ctx->mu);
+    while (!ctx->sent)
+        cando_os_cond_wait(&ctx->cv, &ctx->mu);
+    cando_os_mutex_unlock(&ctx->mu);
 }
 
 /* res.status(code) */
@@ -555,27 +597,56 @@ static int res_setHeader_fn(CandoVM *vm, int argc, CandoValue *args)
     return 1;
 }
 
-/* res.send(body) */
+/*
+ * res.send([body])
+ *
+ * If `body` is omitted (or null), the value of the receiver's `body` field is
+ * sent instead.  The default `body` field is initialised to "" when the res
+ * object is built, and meta-method extensions like `_meta.http_response.write`
+ * append to it before calling :send().
+ */
 static int res_send_fn(CandoVM *vm, int argc, CandoValue *args)
 {
     if (argc < 1) { cando_vm_push(vm, cando_null()); return 1; }
     HttpResCtx *ctx = res_get_ctx_from(vm, args[0]);
-    if (!ctx || ctx->sent) { cando_vm_push(vm, args[0]); return 1; }
+    if (!ctx) { cando_vm_push(vm, args[0]); return 1; }
 
     const char *body = "";
     u32         blen = 0;
     char       *tmp  = NULL;
-    if (argc >= 2) {
+    CdoValue    field_val = cdo_null();
+    bool        have_field = false;
+
+    if (argc >= 2 && !cando_is_null(args[1])) {
         if (cando_is_string(args[1])) {
             body = args[1].as.string->data;
             blen = args[1].as.string->length;
-        } else if (!cando_is_null(args[1])) {
+        } else {
             tmp = cando_value_tostring(args[1]);
             if (tmp) { body = tmp; blen = (u32)strlen(tmp); }
         }
+    } else {
+        /* Fall back to the receiver's `body` field so users can build the
+         * response incrementally (e.g. via res:write) and call res:send(). */
+        CdoObject *obj = cando_bridge_resolve(vm, args[0].as.handle);
+        if (obj) {
+            CdoString *kbody = cdo_string_intern("body", 4);
+            have_field = cdo_object_get(obj, kbody, &field_val);
+            cdo_string_release(kbody);
+        }
+        if (have_field && field_val.tag == CDO_STRING && field_val.as.string) {
+            body = field_val.as.string->data;
+            blen = field_val.as.string->length;
+        } else if (have_field && field_val.tag != CDO_NULL) {
+            tmp = cdo_value_tostring(field_val);
+            if (tmp) { body = tmp; blen = (u32)strlen(tmp); }
+        }
     }
+
     res_send_impl(ctx, body, blen);
     if (tmp) free(tmp);
+    /* field_val is borrowed from cdo_object_get -- do NOT release. */
+    (void)have_field;
     cando_vm_push(vm, args[0]);
     return 1;
 }
@@ -723,25 +794,36 @@ static CANDO_THREAD_RETURN conn_thread_fn(void *arg_p)
                       (u32)strlen(preq.headers.entries[i].value));
     }
     set_obj_field(req_obj, "headers", hdrs_obj);
+    cando_lib_meta_attach(&child, req_obj, "http_request");
 
-    /* Build res object. */
+    /* Build res object.  Methods live on `_meta.http_response` so users can
+     * extend them; we only stash the per-instance `__res_id` and an empty
+     * mutable `body` accumulator here. */
     CandoValue res_val = cando_bridge_new_object(&child);
     CdoObject *res_obj = cando_bridge_resolve(&child, res_val.as.handle);
     set_num_field(res_obj, "__res_id", (f64)res_idx);
-    libutil_set_method(&child, res_obj, "status",    res_status_fn);
-    libutil_set_method(&child, res_obj, "setHeader", res_setHeader_fn);
-    libutil_set_method(&child, res_obj, "send",      res_send_fn);
-    libutil_set_method(&child, res_obj, "json",      res_json_fn);
+    set_str_field(res_obj, "body", "", 0);
+    cando_lib_meta_attach(&child, res_obj, "http_response");
 
     /* Call the user callback(req, res). */
     CandoValue cb_args[2] = { req_val, res_val };
     cando_vm_call_value(&child, server->callback_fn, cb_args, 2);
 
-    /* If the callback did not send anything, flush a default 500. */
-    if (!ctx->sent) {
-        ctx->status_code = 500;
-        res_send_impl(ctx, "Internal Server Error", 21);
+    /* If the callback errored out, send a 500 immediately so the client
+     * doesn't hang.  Otherwise wait for res:send -- which may be invoked
+     * synchronously from the callback or asynchronously from another
+     * Cando thread that captured the res object. */
+    if (child.has_error) {
+        cando_os_mutex_lock(&ctx->mu);
+        bool already_sent = ctx->sent;
+        cando_os_mutex_unlock(&ctx->mu);
+        if (!already_sent) {
+            ctx->status_code = 500;
+            res_send_impl(ctx, "Internal Server Error", 21);
+        }
     }
+
+    res_wait_until_sent(ctx);
 
     /* Cleanup. */
     http_parsed_request_free(&preq);
@@ -933,11 +1015,12 @@ int http_create_server_native_impl(CandoVM *vm, CandoValue callback,
     server->ssl_ctx     = (SSL_CTX *)ssl_ctx;
     server->listen_fd   = -1;
 
+    /* The instance only carries the per-server identifier; listen/close are
+     * inherited from `_meta.http_server`. */
     CandoValue sobj_val = cando_bridge_new_object(vm);
     CdoObject *sobj     = cando_bridge_resolve(vm, sobj_val.as.handle);
     set_num_field(sobj, "__server_id", (f64)sidx);
-    libutil_set_method(vm, sobj, "listen", server_listen_fn);
-    libutil_set_method(vm, sobj, "close",  server_close_fn);
+    cando_lib_meta_attach(vm, sobj, "http_server");
 
     cando_vm_push(vm, sobj_val);
     return 1;
@@ -956,6 +1039,52 @@ static int http_create_server_fn(CandoVM *vm, int argc, CandoValue *args)
  * Registration
  * ===================================================================== */
 
+/*
+ * meta_define_method -- like libutil_set_method but a no-op if the slot is
+ * already populated.  Keeps http_register_meta_tables idempotent so both http
+ * and https registration paths can call it without exhausting the per-VM
+ * native function table.
+ */
+static void meta_define_method(CandoVM *vm, CdoObject *obj,
+                               const char *name, CandoNativeFn fn)
+{
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    CdoValue   existing = cdo_null();
+    bool       have     = cdo_object_rawget(obj, key, &existing);
+    cdo_string_release(key);
+    if (have && !cdo_is_null(existing)) return;
+    libutil_set_method(vm, obj, name, fn);
+}
+
+/*
+ * http_register_meta_tables -- populate the user-extensible `_meta` tables
+ * for HTTP/HTTPS objects with their default native methods.  Idempotent and
+ * safe to call from both http and https registration so either library may
+ * be opened standalone.
+ */
+void http_register_meta_tables(CandoVM *vm)
+{
+    cando_lib_meta_register(vm);
+
+    CdoObject *res_meta = cando_lib_meta_table(vm, "http_response");
+    if (res_meta) {
+        meta_define_method(vm, res_meta, "status",    res_status_fn);
+        meta_define_method(vm, res_meta, "setHeader", res_setHeader_fn);
+        meta_define_method(vm, res_meta, "send",      res_send_fn);
+        meta_define_method(vm, res_meta, "json",      res_json_fn);
+    }
+    /* http_request currently has no native methods.  The table is created
+     * eagerly so user code can attach methods reliably at script startup. */
+    (void)cando_lib_meta_table(vm, "http_request");
+    (void)cando_lib_meta_table(vm, "http_client_response");
+
+    CdoObject *server_meta = cando_lib_meta_table(vm, "http_server");
+    if (server_meta) {
+        meta_define_method(vm, server_meta, "listen", server_listen_fn);
+        meta_define_method(vm, server_meta, "close",  server_close_fn);
+    }
+}
+
 void cando_lib_http_register(CandoVM *vm)
 {
     ensure_pools_inited();
@@ -969,6 +1098,8 @@ void cando_lib_http_register(CandoVM *vm)
     libutil_set_method(vm, http_obj, "createServer", http_create_server_fn);
 
     cando_vm_set_global(vm, "http", http_val, true);
+
+    http_register_meta_tables(vm);
 
     /* Register global fetch(). */
     cando_vm_register_native(vm, "fetch", fetch_fn);

--- a/source/lib/http.h
+++ b/source/lib/http.h
@@ -57,4 +57,12 @@ int http_do_request_native(CandoVM *vm, int argc, CandoValue *args,
 int http_create_server_native_impl(CandoVM *vm, CandoValue callback,
                                    struct SSL_CTX_st *ssl_ctx);
 
+/*
+ * http_register_meta_tables -- create / populate `_meta.http_request`,
+ * `_meta.http_response`, `_meta.http_client_response`, and `_meta.http_server`
+ * with their default native methods.  Idempotent.  Used by both the http and
+ * https library registration paths.
+ */
+void http_register_meta_tables(CandoVM *vm);
+
 #endif /* CANDO_LIB_HTTP_H */

--- a/source/lib/https.c
+++ b/source/lib/https.c
@@ -196,4 +196,8 @@ void cando_lib_https_register(CandoVM *vm)
     libutil_set_method(vm, https_obj, "createServer", https_create_server_fn);
 
     cando_vm_set_global(vm, "https", https_val, true);
+
+    /* Share the same `_meta` tables as http: TLS only changes the transport,
+     * not the request/response shape, so users register methods once. */
+    http_register_meta_tables(vm);
 }

--- a/source/lib/meta.c
+++ b/source/lib/meta.c
@@ -11,6 +11,7 @@
  */
 
 #include "meta.h"
+#include "libutil.h"
 #include "../vm/bridge.h"
 #include "../object/object.h"
 #include "../object/string.h"
@@ -71,6 +72,17 @@ CdoObject *cando_lib_meta_table(CandoVM *vm, const char *name)
     return tbl;
 }
 
+void cando_lib_meta_set(CandoVM *vm, const char *name, CdoObject *table)
+{
+    if (!table) return;
+    CdoObject *root = meta_root_obj(vm);
+    if (!root) return;
+
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    cdo_object_rawset(root, key, cdo_object_value(table), FIELD_NONE);
+    cdo_string_release(key);
+}
+
 void cando_lib_meta_attach(CandoVM *vm, CdoObject *instance, const char *name)
 {
     if (!instance) return;
@@ -79,4 +91,31 @@ void cando_lib_meta_attach(CandoVM *vm, CdoObject *instance, const char *name)
 
     cdo_object_rawset(instance, g_meta_index,
                       cdo_object_value(tbl), FIELD_NONE);
+}
+
+void cando_lib_meta_define(CandoVM *vm, CdoObject *tbl,
+                           const char *name, CandoNativeFn fn)
+{
+    if (!tbl || !name || !fn) return;
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    CdoValue   existing = cdo_null();
+    bool       have     = cdo_object_rawget(tbl, key, &existing);
+    cdo_string_release(key);
+    if (have && !cdo_is_null(existing)) return;
+    libutil_set_method(vm, tbl, name, fn);
+}
+
+void cando_lib_meta_alias(CdoObject *dst, const char *dst_name,
+                          const CdoObject *src, const char *src_name)
+{
+    if (!dst || !src || !dst_name || !src_name) return;
+    CdoString *src_key = cdo_string_intern(src_name, (u32)strlen(src_name));
+    CdoValue   v       = cdo_null();
+    bool       have    = cdo_object_rawget(src, src_key, &v);
+    cdo_string_release(src_key);
+    if (!have) return;
+
+    CdoString *dst_key = cdo_string_intern(dst_name, (u32)strlen(dst_name));
+    cdo_object_rawset(dst, dst_key, v, FIELD_NONE);
+    cdo_string_release(dst_key);
 }

--- a/source/lib/meta.c
+++ b/source/lib/meta.c
@@ -1,0 +1,82 @@
+/*
+ * lib/meta.c -- Global `_meta` registry for built-in object types.
+ *
+ * Implements the helpers declared in meta.h.  The `_meta` global is a plain
+ * writable CdoObject whose fields are subtables for each native type.  Native
+ * libraries call cando_lib_meta_table() during registration to obtain (or
+ * lazily create) their subtable and populate it with default methods, then
+ * call cando_lib_meta_attach() on every new instance to wire up `__index`.
+ *
+ * Must compile with gcc -std=c11.
+ */
+
+#include "meta.h"
+#include "../vm/bridge.h"
+#include "../object/object.h"
+#include "../object/string.h"
+
+#include <string.h>
+
+#define META_GLOBAL_NAME "_meta"
+
+static CdoObject *meta_root_obj(CandoVM *vm)
+{
+    CandoValue meta_val = cando_null();
+    if (!cando_vm_get_global(vm, META_GLOBAL_NAME, &meta_val))
+        return NULL;
+    if (!cando_is_object(meta_val))
+        return NULL;
+    return cando_bridge_resolve(vm, meta_val.as.handle);
+}
+
+void cando_lib_meta_register(CandoVM *vm)
+{
+    /* Idempotent: do nothing if _meta is already a global object. */
+    if (meta_root_obj(vm) != NULL) return;
+
+    CandoValue meta_val = cando_bridge_new_object(vm);
+    /* Writable: users must be able to add methods at runtime.  The subtable
+     * fields hold native-method sentinels and are likewise mutable. */
+    cando_vm_set_global(vm, META_GLOBAL_NAME, meta_val, false);
+}
+
+CdoObject *cando_lib_meta_table(CandoVM *vm, const char *name)
+{
+    CdoObject *root = meta_root_obj(vm);
+    if (!root) return NULL;
+
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    CdoValue   v   = cdo_null();
+    bool       ok  = cdo_object_rawget(root, key, &v);
+
+    if (ok && v.tag == CDO_OBJECT && v.as.object) {
+        cdo_string_release(key);
+        return v.as.object;
+    }
+    /* Stale or wrong-type slot: replace it. */
+
+    CandoValue tbl_val = cando_bridge_new_object(vm);
+    CdoObject *tbl     = cando_bridge_resolve(vm, tbl_val.as.handle);
+
+    /* Stamp __type so type() on instances yields the meta name. */
+    CdoString *type_key = cdo_string_intern(META_TYPE, (u32)(sizeof(META_TYPE) - 1));
+    CdoString *type_val = cdo_string_intern(name, (u32)strlen(name));
+    cdo_object_rawset(tbl, type_key,
+                      cdo_string_value(type_val), FIELD_STATIC);
+    cdo_string_release(type_key);
+    cdo_string_release(type_val);
+
+    cdo_object_rawset(root, key, cdo_object_value(tbl), FIELD_NONE);
+    cdo_string_release(key);
+    return tbl;
+}
+
+void cando_lib_meta_attach(CandoVM *vm, CdoObject *instance, const char *name)
+{
+    if (!instance) return;
+    CdoObject *tbl = cando_lib_meta_table(vm, name);
+    if (!tbl) return;
+
+    cdo_object_rawset(instance, g_meta_index,
+                      cdo_object_value(tbl), FIELD_NONE);
+}

--- a/source/lib/meta.h
+++ b/source/lib/meta.h
@@ -42,6 +42,18 @@ CANDO_API void cando_lib_meta_register(CandoVM *vm);
 CANDO_API CdoObject *cando_lib_meta_table(CandoVM *vm, const char *name);
 
 /*
+ * cando_lib_meta_set -- register an existing CdoObject as the meta table
+ * for `name`.  Used when the table is also exposed elsewhere (e.g. the
+ * `string` global is also published as `_meta.string`) so both names
+ * resolve to the same underlying object.
+ *
+ * Does NOT touch `__type` on `table`; the caller is responsible for that
+ * if desired.  No-op if `_meta` is unregistered.
+ */
+CANDO_API void cando_lib_meta_set(CandoVM *vm, const char *name,
+                                  CdoObject *table);
+
+/*
  * cando_lib_meta_attach -- set instance.__index = _meta.<name>.
  *
  * Convenience helper for native libraries that build instance objects.  No-op
@@ -49,5 +61,25 @@ CANDO_API CdoObject *cando_lib_meta_table(CandoVM *vm, const char *name);
  */
 CANDO_API void cando_lib_meta_attach(CandoVM *vm, CdoObject *instance,
                                      const char *name);
+
+/*
+ * cando_lib_meta_define -- like libutil_set_method, but a no-op if `name`
+ * already has a non-null value on `tbl`.  Lets registration paths that may
+ * be called more than once (e.g. once from `http` and once from `https`)
+ * skip redundant entries instead of inflating the per-VM native table.
+ */
+CANDO_API void cando_lib_meta_define(CandoVM *vm, CdoObject *tbl,
+                                     const char *name, CandoNativeFn fn);
+
+/*
+ * cando_lib_meta_alias -- copy an existing field from `src` onto `dst`
+ * under the new key `dst_name`, reading `src_name` from `src`.  Useful for
+ * exposing the same native-method sentinel under two names without burning
+ * a second slot in the VM's native function table.
+ *
+ * No-op if either object is missing or the source key does not exist.
+ */
+CANDO_API void cando_lib_meta_alias(CdoObject *dst, const char *dst_name,
+                                    const CdoObject *src, const char *src_name);
 
 #endif /* CANDO_LIB_META_H */

--- a/source/lib/meta.h
+++ b/source/lib/meta.h
@@ -1,0 +1,53 @@
+/*
+ * lib/meta.h -- Global `_meta` registry for built-in object types.
+ *
+ * `_meta` is a writable global object holding named subtables ("meta tables").
+ * Each subtable acts as the prototype (__index target) for instances of a
+ * built-in type, letting users extend the methods available on them:
+ *
+ *     _meta.http_response.write = FUNCTION(self, data) {
+ *         self.body = self.body + data;
+ *     }
+ *
+ * Native libraries register their default methods on the appropriate subtable
+ * via cando_lib_meta_table().  Instances created by the library are stamped
+ * with `__index = _meta.<name>` so method dispatch flows through the chain.
+ *
+ * Must compile with gcc -std=c11.
+ */
+
+#ifndef CANDO_LIB_META_H
+#define CANDO_LIB_META_H
+
+#include "../vm/vm.h"
+#include "../object/object.h"
+
+/*
+ * cando_lib_meta_register -- create the `_meta` global as an empty writable
+ * object.  Idempotent: calling it twice is a no-op.  Must be called before
+ * any cando_lib_meta_table() lookups.
+ */
+CANDO_API void cando_lib_meta_register(CandoVM *vm);
+
+/*
+ * cando_lib_meta_table -- return the CdoObject for `_meta.<name>`, creating
+ * an empty subtable if none exists.  The returned pointer is owned by the
+ * `_meta` global and remains valid for the lifetime of the VM.
+ *
+ * The returned object's `__type` is set to <name> so user code can inspect
+ * instances with type().
+ *
+ * Returns NULL if `_meta` has not been registered yet.
+ */
+CANDO_API CdoObject *cando_lib_meta_table(CandoVM *vm, const char *name);
+
+/*
+ * cando_lib_meta_attach -- set instance.__index = _meta.<name>.
+ *
+ * Convenience helper for native libraries that build instance objects.  No-op
+ * if either `instance` or the named meta table is missing.
+ */
+CANDO_API void cando_lib_meta_attach(CandoVM *vm, CdoObject *instance,
+                                     const char *name);
+
+#endif /* CANDO_LIB_META_H */

--- a/source/lib/object.c
+++ b/source/lib/object.c
@@ -10,6 +10,7 @@
 
 #include "object.h"
 #include "libutil.h"
+#include "meta.h"
 #include "../vm/bridge.h"
 #include "../object/object.h"
 #include "../object/array.h"
@@ -435,4 +436,11 @@ void cando_lib_object_register(CandoVM *vm)
     libutil_set_method(vm, proto, "values",       obj_values);
 
     cando_vm_set_global(vm, "object", proto_val, true);
+
+    /* Mirror onto `_meta.object` so users may use the same table as a
+     * prototype: `object.setPrototype(myObj, _meta.object)`.  Methods added
+     * via `_meta.object.foo = ...` show up on `object.foo` since both names
+     * resolve to the same underlying table. */
+    cando_lib_meta_register(vm);
+    cando_lib_meta_set(vm, "object", proto);
 }

--- a/source/lib/string.c
+++ b/source/lib/string.c
@@ -11,6 +11,7 @@
 
 #include "string.h"
 #include "libutil.h"
+#include "meta.h"
 #include "../vm/bridge.h"
 #include "../vm/vm.h"
 #include "../object/string.h"
@@ -582,4 +583,9 @@ void cando_lib_string_register(CandoVM *vm)
     /* Expose as both a global module and the default string prototype. */
     cando_vm_set_global(vm, "string", proto_val, true);
     vm->string_proto = proto_val;
+
+    /* Mirror onto `_meta.string` so user scripts can extend the prototype
+     * via either name (`string.foo = ...` or `_meta.string.foo = ...`). */
+    cando_lib_meta_register(vm);
+    cando_lib_meta_set(vm, "string", proto);
 }

--- a/source/lib/thread.c
+++ b/source/lib/thread.c
@@ -19,6 +19,7 @@
 
 #include "thread.h"
 #include "libutil.h"
+#include "meta.h"
 #include "../vm/bridge.h"
 #include "../object/object.h"
 #include "../object/thread.h"
@@ -396,4 +397,29 @@ void cando_lib_thread_register(CandoVM *vm)
     libutil_set_method(vm, thread_obj, "catch",   thread_catch);
 
     cando_vm_set_global(vm, "thread", thread_val, true);
+
+    /* Build `_meta.thread` -- the per-instance method table for OBJ_THREAD
+     * receivers.  These are the subset of the thread library that operate on
+     * a thread argument, exposed under the colon-call form (`t:done()`,
+     * `t:join()`, ...).  We alias the existing native sentinels off the
+     * `thread` global instead of re-registering, both to keep the VM's
+     * fixed-size native table from filling up and so that user overrides
+     * applied to `thread.foo` are observed via `t:foo()` and vice-versa.
+     * vm->thread_proto caches a handle so the VM dispatcher can find the
+     * table without a global lookup on every method call. */
+    cando_lib_meta_register(vm);
+    CdoObject *t_meta = cando_lib_meta_table(vm, "thread");
+    if (t_meta) {
+        cando_lib_meta_alias(t_meta, "done",   thread_obj, "done");
+        cando_lib_meta_alias(t_meta, "join",   thread_obj, "join");
+        cando_lib_meta_alias(t_meta, "cancel", thread_obj, "cancel");
+        cando_lib_meta_alias(t_meta, "state",  thread_obj, "state");
+        cando_lib_meta_alias(t_meta, "error",  thread_obj, "error");
+        cando_lib_meta_alias(t_meta, "then",   thread_obj, "then");
+        cando_lib_meta_alias(t_meta, "catch",  thread_obj, "catch");
+
+        /* Cache the meta table handle for fast OBJ_THREAD method dispatch. */
+        HandleIndex h = cando_handle_alloc(vm->handles, t_meta);
+        vm->thread_proto = cando_object_value(h);
+    }
 }

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -84,6 +84,7 @@ void cando_vm_init(CandoVM *vm, CandoMemCtrl *mem) {
     for (u32 i = 0; i < CANDO_MAX_THROW_ARGS; i++) vm->thread_results[i] = cando_null();
     vm->string_proto    = cando_null();
     vm->array_proto     = cando_null();
+    vm->thread_proto    = cando_null();
     vm->default_class_call = cando_null();
 
     /* Module cache — initially empty. */
@@ -143,6 +144,7 @@ void cando_vm_init_child(CandoVM *child, const CandoVM *parent) {
     for (u32 i = 0; i < CANDO_MAX_THROW_ARGS; i++) child->thread_results[i] = cando_null();
     child->string_proto    = cando_value_copy(parent->string_proto);
     child->array_proto     = cando_value_copy(parent->array_proto);
+    child->thread_proto    = cando_value_copy(parent->thread_proto);
     child->default_class_call = parent->default_class_call;
 
     /* Module cache: child VMs do not cache modules independently. */
@@ -2022,12 +2024,20 @@ static CandoVMResult vm_run(CandoVM *vm) {
             CandoString *ks = frame->closure->chunk->constants[ci].as.string;
             CdoString   *key = cando_bridge_intern_key(ks);
             CdoValue     result;
+            bool         got = false;
             /* Use cdo_object_get for __index prototype-chain traversal. */
             if (cdo_object_get(obj, key, &result)) {
-                PUSH(cando_bridge_to_cando(vm, result));
-            } else {
-                PUSH(cando_null());
+                got = true;
+            } else if (obj->kind == OBJ_THREAD &&
+                       cando_is_object(vm->thread_proto)) {
+                /* Thread instances have no slot table; fall back to the
+                 * cached `_meta.thread` prototype for method lookups. */
+                CdoObject *tproto = cando_bridge_resolve(
+                    vm, vm->thread_proto.as.handle);
+                if (cdo_object_get(tproto, key, &result)) got = true;
             }
+            if (got) PUSH(cando_bridge_to_cando(vm, result));
+            else     PUSH(cando_null());
             cdo_string_release(key);
             cando_value_release(obj_val);
             DISPATCH();
@@ -2546,6 +2556,11 @@ static CandoVMResult vm_run(CandoVM *vm) {
                         CdoObject *aproto = cando_bridge_resolve(vm, vm->array_proto.as.handle);
                         cdo_object_get(aproto, key, &method_cdo);
                     }
+                } else if (robj->kind == OBJ_THREAD && cando_is_object(vm->thread_proto)) {
+                    /* Thread instances have no slot table; methods live on
+                     * the cached `_meta.thread` prototype. */
+                    CdoObject *tproto = cando_bridge_resolve(vm, vm->thread_proto.as.handle);
+                    cdo_object_get(tproto, key, &method_cdo);
                 } else {
                     cdo_object_get(robj, key, &method_cdo);
                 }

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -276,6 +276,7 @@ struct CandoVM {
     /* Built-in type prototypes ----------------------------------------- */
     CandoValue     string_proto;    /* string method table (or null)        */
     CandoValue     array_proto;     /* array method table (or null)         */
+    CandoValue     thread_proto;    /* thread instance method table (or null) */
 
     /* Default constructor wrapper ------------------------------------- */
     /* Native sentinel value bound to __call on every CLASS object.       */

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -131,7 +131,7 @@ run_test "lib_object" "$SCRIPTS/lib_object.cdo" \
     "$(printf '1\n99\n2\n1\n2\n3\n10\n99\n30\n20\nalice\nbob\nhello\nc\na\nb\n3\n1\n2\nfalse\ntrue\nfalse')"
 
 run_test "lib_meta" "$SCRIPTS/lib_meta.cdo" \
-    "$(printf 'object\nhttp_response\nhttp_request\nhttp_server\nhttp_client_response\nobject\ngreeter\nhi, world')"
+    "$(printf 'object\nhttp_response\nhttp_request\nhttp_server\nhttp_client_response\nobject\nobject\nobject\nthread\nHI!\nYES!\n10\n42\ntrue\ndone\nobject\ngreeter\nhi, world')"
 
 run_test "lib_http" "$SCRIPTS/lib_http.cdo" \
     "$(printf '200\nok-1\nbasic\nhello world\ndelayed\nhi alice')"

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -130,6 +130,12 @@ run_test "metamethods" "$SCRIPTS/metamethods.cdo" \
 run_test "lib_object" "$SCRIPTS/lib_object.cdo" \
     "$(printf '1\n99\n2\n1\n2\n3\n10\n99\n30\n20\nalice\nbob\nhello\nc\na\nb\n3\n1\n2\nfalse\ntrue\nfalse')"
 
+run_test "lib_meta" "$SCRIPTS/lib_meta.cdo" \
+    "$(printf 'object\nhttp_response\nhttp_request\nhttp_server\nhttp_client_response\nobject\ngreeter\nhi, world')"
+
+run_test "lib_http" "$SCRIPTS/lib_http.cdo" \
+    "$(printf '200\nok-1\nbasic\nhello world\ndelayed\nhi alice')"
+
 run_test "lib_crypto" "$SCRIPTS/lib_crypto.cdo" \
     "$(printf 'md5_ok\nsha256_ok\naGVsbG8gd29ybGQA\nhello world')"
 

--- a/tests/scripts/lib_http.cdo
+++ b/tests/scripts/lib_http.cdo
@@ -1,0 +1,68 @@
+/* lib_http.cdo -- Integration tests for the HTTP server, the `_meta`
+ * extensibility hook, and deferred `res:send()`.
+ *
+ * Each scenario starts an HTTP server on a private port, makes a fetch
+ * request, then closes the server.  Expected output is registered in
+ * tests/integration/run_tests.sh.
+ */
+
+/* ----- 1. Built-in res:send() inside the callback ------------------------ */
+VAR s1 = http.createServer(FUNCTION(req, res) {
+    res:status(200);
+    res:setHeader("X-Test", "basic");
+    res:send("ok-1");
+});
+s1:listen(18791);
+VAR r1 = fetch("http://127.0.0.1:18791/");
+print(r1.status);          /* expected: 200 */
+print(r1.body);            /* expected: ok-1 */
+print(r1.headers["x-test"]);  /* expected: basic */
+s1:close();
+
+/* ----- 2. User-defined `write` on _meta.http_response, send() with no body */
+_meta.http_response.write = FUNCTION(self, data) {
+    self.body = self.body + data;
+};
+VAR s2 = http.createServer(FUNCTION(req, res) {
+    res:write("hello ");
+    res:write("world");
+    res:send();          /* uses the accumulated `body` field */
+});
+s2:listen(18792);
+VAR r2 = fetch("http://127.0.0.1:18792/");
+print(r2.body);            /* expected: hello world */
+s2:close();
+
+/* ----- 3. Deferred res:send() from outside the callback ------------------
+ *
+ * The handler stashes `res` on a global instead of sending; a separate thread
+ * picks it up later and calls send().  Demonstrates that the connection
+ * stays open across the boundary.  Globals are the simplest cross-thread
+ * channel since thread blocks do not capture function parameters. */
+VAR pending = NULL;
+VAR s3 = http.createServer(FUNCTION(req, res) {
+    pending = res;
+});
+s3:listen(18793);
+
+thread {
+    thread.sleep(50);
+    pending:send("delayed");
+};
+
+VAR r3 = fetch("http://127.0.0.1:18793/");
+print(r3.body);            /* expected: delayed */
+s3:close();
+
+/* ----- 4. User method on _meta.http_response is visible on instances ----- */
+_meta.http_response.greet = FUNCTION(self, who) {
+    self.body = self.body + "hi " + who;
+};
+VAR s4 = http.createServer(FUNCTION(req, res) {
+    res:greet("alice");
+    res:send();
+});
+s4:listen(18794);
+VAR r4 = fetch("http://127.0.0.1:18794/");
+print(r4.body);            /* expected: hi alice */
+s4:close();

--- a/tests/scripts/lib_meta.cdo
+++ b/tests/scripts/lib_meta.cdo
@@ -16,6 +16,32 @@ print(type(_meta.http_request));          /* expected: http_request  */
 print(type(_meta.http_server));           /* expected: http_server   */
 print(type(_meta.http_client_response));  /* expected: http_client_response */
 
+/* The string / array / object / thread libs are aliased onto `_meta` so
+ * extending either name (`string.foo = ...` or `_meta.string.foo = ...`)
+ * touches the same underlying table. */
+print(type(_meta.string));                /* expected: object */
+print(type(_meta.array));                 /* expected: object */
+print(type(_meta.object));                /* expected: object */
+print(type(_meta.thread));                /* expected: thread */
+
+/* Methods added through `_meta.string` are visible on string receivers,
+ * AND reachable from the `string.*` global name -- both names resolve to
+ * the same underlying table. */
+_meta.string.shout = FUNCTION(self) { RETURN self:toUpper() + "!"; };
+print("hi":shout());                      /* expected: HI! */
+print(string.shout("yes"));               /* expected: YES! */
+
+/* Methods added through `_meta.array` are visible on array receivers. */
+_meta.array.first = FUNCTION(self) { RETURN self[0]; };
+print([10, 20, 30]:first());              /* expected: 10 */
+
+/* Method calls on thread instances dispatch through `_meta.thread`. */
+VAR t = thread { RETURN 42; };
+VAR r = await t;
+print(r);                                  /* expected: 42 */
+print(t:done());                           /* expected: true */
+print(t:state());                          /* expected: done */
+
 /* Users can attach arbitrary methods to a meta table. */
 _meta.http_response.write = FUNCTION(self, data) {
     self.body = self.body + data;

--- a/tests/scripts/lib_meta.cdo
+++ b/tests/scripts/lib_meta.cdo
@@ -1,0 +1,32 @@
+/* lib_meta.cdo -- Integration tests for the global `_meta` registry.
+ *
+ * `_meta` is a writable global object whose subtables act as the prototype
+ * (`__index`) for instances of built-in types.  Native libraries populate
+ * the default tables; users may add or override methods at runtime.
+ *
+ * Expected output is registered in tests/integration/run_tests.sh.
+ */
+
+/* ----- _meta exists and is writable -------------------------------------- */
+print(type(_meta));                       /* expected: object */
+
+/* The HTTP library populates `_meta.http_response` with default methods. */
+print(type(_meta.http_response));         /* expected: http_response */
+print(type(_meta.http_request));          /* expected: http_request  */
+print(type(_meta.http_server));           /* expected: http_server   */
+print(type(_meta.http_client_response));  /* expected: http_client_response */
+
+/* Users can attach arbitrary methods to a meta table. */
+_meta.http_response.write = FUNCTION(self, data) {
+    self.body = self.body + data;
+};
+print(type(_meta.http_response.write));   /* expected: object (function) */
+
+/* Users can register their own meta tables. */
+_meta.greeter = { __type: "greeter" };
+_meta.greeter.hello = FUNCTION(self) { RETURN "hi, " + self.name; };
+
+VAR g = { name: "world" };
+object.setPrototype(g, _meta.greeter);
+print(type(g));                            /* expected: greeter */
+print(g:hello());                          /* expected: hi, world */


### PR DESCRIPTION
## Summary

This PR introduces a global `_meta` registry that enables user code to extend methods on built-in object types (HTTP requests/responses, servers, threads, etc.) through a prototype-chain mechanism. Native libraries now register default methods on `_meta.<type>` subtables, and instances are stamped with `__index` pointers to their corresponding meta table, allowing users to add custom methods that propagate to all instances.

## Key Changes

- **New `meta.h`/`meta.c` library**: Implements the `_meta` global registry with functions to:
  - `cando_lib_meta_register()` — create the `_meta` global object
  - `cando_lib_meta_table()` — get or create a named subtable (e.g., `_meta.http_response`)
  - `cando_lib_meta_attach()` — wire an instance to its meta table via `__index`
  - `cando_lib_meta_define()` — register default methods (idempotent)
  - `cando_lib_meta_alias()` — share native sentinels across multiple names

- **HTTP server refactoring**:
  - Response context now includes `cando_mutex_t` and `cando_cond_t` for thread-safe deferred `res:send()`
  - `res_send_impl()` now serializes writes and broadcasts to waiting threads
  - New `res_wait_until_sent()` keeps the connection alive after the handler returns, allowing `res:send()` to be called from other threads
  - Response methods (`status`, `setHeader`, `send`, `json`) moved from instance fields to `_meta.http_response`
  - `res:send()` now falls back to the receiver's `body` field if no argument is provided, enabling incremental response building via user-defined helpers

- **Thread library integration**:
  - Per-instance thread methods (`done`, `join`, `cancel`, `state`, `error`, `then`, `catch`) now dispatch through `_meta.thread`
  - Methods are aliased from the `thread` global to avoid duplicating native sentinels
  - `vm->thread_proto` caches the meta table handle for efficient method dispatch

- **String, array, and object libraries**:
  - Each library now mirrors its global table onto `_meta.<type>` so both names resolve to the same underlying object
  - User overrides applied to either name take effect for both

- **HTTP client responses**:
  - Client response objects now inherit from `_meta.http_client_response` for extensibility

- **Documentation**:
  - New `_meta` section in `standard-library.md` explaining the registry and listing all built-in subtables
  - Updated HTTP server examples in `user-guide.md` to show the new method syntax and deferred `res:send()` pattern
  - New `metamethods.md` section on the `_meta` global registry

- **Integration tests**:
  - `lib_meta.cdo` — tests the `_meta` registry, method aliasing, and user-defined extensions
  - `lib_http.cdo` — tests built-in `res:send()`, user-defined `res:write()`, and deferred `res:send()` from other threads

## Notable Implementation Details

- The `_meta` global is writable, allowing users to add arbitrary subtables and methods at runtime
- Each subtable's `__type` field is stamped as `FIELD_STATIC` so `type(instance)` returns the meta name
- Default native methods use `FIELD_NONE` flags so user code can override them
- HTTP response deferred sending uses condition variables to safely coordinate between the connection thread and user threads that call `res:send()`
- The `res:send()` method now supports both explicit body arguments and falling back to the receiver's accumulated `body` field, enabling patterns like `res:write()` followed by `res:send()`

https://claude.ai/code/session_018yf68nejyEefdRW4MBnMwV