### PR TITLE
Add backtick template string interpolation support

### DIFF
--- a/source/parser/parser.c
+++ b/source/parser/parser.c
@@ -275,9 +275,130 @@ static void parse_number(CandoParser *p, bool can_assign)
     emit_op_a(p, OP_CONST, idx);
 }
 
+/* Compile a backtick template string `lit${expr}lit...` as a chain of
+ * concatenations. Each ${expr} is wrapped in toString(...) so non-string
+ * values (numbers, bools, ...) interpolate correctly via the OP_ADD string-
+ * concat path. The lexer has already validated brace balance for the whole
+ * token; we re-walk the body here to split segments and re-lex each
+ * expression substring with a sub-lexer. */
+static void parse_template_string(CandoParser *p)
+{
+    const char *body  = p->previous.start + 1;
+    u32         total = p->previous.length >= 2 ? p->previous.length - 2 : 0;
+    u32         start_line = p->previous.line;
+
+    bool emitted = false;  /* true once we've pushed something on the stack */
+    u32  i = 0;
+
+    while (i < total) {
+        /* Scan literal segment up to the next "${" or end. */
+        u32 lit_start = i;
+        while (i < total) {
+            char c = body[i];
+            if (c == '\\' && i + 1 < total) { i += 2; continue; }
+            if (c == '$' && i + 1 < total && body[i + 1] == '{') break;
+            i++;
+        }
+        u32 lit_len = i - lit_start;
+        if (lit_len > 0) {
+            u16 idx = str_const(p, body + lit_start, lit_len);
+            emit_op_a(p, OP_CONST, idx);
+            if (emitted) emit_op(p, OP_ADD);
+            emitted = true;
+        }
+        if (i >= total) break;
+
+        /* Found "${": find the matching '}'. */
+        i += 2;
+        u32 expr_start = i;
+        int depth = 1;
+        while (i < total) {
+            char c = body[i];
+            if (c == '\\' && i + 1 < total) { i += 2; continue; }
+            if      (c == '{') depth++;
+            else if (c == '}') { depth--; if (depth == 0) break; }
+            i++;
+        }
+        u32 expr_len = i - expr_start;
+        if (i < total && body[i] == '}') i++;  /* consume closing '}' */
+
+        /* Emit toString(<expr>) — load the global, parse the expression,
+         * then OP_CALL with one argument. */
+        u16 fn_idx = str_const(p, "toString", 8);
+        emit_op_a(p, OP_LOAD_GLOBAL, fn_idx);
+
+        /* Trim leading whitespace so an empty `${ }` is detected cleanly. */
+        u32 trim_start = expr_start, trim_end = expr_start + expr_len;
+        while (trim_start < trim_end &&
+               (body[trim_start] == ' '  || body[trim_start] == '\t' ||
+                body[trim_start] == '\n' || body[trim_start] == '\r'))
+            trim_start++;
+
+        if (trim_start >= trim_end) {
+            /* Empty interpolation: pass an empty string so toString(...) is
+             * still well-formed. */
+            u16 empty_idx = str_const(p, "", 0);
+            emit_op_a(p, OP_CONST, empty_idx);
+        } else {
+            /* Save outer parser state, swap in a sub-lexer over the
+             * expression substring, parse, then restore.                  */
+            CandoLexer saved_lexer    = p->lexer;
+            CandoToken saved_current  = p->current;
+            CandoToken saved_previous = p->previous;
+            bool       saved_panic    = p->panic_mode;
+            u32        saved_call_d   = p->call_depth;
+            bool       saved_was_call = p->last_expr_was_call;
+            bool       saved_was_unp  = p->last_expr_was_unpack;
+            u32        saved_mpush    = p->last_multi_push;
+
+            cando_lexer_init(&p->lexer, body + expr_start, expr_len);
+            p->lexer.line = start_line;
+            p->panic_mode = false;
+            p->call_depth = 0;
+            p->last_expr_was_call   = false;
+            p->last_expr_was_unpack = false;
+            p->last_multi_push      = 1;
+
+            advance(p);  /* prime current with first token of the sub-expr */
+            parse_expression(p);
+            /* If the inner expression was itself a call, spread its return
+             * values into our toString argument list so the static argc=1
+             * gets adjusted at runtime to the actual count.               */
+            if (p->last_expr_was_call) emit_op(p, OP_SPREAD_RET);
+
+            p->lexer    = saved_lexer;
+            p->current  = saved_current;
+            p->previous = saved_previous;
+            p->panic_mode           = saved_panic;
+            p->call_depth           = saved_call_d;
+            p->last_expr_was_call   = saved_was_call;
+            p->last_expr_was_unpack = saved_was_unp;
+            p->last_multi_push      = saved_mpush;
+        }
+
+        emit_op_a(p, OP_CALL, 1);
+        if (emitted) emit_op(p, OP_ADD);
+        emitted = true;
+    }
+
+    if (!emitted) {
+        u16 idx = str_const(p, "", 0);
+        emit_op_a(p, OP_CONST, idx);
+    }
+
+    /* The result is a single string value. */
+    p->last_expr_was_call   = false;
+    p->last_expr_was_unpack = false;
+    p->last_multi_push      = 1;
+}
+
 static void parse_string_literal(CandoParser *p, bool can_assign)
 {
     (void)can_assign;
+    if (p->previous.type == TOK_STRING_BT) {
+        parse_template_string(p);
+        return;
+    }
     const char *s   = p->previous.start + 1;
     u32         len = p->previous.length >= 2 ? p->previous.length - 2 : 0;
     u16 idx = str_const(p, s, len);

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -85,6 +85,9 @@ run_test "inline_functions" "$SCRIPTS/inline_functions.cdo" \
 run_test "strings" "$SCRIPTS/strings.cdo" \
     "$(printf 'hello world\n5\nstring\nnumber\nbool\nnull\n42\n3.1400000000000001\ntrue\ntrue\nfalse\ntrue\n5\nworld\nhello world\nHELLO WORLD\nhi\nabc\ndef\nababab\n6\na\nb\nc\ncount: 99')"
 
+run_test "template_strings" "$SCRIPTS/template_strings.cdo" \
+    "$(printf 'hello\nhi world!\nworld\n3 = three\na42b43c\nbool=true null=null\nprepost\nauth=user:pass')"
+
 run_test "arrays" "$SCRIPTS/arrays.cdo" \
     "$(printf '3\n10\n20\n30\n99\n15\n1\n2\n3\n4\n0\n1\n4\n9\n15')"
 

--- a/tests/scripts/template_strings.cdo
+++ b/tests/scripts/template_strings.cdo
@@ -1,0 +1,28 @@
+/* template_strings.cdo -- backtick template string interpolation */
+
+VAR name = "world";
+VAR n    = 42;
+
+/* Plain backtick (no interpolation) behaves like a string literal. */
+print(`hello`);
+
+/* Single ${expr} between literal segments. */
+print(`hi ${name}!`);
+
+/* Pure interpolation, no surrounding literal. */
+print(`${name}`);
+
+/* Multiple interpolations and arithmetic inside ${...}. */
+print(`${1 + 2} = three`);
+print(`a${n}b${n + 1}c`);
+
+/* Non-string values are coerced via toString(). */
+print(`bool=${TRUE} null=${NULL}`);
+
+/* Empty interpolation segment ${} renders as empty. */
+print(`pre${}post`);
+
+/* Nested templates: a backtick string inside ${...}. */
+VAR u = "user";
+VAR p = "pass";
+print(`auth=${`${u}:${p}`}`);

--- a/tests/test_lexer.c
+++ b/tests/test_lexer.c
@@ -387,6 +387,16 @@ TEST(test_string_backtick_nested_braces)
     EXPECT_EQ(tok.type, TOK_STRING_BT);
 }
 
