### PR TITLE
Support callable __index, __type, and __tostring meta-methods

### DIFF
--- a/source/natives.c
+++ b/source/natives.c
@@ -11,6 +11,18 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Forward declaration: dispatch a resolved callable CdoValue meta-method.
+ * Defined in vm/vm.c; declared here without pulling object/value.h into the
+ * public vm.h surface. */
+bool cando_vm_dispatch_callable(CandoVM *vm, const struct CdoValue *raw,
+                                 CandoValue *args, u32 argc);
+
+static bool meta_is_callable(CdoValue v)
+{
+    return v.tag == CDO_FUNCTION || v.tag == CDO_NATIVE ||
+           v.tag == CDO_NUMBER;
+}
+
 /* =========================================================================
  * Dispatch and name tables
  * Sized to CANDO_NATIVE_MAX; unused trailing slots are zero-initialised
@@ -68,61 +80,71 @@ int cando_native_print(CandoVM *vm, int argc, CandoValue *args)
 /* =========================================================================
  * type(val) -- push the type name of val as a CandoString; returns 1.
  * If the value is an object with a __type field, return that field's value.
+ * __type may be a string (returned directly) or a callable (invoked as
+ * __type(val) -> string).
  * ===================================================================== */
 int cando_native_type(CandoVM *vm, int argc, CandoValue *args)
 {
     if (argc < 1) {
         cando_vm_push(vm, cando_null());
-    } else if (cando_is_object(args[0]) && g_meta_type) {
+        return 1;
+    }
+    if (cando_is_object(args[0]) && g_meta_type) {
         /* Follow the prototype (__index) chain so a class instance whose
          * class declares __type reports that class as its type. */
         CdoObject *obj = cando_bridge_resolve(vm, args[0].as.handle);
         CdoValue type_val;
         if (cdo_object_get(obj, g_meta_type, &type_val)) {
-            cando_vm_push(vm, cando_bridge_to_cando(vm, type_val));
-        } else {
-            const char *name = cando_value_type_name((TypeTag)args[0].tag);
-            u32 len = (u32)strlen(name);
-            CandoString *s = cando_string_new(name, len);
-            cando_vm_push(vm, cando_string_value(s));
+            if (cdo_is_string(type_val)) {
+                cando_vm_push(vm, cando_bridge_to_cando(vm, type_val));
+                return 1;
+            }
+            if (meta_is_callable(type_val)) {
+                if (cando_vm_dispatch_callable(vm, &type_val, args, 1))
+                    return 1;
+                if (vm->has_error) return -1;
+            }
         }
-    } else {
-        const char *name = cando_value_type_name((TypeTag)args[0].tag);
-        u32 len = (u32)strlen(name);
-        CandoString *s = cando_string_new(name, len);
-        cando_vm_push(vm, cando_string_value(s));
     }
+    /* Default: built-in type tag name. */
+    const char *name = cando_value_type_name((TypeTag)args[0].tag);
+    u32 len = (u32)strlen(name);
+    CandoString *s = cando_string_new(name, len);
+    cando_vm_push(vm, cando_string_value(s));
     return 1;
 }
 
 /* =========================================================================
  * toString(val) -- push string representation as a CandoString; returns 1.
- * If the value is an object with a __tostring meta-method, call it.
+ * If the value is an object with a __tostring meta-method, return its value
+ * directly when it is a string, or invoke it when it is a callable.
  * ===================================================================== */
 int cando_native_tostring(CandoVM *vm, int argc, CandoValue *args)
 {
     if (argc < 1) {
         cando_vm_push(vm, cando_null());
-    } else if (cando_is_object(args[0]) && g_meta_tostring) {
-        /* Dispatch __tostring meta-method if present. */
-        if (cando_vm_call_meta(vm, args[0].as.handle,
-                               (struct CdoString *)g_meta_tostring,
-                               args, 1)) {
-            return 1;  /* meta pushed 1 result */
-        }
-        if (vm->has_error) return -1;
-        /* No __tostring — fall through to default. */
-        char *s = cando_value_tostring(args[0]);
-        u32 len = (u32)strlen(s);
-        CandoString *cs = cando_string_new(s, len);
-        free(s);
-        cando_vm_push(vm, cando_string_value(cs));
-    } else {
-        char *s = cando_value_tostring(args[0]);
-        u32 len = (u32)strlen(s);
-        CandoString *cs = cando_string_new(s, len);
-        free(s);
-        cando_vm_push(vm, cando_string_value(cs));
+        return 1;
     }
+    if (cando_is_object(args[0]) && g_meta_tostring) {
+        CdoObject *obj = cando_bridge_resolve(vm, args[0].as.handle);
+        CdoValue ts_val;
+        if (cdo_object_get(obj, g_meta_tostring, &ts_val)) {
+            if (cdo_is_string(ts_val)) {
+                cando_vm_push(vm, cando_bridge_to_cando(vm, ts_val));
+                return 1;
+            }
+            if (meta_is_callable(ts_val)) {
+                if (cando_vm_dispatch_callable(vm, &ts_val, args, 1))
+                    return 1;
+                if (vm->has_error) return -1;
+            }
+        }
+    }
+    /* Default: built-in tostring. */
+    char *s = cando_value_tostring(args[0]);
+    u32 len = (u32)strlen(s);
+    CandoString *cs = cando_string_new(s, len);
+    free(s);
+    cando_vm_push(vm, cando_string_value(cs));
     return 1;
 }

