### PR TITLE
Statically link winpthread on Windows MinGW builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,13 @@ target_include_directories(libcando
 target_link_libraries(libcando PUBLIC Threads::Threads OpenSSL::SSL OpenSSL::Crypto ${PLATFORM_LIBS})
 
 if(WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_link_options(libcando PRIVATE -static-libgcc)
+    # Statically link libgcc and libwinpthread so libcando.dll has no runtime
+    # DLL dependencies beyond system libraries.  Without -Bstatic on
+    # winpthread, MinGW pulls in libwinpthread-1.dll dynamically.
+    target_link_options(libcando PRIVATE
+        -static-libgcc
+        -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
+    )
 endif()
 
 # ----------------------------------------------------------------------------
@@ -213,7 +219,10 @@ target_include_directories(cando PRIVATE
 target_link_libraries(cando PRIVATE libcando)
 
 if(WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_link_options(cando PRIVATE -static-libgcc)
+    target_link_options(cando PRIVATE
+        -static-libgcc
+        -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
+    )
 endif()
 
 # ----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -267,15 +267,20 @@ CFLAGS_WIN  = -std=c11 -Wall -Wextra -DCANDO_PLATFORM_WINDOWS -D_WIN32_WINNT=0x0
 CFLAGS_EXE_WIN = -std=c11 -Wall -Wextra -DCANDO_PLATFORM_WINDOWS -D_WIN32_WINNT=0x0600 \
                  -iquote source -iquote source/core -Iinclude
 
-# OpenSSL is linked statically into libcando.dll so the only files needed
-# at runtime are cando.exe and libcando.dll (no libcrypto-3-x64.dll, etc.).
+# OpenSSL and winpthread are linked statically into libcando.dll so the only
+# files needed at runtime are cando.exe and libcando.dll (no
+# libcrypto-3-x64.dll, libwinpthread-1.dll, etc.).
 # crypt32 is required by OpenSSL's static libcrypto on Windows.
 LDFLAGS_LIB_WIN = -static-libgcc \
-                  -Wl,-Bstatic -lssl -lcrypto -Wl,-Bdynamic \
+                  -Wl,-Bstatic -lssl -lcrypto -lwinpthread -Wl,-Bdynamic \
                   -lws2_32 -lcrypt32 -lm
 
 # The executable links against libcando.dll only — no OpenSSL needed here.
-LDFLAGS_EXE_WIN = -static-libgcc -lws2_32 -lm
+# winpthread is statically linked defensively in case the toolchain pulls it
+# in for the EXE itself.
+LDFLAGS_EXE_WIN = -static-libgcc \
+                  -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic \
+                  -lws2_32 -lm
 
 libcando.dll: $(CANDO_LIB_SRCS) $(CANDO_WIN_EXTRA)
 	$(MINGW_CC) $(CFLAGS_WIN) -shared $^ -o $@ \


### PR DESCRIPTION
## Summary
This change ensures that `libwinpthread` is statically linked into `libcando.dll` on Windows MinGW builds, eliminating runtime dependencies on `libwinpthread-1.dll` and reducing deployment complexity.

## Key Changes
- **CMakeLists.txt**: Updated both `libcando` and `cando` targets to include `-Wl,-Bstatic -lwinpthread -Wl,-Bdynamic` linker options alongside the existing `-static-libgcc` flag for Windows MinGW builds
- **Makefile**: 
  - Modified `LDFLAGS_LIB_WIN` to statically link `lwinpthread` when building `libcando.dll`
  - Modified `LDFLAGS_EXE_WIN` to defensively statically link `lwinpthread` in the executable as well
  - Updated comments to reflect that both OpenSSL and winpthread are now statically linked

## Implementation Details
- Uses linker flags `-Wl,-Bstatic` and `-Wl,-Bdynamic` to selectively enable static linking for `winpthread` while keeping other libraries dynamic
- Applied consistently across both CMake and Makefile build systems
- Includes explanatory comments noting that without `-Bstatic`, MinGW would pull in `libwinpthread-1.dll` dynamically
- The executable defensively links winpthread statically in case the toolchain pulls it in automatically

https://claude.ai/code/session_01NcW7SjkZuLbG8WoXionktg