+TEST(test_string_backtick_nested_template)
+{
+    /* A backtick string inside ${ } — the inner backticks must round-trip
+     * out as a single TOK_STRING_BT so the whole outer token covers both. */
+    const char *src = "`Bearer ${enc(`${u}:${p}`)}`";
+    CandoToken tok = lex_nth(src, 0);
+    EXPECT_EQ(tok.type, TOK_STRING_BT);
+    EXPECT_EQ(tok.length, (u32)strlen(src));
+}
+
 TEST(test_string_unterminated_dq)
 {
     CandoLexer lex;
@@ -715,6 +725,7 @@ int main(void)
     run_test("single-quoted string",      test_string_single_quote);
     run_test("backtick string",           test_string_backtick);
     run_test("backtick nested braces",    test_string_backtick_nested_braces);
+    run_test("backtick nested template",  test_string_backtick_nested_template);
     run_test("unterminated double-quote", test_string_unterminated_dq);
     run_test("unterminated single-quote", test_string_unterminated_sq);
     run_test("unterminated backtick",     test_string_unterminated_bt);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -129,6 +129,14 @@ static bool const_is_string(const CandoChunk *c, u32 idx, const char *expected)
            memcmp(s->data, expected, s->length) == 0;
 }
 
+/* True if any string constant in the chunk equals expected. */
+static bool has_string_const(const CandoChunk *c, const char *expected)
+{
+    for (u32 i = 0; i < c->const_count; i++)
+        if (const_is_string(c, i, expected)) return true;
+    return false;
+}
+
 /* -------------------------------------------------------------------------
  * Tests: chunk management
  * ------------------------------------------------------------------------ */
