### PR TITLE
Implement pretty-printing for inspect() with multi-line formatting

### DIFF
--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -206,17 +206,35 @@ static void set_obj_field(CdoObject *obj, const char *name, CdoObject *child)
     cdo_string_release(key);
 }
 
-/* Iterate headers from a CdoObject (user-supplied {"Name": "Value", ...}). */
+/* Iterate headers from a CdoObject (user-supplied {"Name": "Value", ...}).
+ *
+ * Non-string values (numbers, bools, null) are coerced via cdo_value_tostring
+ * so callers can write `{ "X-Count": 42 }` without the field silently dropping.
+ * Internal keys prefixed with `__` are skipped so meta-method machinery does
+ * not bleed into the wire request. */
 typedef struct { HttpBuf *buf; } HeaderAppendUD;
 
 static bool append_header_iter(CdoString *key, CdoValue *val, u8 flags, void *ud)
 {
     (void)flags;
     HeaderAppendUD *a = (HeaderAppendUD *)ud;
-    if (val->tag != CDO_STRING) return true;
+
+    if (key->length == 0) return true;
+    if (key->length >= 2 && key->data[0] == '_' && key->data[1] == '_')
+        return true;
+    if (val->tag == CDO_NULL) return true;
+
     httpbuf_append(a->buf, key->data, key->length);
     httpbuf_append_cstr(a->buf, ": ");
-    httpbuf_append(a->buf, val->as.string->data, val->as.string->length);
+    if (val->tag == CDO_STRING && val->as.string) {
+        httpbuf_append(a->buf, val->as.string->data, val->as.string->length);
+    } else {
+        char *s = cdo_value_tostring(*val);
+        if (s) {
+            httpbuf_append_cstr(a->buf, s);
+            free(s);
+        }
+    }
     httpbuf_append_cstr(a->buf, "\r\n");
     return true;
 }

--- a/source/natives.c
+++ b/source/natives.c
@@ -160,6 +160,10 @@ int cando_native_tostring(CandoVM *vm, int argc, CandoValue *args)
  *  depth = 0 (default) means unlimited recursion; cycles are always
  *  short-circuited with `<circular>`.  depth = N > 0 truncates nested
  *  arrays / objects beyond that level to `[...]` / `{...}`.
+ *
+ * Output is pretty-printed: empty containers render as `[]` / `{}`, while
+ * non-empty ones break across lines with 2-space indentation per nesting
+ * level.  Truncation markers and circular references stay compact.
  * ===================================================================== */
 
 typedef struct {
@@ -277,6 +281,14 @@ static void inspect_write_number(InspectCtx *ctx, f64 n)
     if (m > 0) inspect_push(ctx, buf, (u32)m);
 }
 
+/* Indentation step is fixed at 2 spaces.  `depth` here counts levels of
+ * nesting, not the user-facing max_depth limit. */
+static void inspect_indent(InspectCtx *ctx, int depth)
+{
+    for (int i = 0; i < depth; i++)
+        inspect_push(ctx, "  ", 2);
+}
+
 static void inspect_cdo(InspectCtx *ctx, CdoValue v, int depth);
 
 static void inspect_array(InspectCtx *ctx, CdoObject *arr, int depth)
@@ -289,17 +301,24 @@ static void inspect_array(InspectCtx *ctx, CdoObject *arr, int depth)
         inspect_push_cstr(ctx, "[...]");
         return;
     }
+    u32 n = cdo_array_len(arr);
+    if (n == 0) {
+        inspect_push(ctx, "[]", 2);
+        return;
+    }
     if (!inspect_path_push(ctx, arr)) return;
 
-    inspect_push_char(ctx, '[');
-    u32 n = cdo_array_len(arr);
+    inspect_push(ctx, "[\n", 2);
     for (u32 i = 0; i < n; i++) {
-        if (i > 0) inspect_push(ctx, ", ", 2);
+        if (i > 0) inspect_push(ctx, ",\n", 2);
+        inspect_indent(ctx, depth + 1);
         CdoValue elem = cdo_null();
         cdo_array_rawget_idx(arr, i, &elem);
         inspect_cdo(ctx, elem, depth + 1);
         if (ctx->oom) break;
     }
+    inspect_push_char(ctx, '\n');
+    inspect_indent(ctx, depth);
     inspect_push_char(ctx, ']');
 
     inspect_path_pop(ctx);
@@ -314,8 +333,10 @@ static bool inspect_field_cb(CdoString *key, CdoValue *val, u8 flags, void *ud)
     InspectCtx  *ctx = it->ctx;
     if (ctx->oom) return false;
 
-    if (!it->first) inspect_push(ctx, ", ", 2);
+    if (!it->first) inspect_push(ctx, ",\n", 2);
     it->first = false;
+
+    inspect_indent(ctx, it->depth + 1);
 
     if (inspect_key_is_ident(key->data, key->length))
         inspect_push(ctx, key->data, key->length);
