### PR TITLE
Add inspect() built-in function for debug-friendly value printing

### DIFF
--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -38,6 +38,54 @@ instead.
 Returns the canonical string representation.  If `v` is an object with
 a `__tostring` meta-method, calls it and returns the result.
 
+### `inspect(v, depth*) → string`
+
+Returns a debug-friendly string showing the *contents* of arrays and
+objects rather than their handle id.  Designed to be passed to `print`:
+
+```cando
+var data = { name: "Alice", scores: [10, 20, 30] };
+print(inspect(data));
+// { name: "Alice", scores: [10, 20, 30] }
+```
+
+Formatting:
+
+| Value | Rendering |
+|---|---|
+| `null` / `true` / `false` | as-is |
+| number | same as `toString(n)` |
+| string | double-quoted, with `\\`, `\"`, `\n`, `\r`, `\t`, `\xNN` escapes |
+| array | `[v1, v2, ...]` |
+| object | `{ key: value, ... }` (FIFO insertion order; non-identifier keys are quoted) |
+| function / native / thread | `<function>` / `<native>` / `<thread>` |
+
+`depth` (default `0`) limits how many levels of nested arrays / objects
+are expanded:
+
+- `0` (default) — unlimited recursion.
+- `N > 0` — nested arrays / objects beyond level `N` are truncated to
+  `[...]` / `{...}`.
+
+Cycles are detected on the current path and rendered as `<circular>`,
+so `inspect` always terminates regardless of `depth`.  Two distinct
+sub-trees that happen to reference the same object are *not* flagged
+as cycles (they are printed twice).
+
+```cando
+var a = [1];
+a:push(a);
+print(inspect(a));            // [1, <circular>]
+
+var deep = { a: { b: { c: 1 } } };
+print(inspect(deep, 1));      // { a: {...} }
+print(inspect(deep, 2));      // { a: { b: {...} } }
+```
+
+`inspect` does not invoke `__tostring`; it always shows raw structure,
+which is what you want when debugging.  Use `toString(v)` when you do
+want the meta-method.
+
 ---
 
 ## `math`

--- a/source/natives.c
+++ b/source/natives.c
@@ -8,7 +8,10 @@
 #include "vm/bridge.h"
 #include "object/array.h"
 