--- a/source/object/object.c
+++ b/source/object/object.c
@@ -397,6 +397,11 @@ bool cdo_object_rawdelete(CdoObject *obj, CdoString *key) {
 
 /* -----------------------------------------------------------------------
  * Prototype-chain lookup
+ *
+ * __index can be:
+ *   - a plain object or array (lookup table): traversal continues into it
+ *   - a function/native (callable): traversal stops; the VM layer dispatches
+ *     the callable via cdo_object_index_callable + cando_vm_dispatch_callable
  * --------------------------------------------------------------------- */
 bool cdo_object_get(CdoObject *obj, CdoString *key, CdoValue *out) {
     CdoObject *cur = obj;
@@ -415,7 +420,52 @@ bool cdo_object_get(CdoObject *obj, CdoString *key, CdoValue *out) {
         if (!cdo_object_rawget(cur, meta_index, &idx_val))
             return false;
 
-        if (!cdo_is_any_object(idx_val) || !idx_val.as.object)
+        /* Only plain objects and arrays act as lookup tables; callables
+         * (functions/natives/PC sentinels) terminate the chain. */
+        if (idx_val.tag != CDO_OBJECT && idx_val.tag != CDO_ARRAY)
+            return false;
+        if (!idx_val.as.object)
+            return false;
+
+        CdoObject *next = idx_val.as.object;
+        if (next == cur)
+            return false; /* self-loop guard */
+        cur = next;
+    }
+    return false;
+}
+
+/* -----------------------------------------------------------------------
+ * Callable __index lookup
+ *
+ * Walks the same chain as cdo_object_get, but instead of looking for a
+ * field by `key` it returns the first callable __index encountered.
+ * Used by the VM layer to dispatch __index as a function when a regular
+ * field lookup misses.
+ * --------------------------------------------------------------------- */
+bool cdo_object_index_callable(CdoObject *obj, CdoValue *out) {
+    CdoObject *cur = obj;
+
+    for (int depth = 0; depth < CANDO_PROTO_DEPTH_MAX; depth++) {
+        CdoString *meta_index = g_meta_index
+            ? g_meta_index
+            : cdo_intern_weak(META_INDEX, (u32)(sizeof(META_INDEX) - 1));
+        if (!meta_index)
+            return false;
+
+        CdoValue idx_val;
+        if (!cdo_object_rawget(cur, meta_index, &idx_val))
+            return false;
+
+        if (idx_val.tag == CDO_FUNCTION || idx_val.tag == CDO_NATIVE ||
+            idx_val.tag == CDO_NUMBER) {
+            *out = idx_val;
+            return true;
+        }
+
+        if (idx_val.tag != CDO_OBJECT && idx_val.tag != CDO_ARRAY)
+            return false;
+        if (!idx_val.as.object)
             return false;
 
         CdoObject *next = idx_val.as.object;

--- a/source/object/object.h
+++ b/source/object/object.h
@@ -186,11 +186,22 @@ CANDO_API bool cdo_object_rawdelete(CdoObject *obj, CdoString *key);
  * Prototype-chain lookup (__index traversal)
  *
  * Looks up key in obj; if not found AND obj has an __index field that is
- * an object, recurses up to CANDO_PROTO_DEPTH_MAX levels.
+ * a plain object or array (lookup table), recurses up to
+ * CANDO_PROTO_DEPTH_MAX levels.  A callable __index (function/native)
+ * terminates the chain -- callers can dispatch it via
+ * cdo_object_index_callable.
  * --------------------------------------------------------------------- */
 #define CANDO_PROTO_DEPTH_MAX 32
 
 CANDO_API bool cdo_object_get(CdoObject *obj, CdoString *key, CdoValue *out);
+
+/*
+ * cdo_object_index_callable -- walk the __index chain looking for the
+ * first callable (function/native/PC sentinel) __index value.  Returns
+ * true and writes *out with the callable when found.  Used by the VM
+ * layer to dispatch __index as a function after a field lookup miss.
+ */
+CANDO_API bool cdo_object_index_callable(CdoObject *obj, CdoValue *out);
 
 /* -----------------------------------------------------------------------
  * Readonly flag

--- a/source/object/value.h
+++ b/source/object/value.h
@@ -41,7 +41,7 @@ typedef enum {
 /* -----------------------------------------------------------------------
  * CdoValue -- the object layer's tagged value
  * --------------------------------------------------------------------- */
-typedef struct {
+typedef struct CdoValue {
     u8 tag;  /* CdoTypeTag stored as u8 */
     union {
         bool        boolean;   /* CDO_BOOL                                */

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -553,16 +553,10 @@ static void vm_close_upvalues(CandoVM *vm, CandoValue *last) {
  * Meta-method dispatch helper
  * ===================================================================== */
 
-bool cando_vm_call_meta(CandoVM *vm, HandleIndex h,
-                         struct CdoString *meta_key,
-                         CandoValue *args, u32 argc) {
-    CdoObject *obj = cando_bridge_resolve(vm, h);
-    if (!obj || !meta_key) return false;
-
-    CdoValue raw;
-    if (!cdo_object_get(obj, (CdoString *)meta_key, &raw))
-        return false;
-
+bool cando_vm_dispatch_callable(CandoVM *vm, const struct CdoValue *raw_p,
+                                 CandoValue *args, u32 argc) {
+    if (!raw_p) return false;
+    CdoValue raw = *raw_p;
     CandoValue callee = cando_bridge_to_cando(vm, raw);
 
     /* Native sentinel: dispatch via vm->native_fns table. */
@@ -678,6 +672,19 @@ bool cando_vm_call_meta(CandoVM *vm, HandleIndex h,
 
     vm_runtime_error(vm, "meta-method is not callable");
     return false;
+}
+
+bool cando_vm_call_meta(CandoVM *vm, HandleIndex h,
+                         struct CdoString *meta_key,
+                         CandoValue *args, u32 argc) {
+    CdoObject *obj = cando_bridge_resolve(vm, h);
+    if (!obj || !meta_key) return false;
+
+    CdoValue raw;
+    if (!cdo_object_get(obj, (CdoString *)meta_key, &raw))
+        return false;
+
+    return cando_vm_dispatch_callable(vm, &raw, args, argc);
 }
 
 /* =========================================================================
@@ -2035,6 +2042,29 @@ static CandoVMResult vm_run(CandoVM *vm) {
                 CdoObject *tproto = cando_bridge_resolve(
                     vm, vm->thread_proto.as.handle);
                 if (cdo_object_get(tproto, key, &result)) got = true;
+            }
+            if (!got) {
+                /* Try a callable __index: __index(obj, key) -> value. */
+                CdoValue idx_callable;
+                if (cdo_object_index_callable(obj, &idx_callable)) {
+                    CandoValue idx_args[2];
+                    idx_args[0] = obj_val;
+                    idx_args[1] = cando_string_value(
+                        cando_string_new(key->data, key->length));
+                    bool ok = cando_vm_dispatch_callable(
+                        vm, &idx_callable, idx_args, 2);
+                    cando_value_release(idx_args[1]);
+                    if (vm->has_error) {
+                        cdo_string_release(key);
+                        cando_value_release(obj_val);
+                        goto handle_error;
+                    }
+                    if (ok) {
+                        cdo_string_release(key);
+                        cando_value_release(obj_val);
+                        DISPATCH();
+                    }
+                }
             }
             if (got) PUSH(cando_bridge_to_cando(vm, result));
             else     PUSH(cando_null());

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -471,6 +471,20 @@ CANDO_API bool cando_vm_call_meta(CandoVM *vm, HandleIndex h,
                          struct CdoString *meta_key,
                          CandoValue *args, u32 argc);
 
+/*
+ * cando_vm_dispatch_callable -- invoke an already-resolved callable CdoValue
+ * (function/native/PC sentinel) with the given args.  Pushes one result onto
+ * vm->stack on success.  Used by callers that have located a callable meta
+ * value through their own walk (e.g. cdo_object_index_callable).
+ *
+ * `raw` is passed by const pointer so vm.h does not need the object-layer
+ * value definition; callers must include "object/value.h" before use.
+ */
+struct CdoValue;
+CANDO_API bool cando_vm_dispatch_callable(CandoVM *vm,
+                                           const struct CdoValue *raw,
+                                           CandoValue *args, u32 argc);
+
 /* =========================================================================
  * Threading helpers
  * ===================================================================== */

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -125,7 +125,7 @@ run_test "lib_array" "$SCRIPTS/lib_array.cdo" \
     "$(printf '3\n4\n4\n3\n2\n4\n6\n4\n6\n6')"
 
 run_test "metamethods" "$SCRIPTS/metamethods.cdo" \
-    "$(printf '10\n20\nhello\n99\n10\nfrom_a\nproto\nVec3\nnumber\nstring\nnull\nbool\n3\n4\nstring\nAnimal\nRex says hello\nRex\nPoint\n5\n7\n49\n27\n3\n11\n3\noverridden\nbase greet\n4\n6\n7\n15\n6\n20\n5\n5\n1\n1\n8\n9\n-5\n3\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\ntrue\ntrue\n35\nVec(7,8)\nDog\nRex says hello\nRex says hello (woof, labrador)\nset:foo')"
+    "$(printf '10\n20\nhello\n99\n10\nfrom_a\nproto\nVec3\nnumber\nstring\nnull\nbool\n3\n4\nstring\nAnimal\nRex says hello\nRex\nPoint\n5\n7\n49\n27\n3\n11\n3\noverridden\nbase greet\n4\n6\n7\n15\n6\n20\n5\n5\n1\n1\n8\n9\n-5\n3\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\ntrue\ntrue\n35\nVec(7,8)\nDog\nRex says hello\nRex says hello (woof, labrador)\nset:foo\nlooked_up:anything\nlooked_up:other\nbase_value\nfallback:unknown\nDynamicType\nliteral-form')"
 
 run_test "lib_object" "$SCRIPTS/lib_object.cdo" \
     "$(printf '1\n99\n2\n1\n2\n3\n10\n99\n30\n20\nalice\nbob\nhello\nc\na\nb\n3\n1\n2\nfalse\ntrue\nfalse')"

--- a/tests/scripts/metamethods.cdo
+++ b/tests/scripts/metamethods.cdo
@@ -246,3 +246,30 @@ VAR ni_proto = {
 object.setPrototype(log_obj, ni_proto);
 log_obj.foo = 1;
 print(ni_log[0]);            // set:foo
+
+/* ----- __index as a function (computed properties) ----------------------- */
+VAR computed = {};
+computed.__index = FUNCTION(self, key) {
+    RETURN "looked_up:" + key;
+};
+print(computed.anything);    // looked_up:anything
+print(computed.other);       // looked_up:other
+
+/* Function __index after a prototype-table chain still dispatches. */
+VAR base_tbl = { explicit: "base_value" };
+base_tbl.__index = FUNCTION(self, key) {
+    RETURN "fallback:" + key;
+};
+VAR layered = {};
+object.setPrototype(layered, base_tbl);
+print(layered.explicit);     // base_value         (table hit short-circuits)
+print(layered.unknown);      // fallback:unknown   (callable __index dispatches)
+
+/* ----- __type as a function ---------------------------------------------- */
+VAR typed_fn = {};
+typed_fn.__type = FUNCTION(self) { RETURN "DynamicType"; };
+print(type(typed_fn));       // DynamicType
+
+/* ----- __tostring as a literal string ------------------------------------ */
+VAR ts_str = { __tostring: "literal-form" };
+print(toString(ts_str));     // literal-form

--- a/tests/test_object.c
+++ b/tests/test_object.c
@@ -577,6 +577,78 @@ TEST(test_prototype_self_loop_guard) {
 }
 
 /* -----------------------------------------------------------------------
+ * Callable __index detection
+ *
+ * A function/native __index does NOT act as a lookup-table; cdo_object_get
+ * must terminate without descending into it, and cdo_object_index_callable
+ * must surface it for VM-layer dispatch.
+ * --------------------------------------------------------------------- */
+TEST(test_index_callable_direct) {
+    CdoObject *obj = cdo_object_new();
+    CdoObject *fn  = cdo_function_new(0, NULL, NULL, 0);
+    CdoString *k   = cdo_string_intern("missing", 7);
+
+    CdoValue fv = { .tag = CDO_FUNCTION, .as = { .object = fn } };
+    EXPECT_TRUE(cdo_object_rawset(obj, g_meta_index, fv, FIELD_NONE));
+
+    /* cdo_object_get must NOT recurse into the function. */
+    CdoValue out;
+    EXPECT_FALSE(cdo_object_get(obj, k, &out));
+
+    /* cdo_object_index_callable must surface the function. */
+    CdoValue cb;
+    EXPECT_TRUE(cdo_object_index_callable(obj, &cb));
+    EXPECT_EQ(cb.tag, (u8)CDO_FUNCTION);
+    EXPECT_EQ(cb.as.object, fn);
+
+    cdo_string_release(k);
+    cdo_object_destroy(obj);
+    cdo_object_destroy(fn);
+}
+
+TEST(test_index_callable_via_chain) {
+    /* instance.__index = mid (table) ; mid.__index = fn (callable) */
+    CdoObject *fn       = cdo_function_new(0, NULL, NULL, 0);
+    CdoObject *mid      = cdo_object_new();
+    CdoObject *instance = cdo_object_new();
+
+    CdoValue fv  = { .tag = CDO_FUNCTION, .as = { .object = fn } };
+    CdoValue mv  = { .tag = CDO_OBJECT,   .as = { .object = mid } };
+    cdo_object_rawset(mid,      g_meta_index, fv, FIELD_NONE);
+    cdo_object_rawset(instance, g_meta_index, mv, FIELD_NONE);
+
+    /* Direct lookup of a non-meta key: chain walks instance -> mid, then
+     * encounters callable __index on mid and stops. */
+    CdoString *k = cdo_string_intern("missing", 7);
+    CdoValue out;
+    EXPECT_FALSE(cdo_object_get(instance, k, &out));
+
+    /* Callable scan walks the same chain and surfaces fn. */
+    CdoValue cb;
+    EXPECT_TRUE(cdo_object_index_callable(instance, &cb));
+    EXPECT_EQ(cb.as.object, fn);
+
+    cdo_string_release(k);
+    cdo_object_destroy(instance);
+    cdo_object_destroy(mid);
+    cdo_object_destroy(fn);
+}
+
+TEST(test_index_callable_table_only_returns_false) {
+    /* obj.__index = table -- no callable in the chain. */
+    CdoObject *proto = cdo_object_new();
+    CdoObject *obj   = cdo_object_new();
+    CdoValue   pv    = { .tag = CDO_OBJECT, .as = { .object = proto } };
+    cdo_object_rawset(obj, g_meta_index, pv, FIELD_NONE);
+
+    CdoValue cb;
+    EXPECT_FALSE(cdo_object_index_callable(obj, &cb));
+
+    cdo_object_destroy(obj);
+    cdo_object_destroy(proto);
+}
+
+/* -----------------------------------------------------------------------
  * Object length
  * --------------------------------------------------------------------- */
 TEST(test_object_length) {
@@ -1263,6 +1335,9 @@ int main(void) {
     run_test("basic __index chain",       test_prototype_chain_basic);
     run_test("3-level chain",             test_prototype_chain_depth);
     run_test("self-loop guard",           test_prototype_self_loop_guard);
+    run_test("__index callable direct",   test_index_callable_direct);
+    run_test("__index callable in chain", test_index_callable_via_chain);
+    run_test("__index table-only false",  test_index_callable_table_only_returns_false);
 
     printf("\n-- Length --\n");
     run_test("object length",             test_object_length);


### PR DESCRIPTION
## Summary
This PR extends meta-method support to allow `__index`, `__type`, and `__tostring` to be callable (functions/natives) in addition to their existing forms. When these meta-methods are callables, they are invoked by the VM layer rather than treated as lookup tables or static values.

## Key Changes

- **New VM dispatch function**: Added `cando_vm_dispatch_callable()` to invoke an already-resolved callable CdoValue. This is extracted from the internal logic of `cando_vm_call_meta()` and exposed for use by callers that locate callables through their own walks.

- **Callable __index support**: 
  - Added `cdo_object_index_callable()` to walk the prototype chain and return the first callable `__index` encountered
  - Modified `cdo_object_get()` to stop traversal when encountering a callable `__index` (only plain objects/arrays act as lookup tables)
  - Updated the VM's INDEX opcode to dispatch callable `__index` as `__index(obj, key)` after a field lookup miss

- **Callable __type support**:
  - Modified `cando_native_type()` to handle `__type` as either a string (returned directly) or a callable (invoked as `__type(val)`)
  - Falls back to built-in type names when no `__type` meta-method is present

- **Callable __tostring support**:
  - Modified `cando_native_tostring()` to handle `__tostring` as either a string (returned directly) or a callable (invoked as `__tostring(val)`)
  - Falls back to built-in string conversion when no `__tostring` meta-method is present

- **Test coverage**: Added three new unit tests for callable `__index` behavior (direct, via chain, and table-only cases) and integration tests demonstrating computed properties, dynamic typing, and literal string `__tostring`.

## Implementation Details

- The prototype chain traversal logic distinguishes between lookup-table `__index` (objects/arrays) and callable `__index` (functions/natives/PC sentinels), allowing the chain to continue through tables but stop at callables
- Forward declaration of `cando_vm_dispatch_callable()` in `natives.c` avoids pulling internal object/value definitions into the public `vm.h` surface
- Meta-method values are checked with `cdo_is_string()` first for direct return, then `meta_is_callable()` for dispatch, with fallback to built-in behavior

https://claude.ai/code/session_01DPzZAsa8RoMqzbf9kHjvJg