@@ -325,6 +346,16 @@ static bool inspect_field_cb(CdoString *key, CdoValue *val, u8 flags, void *ud)
     inspect_push(ctx, ": ", 2);
     inspect_cdo(ctx, *val, it->depth + 1);
     return !ctx->oom;
+}
+
+/* Probe to decide whether an object is empty without performing the recursive
+ * write — needed because cdo_object_foreach has no length accessor that
+ * cleanly maps to the iteration order used elsewhere. */
+static bool obj_first_cb(CdoString *k, CdoValue *v, u8 f, void *ud)
+{
+    (void)k; (void)v; (void)f;
+    *(bool *)ud = false;
+    return false;
 }
 
 static void inspect_object(InspectCtx *ctx, CdoObject *obj, int depth)
@@ -337,15 +368,21 @@ static void inspect_object(InspectCtx *ctx, CdoObject *obj, int depth)
         inspect_push_cstr(ctx, "{...}");
         return;
     }
+
+    bool empty = true;
+    cdo_object_foreach(obj, obj_first_cb, &empty);
+    if (empty) {
+        inspect_push(ctx, "{}", 2);
+        return;
+    }
+
     if (!inspect_path_push(ctx, obj)) return;
 
     InspectIter it = { .ctx = ctx, .depth = depth, .first = true };
-    inspect_push(ctx, "{ ", 2);
+    inspect_push(ctx, "{\n", 2);
     cdo_object_foreach(obj, inspect_field_cb, &it);
-    if (it.first)
-        ctx->len--;          /* drop the trailing space for empty `{ }` */
-    else
-        inspect_push_char(ctx, ' ');
+    inspect_push_char(ctx, '\n');
+    inspect_indent(ctx, depth);
     inspect_push_char(ctx, '}');
 
     inspect_path_pop(ctx);

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -134,7 +134,7 @@ run_test "lib_object" "$SCRIPTS/lib_object.cdo" \
     "$(printf '1\n99\n2\n1\n2\n3\n10\n99\n30\n20\nalice\nbob\nhello\nc\na\nb\n3\n1\n2\nfalse\ntrue\nfalse')"
 
 run_test "inspect" "$SCRIPTS/inspect.cdo" \
-    "$(printf 'null\ntrue\nfalse\n0\n42\n-7\n"hi"\n"a\\nb"\n[]\n[1, 2, 3]\n[1, "two", null]\n{}\n{ a: 1 }\n{ a: 1, b: 2 }\n{ "with space": 1 }\n{ list: [1, 2, [3, 4]] }\n{ a: { b: { c: 1 } } }\n{ a: {...} }\n{ a: { b: {...} } }\n{ a: { b: { c: 1 } } }\n[[...]]\n[[[...]]]\n[1, <circular>]\n{ x: 1, self: <circular> }\n[[9], [9]]')"
+    "$(printf 'null\ntrue\nfalse\n0\n42\n-7\n"hi"\n"a\\nb"\n[]\n[\n  1,\n  2,\n  3\n]\n[\n  1,\n  "two",\n  null\n]\n{}\n{\n  a: 1\n}\n{\n  a: 1,\n  b: 2\n}\n{\n  "with space": 1\n}\n{\n  list: [\n    1,\n    2,\n    [\n      3,\n      4\n    ]\n  ]\n}\n{\n  a: {\n    b: {\n      c: 1\n    }\n  }\n}\n{\n  a: {...}\n}\n{\n  a: {\n    b: {...}\n  }\n}\n{\n  a: {\n    b: {\n      c: 1\n    }\n  }\n}\n[\n  [...]\n]\n[\n  [\n    [...]\n  ]\n]\n[\n  1,\n  <circular>\n]\n{\n  x: 1,\n  self: <circular>\n}\n[\n  [\n    9\n  ],\n  [\n    9\n  ]\n]')"
 
 run_test "lib_meta" "$SCRIPTS/lib_meta.cdo" \
     "$(printf 'object\nhttp_response\nhttp_request\nhttp_server\nhttp_client_response\nobject\nobject\nobject\nthread\nHI!\nYES!\n10\n42\ntrue\ndone\nobject\ngreeter\nhi, world')"

--- a/tests/scripts/inspect.cdo
+++ b/tests/scripts/inspect.cdo
@@ -1,62 +1,62 @@
 /* inspect.cdo -- Integration tests for the inspect built-in.
  *
- * Each test prints a labelled result to stdout.  Expected output is
- * registered in tests/integration/run_tests.sh.
+ * Containers are rendered with multi-line indentation; primitives, empty
+ * containers, depth-truncation markers, and circular references stay
+ * compact.  Expected output is registered in tests/integration/run_tests.sh.
  */
 
 /* ----- primitives -------------------------------------------------------- */
-print(inspect(null));        /* expected: null  */
-print(inspect(true));        /* expected: true  */
-print(inspect(false));       /* expected: false */
-print(inspect(0));           /* expected: 0     */
-print(inspect(42));          /* expected: 42    */
-print(inspect(-7));          /* expected: -7    */
-print(inspect("hi"));        /* expected: "hi"  */
+print(inspect(null));        /* null  */
+print(inspect(true));        /* true  */
+print(inspect(false));       /* false */
+print(inspect(0));           /* 0     */
+print(inspect(42));          /* 42    */
+print(inspect(-7));          /* -7    */
+print(inspect("hi"));        /* "hi"  */
 
 /* ----- string escapes ---------------------------------------------------- */
 var nl = `a
 b`;