@@ -257,6 +265,130 @@ TEST(test_string_literal)
     CandoChunk *c = compile_ok("\"hello\";");
     EXPECT_EQ(c->code[0], (u8)OP_CONST);
     EXPECT_TRUE(const_is_string(c, 0, "hello"));
+    cando_chunk_free(c);
+}
+
+/* -------------------------------------------------------------------------
+ * Tests: backtick template strings -- `lit${expr}lit`
+ *
+ * Each ${expr} compiles to toString(expr) and concatenates with adjacent
+ * literal segments via OP_ADD.  The bare backtick form (no ${...}) emits
+ * a single OP_CONST with the literal body.
+ * ------------------------------------------------------------------------ */
+TEST(test_template_string_no_interpolation)
+{
+    /* "`hello`;" should behave like a plain string literal.               */
+    CandoChunk *c = compile_ok("`hello`;");
+    EXPECT_EQ(c->code[0], (u8)OP_CONST);
+    EXPECT_TRUE(has_string_const(c, "hello"));
+    /* No concatenation, no toString lookup. */
+    EXPECT_EQ(count_op(c, OP_ADD), 0);
+    EXPECT_FALSE(has_string_const(c, "toString"));
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_empty)
+{
+    /* "``;" should still emit something so the expression statement has
+     * a value to OP_POP.                                                  */
+    CandoChunk *c = compile_ok("``;");
+    EXPECT_EQ(c->code[0], (u8)OP_CONST);
+    EXPECT_TRUE(has_string_const(c, ""));
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_single_interp)
+{
+    /* "`hi ${name}`;" should:
+     *   - emit "hi " as a literal segment
+     *   - load global toString
+     *   - load global name
+     *   - OP_CALL with arity 1
+     *   - OP_ADD to concat literal + result                               */
+    CandoChunk *c = compile_ok("`hi ${name}`;");
+    EXPECT_TRUE(has_string_const(c, "hi "));
+    EXPECT_TRUE(has_string_const(c, "toString"));
+    EXPECT_TRUE(has_string_const(c, "name"));
+    EXPECT_EQ(count_op(c, OP_CALL), 1);
+    EXPECT_EQ(count_op(c, OP_ADD), 1);
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_only_interp)
+{
+    /* "`${42}`;" has no surrounding literal — only the toString call.    */
+    CandoChunk *c = compile_ok("`${42}`;");
+    EXPECT_TRUE(has_string_const(c, "toString"));
+    /* No surrounding literal means no concatenation. */
+    EXPECT_EQ(count_op(c, OP_ADD), 0);
+    EXPECT_EQ(count_op(c, OP_CALL), 1);
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_multiple_interps)
+{
+    /* "`a${x}b${y}c`;" produces 3 literal segments and 2 interpolations.
+     * Concatenation order with OP_ADD merges left-to-right, yielding
+     * 4 OP_ADDs (lit+toStr(x), then +lit, +toStr(y), +lit).              */
+    CandoChunk *c = compile_ok("`a${x}b${y}c`;");
+    EXPECT_TRUE(has_string_const(c, "a"));
+    EXPECT_TRUE(has_string_const(c, "b"));
+    EXPECT_TRUE(has_string_const(c, "c"));
+    EXPECT_TRUE(has_string_const(c, "x"));
+    EXPECT_TRUE(has_string_const(c, "y"));
+    EXPECT_TRUE(has_string_const(c, "toString"));
+    EXPECT_EQ(count_op(c, OP_CALL), 2);
+    EXPECT_EQ(count_op(c, OP_ADD), 4);
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_with_expression)
+{
+    /* "`sum=${1+2}`;" — interpolated expression with its own OP_ADD.
+     * Two OP_ADDs total: one inside ${...} (for 1+2) and one to
+     * concat the literal "sum=" with the result.                         */
+    CandoChunk *c = compile_ok("`sum=${1+2}`;");
+    EXPECT_TRUE(has_string_const(c, "sum="));
+    EXPECT_TRUE(has_string_const(c, "toString"));
+    EXPECT_TRUE(const_is_number(c, 0, 1.0) || const_is_number(c, 1, 1.0) ||
+                const_is_number(c, 2, 1.0) || const_is_number(c, 3, 1.0));
+    EXPECT_EQ(count_op(c, OP_CALL), 1);
+    EXPECT_EQ(count_op(c, OP_ADD), 2);
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_nested)
+{
+    /* "`outer ${ `inner ${x}` }`;" — a template inside a template.       */
+    CandoChunk *c = compile_ok("`outer ${ `inner ${x}` }`;");
+    EXPECT_TRUE(has_string_const(c, "outer "));
+    EXPECT_TRUE(has_string_const(c, "inner "));
+    EXPECT_TRUE(has_string_const(c, "x"));
+    /* Outer toString + inner toString = 2 calls. */
+    EXPECT_EQ(count_op(c, OP_CALL), 2);
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_method_call_inside)
+{
+    /* "`auth=${obj.name}`;" — method/field access inside ${...}.         */
+    CandoChunk *c = compile_ok("`auth=${obj.name}`;");
+    EXPECT_TRUE(has_string_const(c, "auth="));
+    EXPECT_TRUE(has_string_const(c, "toString"));
+    EXPECT_TRUE(has_string_const(c, "obj"));
+    EXPECT_TRUE(has_string_const(c, "name"));
+    EXPECT_TRUE(find_op(c, OP_GET_FIELD) >= 0);
+    cando_chunk_free(c);
+}
+
+TEST(test_template_string_empty_interp)
+{
+    /* "`pre ${} post`;" — interpolation with no expression should emit
+     * an empty string for that segment instead of erroring.              */
+    CandoChunk *c = compile_ok("`pre ${} post`;");
+    EXPECT_TRUE(has_string_const(c, "pre "));
+    EXPECT_TRUE(has_string_const(c, " post"));
+    EXPECT_TRUE(has_string_const(c, "toString"));
     cando_chunk_free(c);
 }
 
