### PR TITLE
Force libwinpthread fully static and verify in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,23 @@ jobs:
       - name: Build cando.exe
         run: make cando.exe MINGW_CC=gcc WINDRES=windres
 
+      - name: Verify no MinGW runtime DLL deps
+        run: |
+          set -e
+          echo "=== cando.exe imports ==="
+          objdump -p cando.exe | grep "DLL Name" || true
+          echo "=== libcando.dll imports ==="
+          objdump -p libcando.dll | grep "DLL Name" || true
+          for bin in cando.exe libcando.dll; do
+            for dll in libwinpthread-1.dll libgcc_s_seh-1.dll libstdc++-6.dll libssl-3-x64.dll libcrypto-3-x64.dll; do
+              if objdump -p "$bin" | grep -qi "DLL Name: $dll"; then
+                echo "ERROR: $bin still imports $dll"
+                exit 1
+              fi
+            done
+          done
+          echo "OK: no MinGW runtime DLL dependencies."
+
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,11 +165,14 @@ target_link_libraries(libcando PUBLIC Threads::Threads OpenSSL::SSL OpenSSL::Cry
 
 if(WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
     # Statically link libgcc and libwinpthread so libcando.dll has no runtime
-    # DLL dependencies beyond system libraries.  Without -Bstatic on
-    # winpthread, MinGW pulls in libwinpthread-1.dll dynamically.
+    # DLL dependencies beyond system libraries.  --whole-archive forces every
+    # winpthread symbol to be embedded, and the trailing -Bstatic catches the
+    # implicit -lpthread MinGW's GCC spec appends to satisfy libgcc's
+    # internal pthread references.
     target_link_options(libcando PRIVATE
         -static-libgcc
-        -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
+        -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic
+        "LINKER:-Bstatic"
     )
 endif()
 
@@ -221,7 +224,8 @@ target_link_libraries(cando PRIVATE libcando)
 if(WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_link_options(cando PRIVATE
         -static-libgcc
-        -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
+        -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive,-Bdynamic
+        "LINKER:-Bstatic"
     )
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -271,16 +271,26 @@ CFLAGS_EXE_WIN = -std=c11 -Wall -Wextra -DCANDO_PLATFORM_WINDOWS -D_WIN32_WINNT=
 # files needed at runtime are cando.exe and libcando.dll (no
 # libcrypto-3-x64.dll, libwinpthread-1.dll, etc.).
 # crypt32 is required by OpenSSL's static libcrypto on Windows.
+#
+# --whole-archive on libwinpthread forces every pthread symbol to be embedded,
+# so any reference (including ones GCC's spec adds implicitly after our flags)
+# resolves to the static archive instead of libwinpthread-1.dll.  The trailing
+# -Wl,-Bstatic catches the implicit -lpthread MinGW's GCC spec appends to
+# satisfy libgcc's internal pthread references.
 LDFLAGS_LIB_WIN = -static-libgcc \
-                  -Wl,-Bstatic -lssl -lcrypto -lwinpthread -Wl,-Bdynamic \
-                  -lws2_32 -lcrypt32 -lm
+                  -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive \
+                  -Wl,-Bstatic -lssl -lcrypto -Wl,-Bdynamic \
+                  -lws2_32 -lcrypt32 -lm \
+                  -Wl,-Bstatic
 
 # The executable links against libcando.dll only — no OpenSSL needed here.
 # winpthread is statically linked defensively in case the toolchain pulls it
-# in for the EXE itself.
+# in for the EXE itself (libgcc's TLS/EH support references pthread symbols
+# even when the user code doesn't).
 LDFLAGS_EXE_WIN = -static-libgcc \
-                  -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic \
-                  -lws2_32 -lm
+                  -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive \
+                  -Wl,-Bdynamic -lws2_32 -lm \
+                  -Wl,-Bstatic
 
 libcando.dll: $(CANDO_LIB_SRCS) $(CANDO_WIN_EXTRA)
 	$(MINGW_CC) $(CFLAGS_WIN) -shared $^ -o $@ \


### PR DESCRIPTION
## Summary
The previous fix (PR #28) wrapped `-lwinpthread` in `-Wl,-Bstatic ... -Wl,-Bdynamic` but Windows users still hit the "libwinpthread-1.dll was not found" dialog. Root cause: MinGW GCC's spec appends an implicit `-lpthread` *after* our user flags to satisfy libgcc's own pthread references, and that implicit reference lands after our `-Wl,-Bdynamic`, so it resolves to `libwinpthread-1.dll` instead of the static archive.

This PR closes the gap and adds a CI guard so it can't regress silently:
- `--whole-archive` on `-lwinpthread` so every pthread symbol is eagerly embedded into the binary; no late reference can fall back to the import lib.
- Trailing `-Wl,-Bstatic` so any GCC-implicit libs appended after our flags resolve statically too.
- New CI step that runs `objdump -p` on `cando.exe` and `libcando.dll` and fails the Windows job if it sees `libwinpthread-1.dll`, `libgcc_s_seh-1.dll`, `libstdc++-6.dll`, `libssl-3-x64.dll`, or `libcrypto-3-x64.dll` in the import table.

After this lands, the `cando-windows-x86_64` artifact really is just `cando.exe` + `libcando.dll` with no MinGW runtime DLL dependencies.

## Test plan
- [ ] CI's `Build (Windows)` job passes, including the new "Verify no MinGW runtime DLL deps" step.
- [ ] Inspect the step's log: confirm `cando.exe` imports list contains only `libcando.dll`, `KERNEL32.dll`, `msvcrt.dll`, `WS2_32.dll` (and similar system DLLs).
- [ ] Confirm `libcando.dll` imports list contains only Windows system DLLs (`KERNEL32.dll`, `msvcrt.dll`, `WS2_32.dll`, `CRYPT32.dll`, `ADVAPI32.dll`, etc.).
- [ ] Download the artifact, place `cando.exe` + `libcando.dll` in an empty folder on a clean Windows machine without MinGW, and confirm `cando.exe` launches without the System Error dialog.

https://claude.ai/code/session_01NcW7SjkZuLbG8WoXionktg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcW7SjkZuLbG8WoXionktg)_