-print(inspect(nl));          /* expected: "a\nb"           */
+print(inspect(nl));          /* "a\nb" */
 
 /* ----- arrays ------------------------------------------------------------ */
-print(inspect([]));               /* expected: []                 */
-print(inspect([1, 2, 3]));        /* expected: [1, 2, 3]          */
-print(inspect([1, "two", null])); /* expected: [1, "two", null]   */
+print(inspect([]));          /* []  */
+print(inspect([1, 2, 3]));   /* multi-line list */
+print(inspect([1, "two", null]));
 
 /* ----- objects ----------------------------------------------------------- */
-print(inspect({}));               /* expected: {}                          */
-print(inspect({a: 1}));           /* expected: { a: 1 }                    */
-print(inspect({a: 1, b: 2}));     /* expected: { a: 1, b: 2 }              */
+print(inspect({}));          /* {}  */
+print(inspect({a: 1}));      /* multi-line object */
+print(inspect({a: 1, b: 2}));
 
 /* non-identifier keys must be quoted */
 var o = {};
 o["with space"] = 1;
-print(inspect(o));                /* expected: { "with space": 1 }         */
+print(inspect(o));
 
 /* ----- nesting ----------------------------------------------------------- */
 print(inspect({list: [1, 2, [3, 4]]}));
-/* expected: { list: [1, 2, [3, 4]] } */
 
 /* ----- depth limit ------------------------------------------------------- */
 var deep = {a: {b: {c: 1}}};
-print(inspect(deep));     /* expected: { a: { b: { c: 1 } } }   (unlimited) */
-print(inspect(deep, 1));  /* expected: { a: {...} }                          */
-print(inspect(deep, 2));  /* expected: { a: { b: {...} } }                   */
-print(inspect(deep, 3));  /* expected: { a: { b: { c: 1 } } }                */
+print(inspect(deep));        /* unlimited */
+print(inspect(deep, 1));     /* { a: {...} }      */
+print(inspect(deep, 2));     /* { a: { b: {...} } } */
+print(inspect(deep, 3));     /* fully expanded    */
 
 var deepa = [[[1]]];
-print(inspect(deepa, 1)); /* expected: [[...]]                               */
-print(inspect(deepa, 2)); /* expected: [[[...]]]                             */
+print(inspect(deepa, 1));
+print(inspect(deepa, 2));
 
 /* ----- cycles ------------------------------------------------------------ */
 var ca = [1];
 ca:push(ca);
-print(inspect(ca));               /* expected: [1, <circular>]             */
+print(inspect(ca));
 
 var co = {x: 1};
 co.self = co;
-print(inspect(co));               /* expected: { x: 1, self: <circular> }  */
+print(inspect(co));
 
 /* shared, non-circular references should NOT be reported as cycles */
 var shared = [9];
-print(inspect([shared, shared])); /* expected: [[9], [9]]                  */
+print(inspect([shared, shared]));


### PR DESCRIPTION
## Summary
This PR implements pretty-printing for the `inspect()` built-in function, formatting containers (arrays and objects) across multiple lines with consistent 2-space indentation, while keeping primitives, empty containers, and special markers compact.

## Key Changes

**Core inspect() formatting (natives.c)**
- Added `inspect_indent()` helper function to emit indentation based on nesting depth
- Modified `inspect_array()` to:
  - Render empty arrays as compact `[]`
  - Format non-empty arrays with opening bracket followed by newline
  - Indent each element and separate with comma-newline
  - Close with newline and matching indentation
- Modified `inspect_object()` to:
  - Add `obj_first_cb()` probe function to detect empty objects without full iteration
  - Render empty objects as compact `{}`
  - Format non-empty objects with opening brace followed by newline
  - Indent each field and separate with comma-newline
  - Close with newline and matching indentation
- Updated documentation to describe the pretty-printing behavior

**HTTP header handling (lib/http.c)**
- Enhanced `append_header_iter()` to coerce non-string header values (numbers, bools) via `cdo_value_tostring()` instead of silently dropping them
- Added filtering for internal keys prefixed with `__` to prevent meta-method machinery from leaking into wire requests
- Added null value filtering and defensive null-pointer checks

**Test updates (inspect.cdo and run_tests.sh)**
- Updated test script comments to reflect new multi-line output format
- Updated expected output in integration tests to match the new pretty-printed format with proper indentation

## Implementation Details
- Indentation is fixed at 2 spaces per nesting level
- Truncation markers (`[...]`, `{...}`) and circular references (`<circular>`) remain compact on single lines
- Empty containers are always rendered compactly regardless of nesting depth
- The depth limit parameter continues to work as before, truncating nested structures beyond the specified level

https://claude.ai/code/session_013gadA25smWoHmHCfS56DUb