@@ -901,6 +1033,17 @@ int main(void)
     run_test("null literal",                   test_null_literal);
     run_test("true/false literals",            test_true_false_literals);
     run_test("string literal",                 test_string_literal);
+
+    printf("\n-- template strings --\n");
+    run_test("backtick: no interpolation",     test_template_string_no_interpolation);
+    run_test("backtick: empty",                test_template_string_empty);
+    run_test("backtick: single ${name}",       test_template_string_single_interp);
+    run_test("backtick: only ${expr}",         test_template_string_only_interp);
+    run_test("backtick: multiple interps",     test_template_string_multiple_interps);
+    run_test("backtick: ${1+2} expression",    test_template_string_with_expression);
+    run_test("backtick: nested templates",     test_template_string_nested);
+    run_test("backtick: ${obj.name}",          test_template_string_method_call_inside);
+    run_test("backtick: empty ${} segment",    test_template_string_empty_interp);
 
     printf("\n-- arithmetic --\n");
     run_test("addition",                       test_addition);


### PR DESCRIPTION
## Summary
Implement backtick template string syntax with `${expr}` interpolation support in the Cando language. Template strings allow embedding expressions within backtick-delimited strings, with automatic `toString()` conversion for non-string values.

## Key Changes

**Parser Implementation (`source/parser/parser.c`)**
- Added `parse_template_string()` function to handle backtick template string compilation
- Parses template body to identify literal segments and `${expr}` interpolations
- Each interpolation is wrapped in a `toString()` call to coerce non-string values
- Uses a sub-lexer to parse expressions within `${}` blocks while preserving outer parser state
- Chains literal segments and interpolation results using `OP_ADD` for concatenation
- Handles edge cases: empty interpolations, nested templates, expressions with operators
- Integrated into `parse_string_literal()` to dispatch on `TOK_STRING_BT` token type

**Test Coverage (`tests/test_parser.c` and `tests/test_lexer.c`)**
- Added helper function `has_string_const()` to check for string constants in compiled chunks
- Comprehensive parser tests covering:
  - Plain backticks without interpolation
  - Empty template strings
  - Single and multiple interpolations
  - Expressions with operators inside `${}`
  - Nested template strings
  - Method/field access in interpolations
  - Empty interpolation segments `${}`
- Lexer test for nested template strings within `${}` blocks
- Integration test script (`tests/scripts/template_strings.cdo`) demonstrating real-world usage

## Implementation Details

- Template strings compile to a series of `OP_CONST` (for literals) and `OP_CALL` (for `toString()`) operations chained with `OP_ADD`
- Sub-lexer approach allows full expression parsing within `${}` while maintaining correct line tracking
- Handles brace nesting depth to correctly identify interpolation boundaries
- Preserves parser state (panic mode, call depth, multi-return tracking) across sub-lexer invocations
- Empty interpolations `${}` emit an empty string constant to maintain valid `toString()` call structure
- Spread return values from nested calls to ensure correct argument count at runtime

https://claude.ai/code/session_0182FQLyNZuWNBUzFKXiuX3h