+#include <ctype.h>
+#include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Forward declaration: dispatch a resolved callable CdoValue meta-method.
@@ -32,12 +35,14 @@ CandoNativeFn cando_native_table[CANDO_NATIVE_MAX] = {
     cando_native_print,     /* index 0, sentinel -1.0 */
     cando_native_type,      /* index 1, sentinel -2.0 */
     cando_native_tostring,  /* index 2, sentinel -3.0 */
+    cando_native_inspect,   /* index 3, sentinel -4.0 */
 };
 
 const char *cando_native_names[CANDO_NATIVE_MAX] = {
     "print",
     "type",
     "toString",
+    "inspect",
 };
 
 /* =========================================================================
@@ -146,5 +151,291 @@ int cando_native_tostring(CandoVM *vm, int argc, CandoValue *args)
     CandoString *cs = cando_string_new(s, len);
     free(s);
     cando_vm_push(vm, cando_string_value(cs));
+    return 1;
+}
+
+/* =========================================================================
+ * inspect(val, depth*) -- debug-printer for arrays / objects.
+ *
+ *  depth = 0 (default) means unlimited recursion; cycles are always
+ *  short-circuited with `<circular>`.  depth = N > 0 truncates nested
+ *  arrays / objects beyond that level to `[...]` / `{...}`.
+ * ===================================================================== */
+
+typedef struct {
+    char       *buf;
+    u32         len;
+    u32         cap;
+    bool        oom;
+    int         max_depth;     /* 0 = unlimited */
+    CdoObject **path;          /* visited stack for cycle detection */
+    u32         path_len;
+    u32         path_cap;
+} InspectCtx;
+
+static void inspect_buf_reserve(InspectCtx *ctx, u32 need)
+{
+    if (ctx->oom) return;
+    if (ctx->len + need + 1 <= ctx->cap) return;
+    u32 nc = ctx->cap ? ctx->cap * 2 : 64;
+    while (nc < ctx->len + need + 1) nc *= 2;
+    char *p = (char *)realloc(ctx->buf, nc);
+    if (!p) { ctx->oom = true; return; }
+    ctx->buf = p;
+    ctx->cap = nc;
+}
+
+static void inspect_push(InspectCtx *ctx, const char *s, u32 n)
+{
+    inspect_buf_reserve(ctx, n);
+    if (ctx->oom) return;
+    memcpy(ctx->buf + ctx->len, s, n);
+    ctx->len += n;
+}
+
+static void inspect_push_cstr(InspectCtx *ctx, const char *s)
+{
+    inspect_push(ctx, s, (u32)strlen(s));
+}
+
+static void inspect_push_char(InspectCtx *ctx, char c)
+{
+    inspect_push(ctx, &c, 1);
+}
+
+static bool inspect_path_contains(const InspectCtx *ctx, const CdoObject *o)
+{
+    for (u32 i = 0; i < ctx->path_len; i++)
+        if (ctx->path[i] == o) return true;
+    return false;
+}
+
+static bool inspect_path_push(InspectCtx *ctx, CdoObject *o)
+{
+    if (ctx->path_len == ctx->path_cap) {
+        u32 nc = ctx->path_cap ? ctx->path_cap * 2 : 8;
+        CdoObject **p = (CdoObject **)realloc(ctx->path, nc * sizeof(*p));
+        if (!p) { ctx->oom = true; return false; }
+        ctx->path     = p;
+        ctx->path_cap = nc;
+    }
+    ctx->path[ctx->path_len++] = o;
+    return true;
+}
+
+static void inspect_path_pop(InspectCtx *ctx)
+{
+    if (ctx->path_len > 0) ctx->path_len--;
+}
+
+/* True if name is a non-empty C-style identifier: [A-Za-z_][A-Za-z0-9_]*.
+ * Used to decide whether an object key needs quoting. */
+static bool inspect_key_is_ident(const char *s, u32 len)
+{
+    if (len == 0) return false;
+    unsigned char c0 = (unsigned char)s[0];
+    if (!(isalpha(c0) || c0 == '_')) return false;
+    for (u32 i = 1; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (!(isalnum(c) || c == '_')) return false;
+    }
+    return true;
+}
+
+static void inspect_write_quoted(InspectCtx *ctx, const char *data, u32 len)
+{
+    inspect_push_char(ctx, '"');
+    for (u32 i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)data[i];
+        switch (c) {
+            case '"':  inspect_push(ctx, "\\\"", 2); break;
+            case '\\': inspect_push(ctx, "\\\\", 2); break;
+            case '\n': inspect_push(ctx, "\\n",  2); break;
+            case '\r': inspect_push(ctx, "\\r",  2); break;
+            case '\t': inspect_push(ctx, "\\t",  2); break;
+            default:
+                if (c < 0x20) {
+                    char esc[8];
+                    int  m = snprintf(esc, sizeof(esc), "\\x%02X", c);
+                    if (m > 0) inspect_push(ctx, esc, (u32)m);
+                } else {
+                    inspect_push_char(ctx, (char)c);
+                }
+        }
+    }
+    inspect_push_char(ctx, '"');
+}
+
+static void inspect_write_number(InspectCtx *ctx, f64 n)
+{
+    char buf[64];
+    int  m;
+    if (n == (i64)n)
+        m = snprintf(buf, sizeof(buf), "%" PRId64, (i64)n);
+    else
+        m = snprintf(buf, sizeof(buf), "%.17g", n);
+    if (m > 0) inspect_push(ctx, buf, (u32)m);
+}
+
+static void inspect_cdo(InspectCtx *ctx, CdoValue v, int depth);
+
+static void inspect_array(InspectCtx *ctx, CdoObject *arr, int depth)
+{
+    if (inspect_path_contains(ctx, arr)) {
+        inspect_push_cstr(ctx, "<circular>");
+        return;
+    }
+    if (ctx->max_depth > 0 && depth >= ctx->max_depth) {
+        inspect_push_cstr(ctx, "[...]");
+        return;
+    }
+    if (!inspect_path_push(ctx, arr)) return;
+
+    inspect_push_char(ctx, '[');
+    u32 n = cdo_array_len(arr);
+    for (u32 i = 0; i < n; i++) {
+        if (i > 0) inspect_push(ctx, ", ", 2);
+        CdoValue elem = cdo_null();
+        cdo_array_rawget_idx(arr, i, &elem);
+        inspect_cdo(ctx, elem, depth + 1);
+        if (ctx->oom) break;
+    }
+    inspect_push_char(ctx, ']');
+
+    inspect_path_pop(ctx);
+}
+
+typedef struct { InspectCtx *ctx; int depth; bool first; } InspectIter;
+
+static bool inspect_field_cb(CdoString *key, CdoValue *val, u8 flags, void *ud)
+{
+    (void)flags;
+    InspectIter *it  = (InspectIter *)ud;
+    InspectCtx  *ctx = it->ctx;
+    if (ctx->oom) return false;
+
+    if (!it->first) inspect_push(ctx, ", ", 2);
+    it->first = false;
+
+    if (inspect_key_is_ident(key->data, key->length))
+        inspect_push(ctx, key->data, key->length);
+    else
+        inspect_write_quoted(ctx, key->data, key->length);
+
+    inspect_push(ctx, ": ", 2);
+    inspect_cdo(ctx, *val, it->depth + 1);
+    return !ctx->oom;
+}
+
+static void inspect_object(InspectCtx *ctx, CdoObject *obj, int depth)
+{
+    if (inspect_path_contains(ctx, obj)) {
+        inspect_push_cstr(ctx, "<circular>");
+        return;
+    }
+    if (ctx->max_depth > 0 && depth >= ctx->max_depth) {
+        inspect_push_cstr(ctx, "{...}");
+        return;
+    }
+    if (!inspect_path_push(ctx, obj)) return;
+
+    InspectIter it = { .ctx = ctx, .depth = depth, .first = true };
+    inspect_push(ctx, "{ ", 2);
+    cdo_object_foreach(obj, inspect_field_cb, &it);
+    if (it.first)
+        ctx->len--;          /* drop the trailing space for empty `{ }` */
+    else
+        inspect_push_char(ctx, ' ');
+    inspect_push_char(ctx, '}');
+
+    inspect_path_pop(ctx);
+}
+
+static void inspect_cdo(InspectCtx *ctx, CdoValue v, int depth)
+{
+    if (ctx->oom) return;
+    switch ((CdoTypeTag)v.tag) {
+        case CDO_NULL:
+            inspect_push(ctx, "null", 4); break;
+        case CDO_BOOL:
+            inspect_push_cstr(ctx, v.as.boolean ? "true" : "false"); break;
+        case CDO_NUMBER:
+            inspect_write_number(ctx, v.as.number); break;
+        case CDO_STRING:
+            inspect_write_quoted(ctx, v.as.string->data, v.as.string->length);
+            break;
+        case CDO_ARRAY:
+            inspect_array(ctx, v.as.object, depth); break;
+        case CDO_OBJECT:
+            /* The bridge layer may yield CDO_OBJECT for an array-kind object;
+             * dispatch by kind to be safe. */
+            if (v.as.object->kind == OBJ_ARRAY)
+                inspect_array(ctx, v.as.object, depth);
+            else if (v.as.object->kind == OBJ_THREAD)
+                inspect_push_cstr(ctx, "<thread>");
+            else
+                inspect_object(ctx, v.as.object, depth);
+            break;
+        case CDO_FUNCTION:
+            inspect_push_cstr(ctx, "<function>"); break;
+        case CDO_NATIVE:
+            inspect_push_cstr(ctx, "<native>"); break;
+    }
+}
+
+int cando_native_inspect(CandoVM *vm, int argc, CandoValue *args)
+{
+    InspectCtx ctx = {0};
+    if (argc >= 2 && cando_is_number(args[1])) {
+        int d = (int)args[1].as.number;
+        ctx.max_depth = (d > 0) ? d : 0;
+    }
+
+    if (argc < 1) {
+        inspect_push(&ctx, "null", 4);
+    } else {
+        CandoValue v = args[0];
+        switch ((TypeTag)v.tag) {
+            case TYPE_NULL:
+                inspect_push(&ctx, "null", 4); break;
+            case TYPE_BOOL:
+                inspect_push_cstr(&ctx, v.as.boolean ? "true" : "false"); break;
+            case TYPE_NUMBER:
+                inspect_write_number(&ctx, v.as.number); break;
+            case TYPE_STRING:
+                inspect_write_quoted(&ctx, v.as.string->data,
+                                           v.as.string->length);
+                break;
+            case TYPE_OBJECT: {
+                CdoObject *obj = cando_bridge_resolve(vm, v.as.handle);
+                if (!obj) {
+                    inspect_push(&ctx, "null", 4);
+                } else if (obj->kind == OBJ_ARRAY) {
+                    inspect_array(&ctx, obj, 0);
+                } else if (obj->kind == OBJ_FUNCTION) {
+                    inspect_push_cstr(&ctx, "<function>");
+                } else if (obj->kind == OBJ_NATIVE) {
+                    inspect_push_cstr(&ctx, "<native>");
+                } else if (obj->kind == OBJ_THREAD) {
+                    inspect_push_cstr(&ctx, "<thread>");
+                } else {
+                    inspect_object(&ctx, obj, 0);
+                }
+                break;
+            }
+        }
+    }
+
+    if (ctx.oom) {
+        free(ctx.buf);
+        free(ctx.path);
+        cando_vm_error(vm, "inspect: out of memory");
+        return -1;
+    }
+
+    CandoString *s = cando_string_new(ctx.buf ? ctx.buf : "", ctx.len);
+    free(ctx.buf);
+    free(ctx.path);
+    cando_vm_push(vm, cando_string_value(s));
     return 1;
 }

--- a/source/natives.h
+++ b/source/natives.h
@@ -2,7 +2,7 @@
  * natives.h -- Native function interface for the Cando interpreter.
  *
  * Native functions are registered as global variables with negative number
- * sentinel values: print=-1.0, type=-2.0, toString=-3.0.
+ * sentinel values: print=-1.0, type=-2.0, toString=-3.0, inspect=-4.0.
  * IS_NATIVE_FN and NATIVE_INDEX macros identify and dispatch them.
  *
  * Must compile with gcc -std=c11.
@@ -26,6 +26,11 @@ int cando_native_type(CandoVM *vm, int argc, CandoValue *args);
 
 /* toString(val) -- push string representation of val; returns 1. */
 int cando_native_tostring(CandoVM *vm, int argc, CandoValue *args);
+
+/* inspect(val, depth*) -- push a debug string showing array/object contents;
+ * cycle-safe.  depth = 0 (default) means unlimited; depth > 0 truncates
+ * nested arrays/objects beyond that level.  Returns 1. */
+int cando_native_inspect(CandoVM *vm, int argc, CandoValue *args);
 
 /* Dispatch table indexed by NATIVE_INDEX.
  * Sized to CANDO_NATIVE_MAX; unused trailing slots are NULL.

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -130,6 +130,9 @@ run_test "metamethods" "$SCRIPTS/metamethods.cdo" \
 run_test "lib_object" "$SCRIPTS/lib_object.cdo" \
     "$(printf '1\n99\n2\n1\n2\n3\n10\n99\n30\n20\nalice\nbob\nhello\nc\na\nb\n3\n1\n2\nfalse\ntrue\nfalse')"
 
+run_test "inspect" "$SCRIPTS/inspect.cdo" \
+    "$(printf 'null\ntrue\nfalse\n0\n42\n-7\n"hi"\n"a\\nb"\n[]\n[1, 2, 3]\n[1, "two", null]\n{}\n{ a: 1 }\n{ a: 1, b: 2 }\n{ "with space": 1 }\n{ list: [1, 2, [3, 4]] }\n{ a: { b: { c: 1 } } }\n{ a: {...} }\n{ a: { b: {...} } }\n{ a: { b: { c: 1 } } }\n[[...]]\n[[[...]]]\n[1, <circular>]\n{ x: 1, self: <circular> }\n[[9], [9]]')"
+
 run_test "lib_meta" "$SCRIPTS/lib_meta.cdo" \
     "$(printf 'object\nhttp_response\nhttp_request\nhttp_server\nhttp_client_response\nobject\nobject\nobject\nthread\nHI!\nYES!\n10\n42\ntrue\ndone\nobject\ngreeter\nhi, world')"
 

--- a/tests/scripts/inspect.cdo
+++ b/tests/scripts/inspect.cdo
@@ -1,0 +1,62 @@
+/* inspect.cdo -- Integration tests for the inspect built-in.
+ *
+ * Each test prints a labelled result to stdout.  Expected output is
+ * registered in tests/integration/run_tests.sh.
+ */
+
+/* ----- primitives -------------------------------------------------------- */
+print(inspect(null));        /* expected: null  */
+print(inspect(true));        /* expected: true  */
+print(inspect(false));       /* expected: false */
+print(inspect(0));           /* expected: 0     */
+print(inspect(42));          /* expected: 42    */
+print(inspect(-7));          /* expected: -7    */
+print(inspect("hi"));        /* expected: "hi"  */
+
+/* ----- string escapes ---------------------------------------------------- */
+var nl = `a
+b`;
+print(inspect(nl));          /* expected: "a\nb"           */
+
+/* ----- arrays ------------------------------------------------------------ */
+print(inspect([]));               /* expected: []                 */
+print(inspect([1, 2, 3]));        /* expected: [1, 2, 3]          */
+print(inspect([1, "two", null])); /* expected: [1, "two", null]   */
+
+/* ----- objects ----------------------------------------------------------- */
+print(inspect({}));               /* expected: {}                          */
+print(inspect({a: 1}));           /* expected: { a: 1 }                    */
+print(inspect({a: 1, b: 2}));     /* expected: { a: 1, b: 2 }              */
+
+/* non-identifier keys must be quoted */
+var o = {};
+o["with space"] = 1;
+print(inspect(o));                /* expected: { "with space": 1 }         */
+
+/* ----- nesting ----------------------------------------------------------- */
+print(inspect({list: [1, 2, [3, 4]]}));
+/* expected: { list: [1, 2, [3, 4]] } */
+
+/* ----- depth limit ------------------------------------------------------- */
+var deep = {a: {b: {c: 1}}};
+print(inspect(deep));     /* expected: { a: { b: { c: 1 } } }   (unlimited) */
+print(inspect(deep, 1));  /* expected: { a: {...} }                          */
+print(inspect(deep, 2));  /* expected: { a: { b: {...} } }                   */
+print(inspect(deep, 3));  /* expected: { a: { b: { c: 1 } } }                */
+
+var deepa = [[[1]]];
+print(inspect(deepa, 1)); /* expected: [[...]]                               */
+print(inspect(deepa, 2)); /* expected: [[[...]]]                             */
+
+/* ----- cycles ------------------------------------------------------------ */
+var ca = [1];
+ca:push(ca);
+print(inspect(ca));               /* expected: [1, <circular>]             */
+
+var co = {x: 1};
+co.self = co;
+print(inspect(co));               /* expected: { x: 1, self: <circular> }  */
+
+/* shared, non-circular references should NOT be reported as cycles */
+var shared = [9];
+print(inspect([shared, shared])); /* expected: [[9], [9]]                  */


### PR DESCRIPTION
## Summary

This PR adds a new `inspect()` built-in function to the Cando standard library that provides debug-friendly string representations of values, particularly arrays and objects. Unlike `toString()`, `inspect()` shows the actual contents of composite data structures rather than their handle IDs.

## Key Changes

- **New native function `cando_native_inspect()`** in `source/natives.c`:
  - Recursively inspects and formats arrays, objects, and primitive values
  - Supports optional `depth` parameter to limit nesting levels (0 = unlimited, N > 0 = truncate beyond level N)
  - Detects and handles circular references by tracking visited objects on a path stack
  - Properly escapes strings with support for `\\`, `\"`, `\n`, `\r`, `\t`, and `\xNN` escape sequences
  - Intelligently quotes object keys only when they're not valid C-style identifiers

- **Helper infrastructure**:
  - `InspectCtx` structure to manage buffer allocation, cycle detection, and depth tracking
  - Buffer management functions (`inspect_buf_reserve`, `inspect_push*`) with out-of-memory handling
  - Path stack for cycle detection (`inspect_path_contains`, `inspect_path_push`, `inspect_path_pop`)
  - Specialized formatting functions for arrays, objects, numbers, and quoted strings

- **Registration**:
  - Added to native function table with sentinel value `-4.0`
  - Registered in `cando_native_names` array
  - Updated `source/natives.h` with function declaration and documentation

- **Documentation**:
  - Comprehensive documentation in `docs/standard-library.md` with examples and formatting table
  - Explains depth limiting, cycle detection, and differences from `toString()`

- **Tests**:
  - New integration test file `tests/scripts/inspect.cdo` covering:
    - Primitives (null, booleans, numbers, strings)
    - String escape sequences
    - Arrays and objects (empty, nested, with various key types)
    - Depth limiting behavior
    - Circular reference detection
    - Shared (non-circular) references

## Notable Implementation Details

- Uses dynamic buffer allocation with exponential growth strategy for efficiency
- Cycle detection uses a separate path stack rather than marking objects, avoiding side effects
- Distinguishes between `CDO_OBJECT` and `CDO_ARRAY` tags while also checking object kind for safety
- Handles out-of-memory conditions gracefully with proper cleanup
- Number formatting uses `PRId64` format specifier for portability
- Added necessary includes: `<ctype.h>`, `<inttypes.h>`, `<stdlib.h>`

https://claude.ai/code/session_019Ccrc4SPqHGKc9p4M2sHVi