### PR TITLE
Add unified stream abstraction with in-memory and file adapters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(LIB_SRCS
     source/lib/http.c
     source/lib/https.c
     source/lib/meta.c
+    source/lib/stream.c
 )
 
 # Windows compatibility shim (POSIX regex replacement)

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ CANDO_LIB_SRCS = \
     source/lib/http.c             \
     source/lib/https.c            \
     source/lib/meta.c             \
+    source/lib/stream.c           \
     source/cando_lib.c
 
 # Windows compatibility shim added on Windows

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ compiled to bytecode for a stack-based VM.
 | [language-reference.md](language-reference.md) | Complete syntax: types, expressions, statements, functions, classes |
 | [standard-library.md](standard-library.md) | Every built-in library module, function-by-function |
 | [socket.md](socket.md) | Long-form guide to the `socket` and `secure_socket` libraries |
+| [streaming.md](streaming.md) | Unified `stream` API: pipe between files, sockets, HTTP, processes, threads |
 | [threading.md](threading.md) | `thread` / `await`, the `thread` library, shared state |
 
 ## For C embedders

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,10 +45,10 @@ source/
     vm.h/.c           CandoVM -- interpreter, call frames, threading
     debug.h/.c        cando_chunk_disasm
 
-  lib/                19 standard library modules
+  lib/                20 standard library modules
     math, file, string, array, object, json, csv,
     thread, os, datetime, crypto, process, net,
-    eval, include, http, https
+    eval, include, http, https, stream
     libutil.c/h       Internal helpers
 
   compat/

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -260,6 +260,7 @@ functions and currently may be `"utf8"` (default) or `"binary"`.
 | `file.lines(path, encoding*) → array` | Array of lines, without newline terminators. |
 | `file.mkdir(path) → bool` | Create a directory.  Non-recursive. |
 | `file.list(path) → array` | Array of directory entry names. |
+| `file.open(path, mode) → stream` | Open a file as a `stream` (modes: `r`/`w`/`a`, optional `b`/`+`).  See [streaming.md](streaming.md). |
 
 ---
 
@@ -329,6 +330,66 @@ proper `strptime` shim is available.
 |---|---|
 | `process.pid() → number` | Current process ID. |
 | `process.ppid() → number` | Parent process ID. |
+| `process.spawn(argv [, opts]) → proc` | Spawn a child process (POSIX only).  `opts.stdin` / `opts.stdout` / `opts.stderr` are `"inherit"` (default), `"pipe"`, or `"null"`.  `opts.cwd` sets the child's working directory. |
+
+### Methods on a spawned `proc`
+
+| Method | Description |
+|---|---|
+| `proc:pid() → number` | Child's process ID. |
+| `proc:stdin() → stream \| null` | Writable stream over the child's stdin (when opened with `pipe`). |
+| `proc:stdout() → stream \| null` | Readable stream over the child's stdout. |
+| `proc:stderr() → stream \| null` | Readable stream over the child's stderr. |
+| `proc:wait() → number` | Block until exit; returns the exit code (or `-signal` for signal termination). |
+| `proc:kill([sig]) → self` | Send a signal (default `SIGTERM`). |
+
+---
+
+## `stream`
+
+The `stream` library is a single byte-oriented I/O abstraction shared by
+files, sockets, HTTP bodies, subprocess pipes, in-memory buffers, and
+thread channels.  See [streaming.md](streaming.md) for the long-form
+guide.
+
+### Constructors
+
+| Function | Description |
+|---|---|
+| `stream.memory([initialBytes]) → stream` | Duplex in-memory buffer; auto-compacts as the reader drains. |
+| `stream.channel([capacity]) → stream` | Bounded thread channel; reads block while empty, writes block while full. |
+
+### Methods (`_meta.stream`)
+
+| Method | Description |
+|---|---|
+| `s:read(maxLen [, timeoutMs])` | Read up to `maxLen` bytes; `""` on clean EOF. |
+| `s:readAll()` | Drain to EOF and return everything. |
+| `s:write(data) → number` | Write; returns bytes consumed. |
+| `s:writeAll(data) → self` | Loop until all bytes are written. |
+| `s:flush() → self` | Adapter-defined.  No-op for memory/channel/socket. |
+| `s:end() → self` | Half-close the write side (signals EOF to readers). |
+| `s:close() → self` | Full close.  Idempotent. |
+| `s:pipeTo(dst [, opts]) → number` | Blocking copy to `dst`; returns total bytes copied. `opts.chunk` overrides the 64 KiB transfer block.  Wrap in `thread { … }` to run off-thread. |
+| `s:isClosed() → bool` | True after `:close()` or once the underlying transport is gone. |
+| `s:error() → string` | Last error message reported by the adapter; `""` if none. |
+| `s:bytesIn() → number` | Bytes read so far through any method. |
+| `s:bytesOut() → number` | Bytes written so far through any method. |
+| `s:kind() → string` | Adapter name: `"memory"`, `"file"`, `"tcp"`, `"tls"`, `"channel"`, `"http_response"`. |
+
+> **Naming note:** the method is `:pipeTo`, not `:pipe`, because `pipe`
+> is reserved as the implicit loop variable in CanDo's `~>` pipe
+> expressions.
+
+### Adapter accessors on existing handles
+
+| Call | Returns |
+|---|---|
+| `file.open(path, mode)` | File-backed stream. |
+| `tcp_socket:stream()` / `tls_socket:stream()` | Duplex view of a connected TCP / TLS socket.  Does not own the socket. |
+| `res:stream()` | Writable view of a server `http_response`; `:end()` flushes the buffered response. |
+| `clientResponse:stream()` | Readable view of an HTTP client response body. |
+| `proc:stdin()` / `:stdout()` / `:stderr()` | Pipes for a spawned subprocess. |
 
 ---
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,171 @@
+# Streams
+
+CanDo's `stream` library is a single byte-oriented I/O abstraction that
+files, sockets, HTTP bodies, subprocesses, and in-memory buffers all
+implement.  Anything that can produce bytes can be `:pipeTo()`'d into
+anything that can consume them, in straight-line code or inside a
+`thread { … }` block — no callbacks, no event loops.
+
+This page is a hands-on companion to the API tables in
+[standard-library.md](standard-library.md).
+
+## Mental model
+
+Four things to keep in mind:
+
+1. **One vtable, many transports.**  The same six methods (`:read`,
+   `:write`, `:pipeTo`, `:end`, `:close`, plus a few accessors) work on
+   every adapter.  Once you know how to drain a memory buffer you know
+   how to drain an HTTP body or a child-process pipe.
+
+2. **`:pipeTo` is blocking.**  It loops `read → write` until the source
+   reports EOF or one side closes.  Backpressure is automatic: each
+   write blocks until the sink consumes.  To run a pipe off the calling
+   thread, wrap it in CanDo's existing `thread { … }` syntax — there is
+   no separate async API.
+
+3. **Streams are safe to share between threads.**  The pool slot is
+   guarded so a stream handed into a child thread will not corrupt the
+   parent's view.  Use `stream.channel(cap)` when you specifically want
+   a *byte channel* for transferring bytes between threads with
+   producer/consumer backpressure.
+
+4. **Errors throw.**  I/O failures (`read`/`write` returning an error
+   from the underlying transport) and programmer mistakes (`:write` on
+   a closed stream) raise CanDo exceptions; clean EOF returns `""` from
+   `:read` and stops `:pipeTo` without an error.
+
+## Constructors
+
+| Call                            | Returns                                         |
+|---------------------------------|-------------------------------------------------|
+| `stream.memory([initialBytes])` | Duplex in-memory buffer (compacts as it drains) |
+| `stream.channel([capacity])`    | Bounded thread channel — backpressure built-in  |
+| `file.open(path, mode)`         | File-backed stream (`r/w/a`, optional `b`/`+`)  |
+| `sock:stream()`                 | Duplex view of an open TCP / TLS socket         |
+| `res:stream()`                  | Writable view of a server `http_response`       |
+| `clientResponse:stream()`       | Readable view of an HTTP client response body   |
+| `proc:stdin()` / `:stdout()` / `:stderr()` | Pipes for a spawned subprocess (when opened with `pipe`) |
+
+## Stream methods
+
+```
+s:read(maxLen [, timeoutMs])    -- string ("" on clean EOF)
+s:readAll()                     -- drain to EOF
+s:write(data)                   -- bytes consumed
+s:writeAll(data)                -- loops until done; returns self
+s:flush()                       -- adapter-defined
+s:end()                         -- half-close write side
+s:close()                       -- full close, idempotent
+s:pipeTo(dst [, opts])          -- blocking copy; returns bytes copied
+s:isClosed() / :error() / :bytesIn() / :bytesOut() / :kind()
+```
+
+`pipeTo` accepts an options object: `{ chunk: <bytes> }` overrides the
+default 64 KiB transfer block.
+
+> **Why `pipeTo` and not `pipe`?**  `pipe` is reserved as the implicit
+> loop variable in CanDo's `~>` pipe expressions and isn't permitted as
+> a method name.
+
+## Examples
+
+### Copy a file, no script-side buffering
+
+```cando
+VAR src = file.open("input.bin",  "rb");
+VAR dst = file.open("output.bin", "wb");
+src:pipeTo(dst);
+src:close();
+dst:close();
+```
+
+### Download an HTTP response straight to disk
+
+```cando
+VAR resp = fetch("https://example.com/big.zip");
+VAR out  = file.open("big.zip", "wb");
+resp:stream():pipeTo(out);
+out:close();
+```
+
+### Echo server using socket streams
+
+```cando
+socket.createServer(FUNCTION(conn) {
+    VAR cs = conn:stream();
+    cs:pipeTo(cs);                  /* echo source -> sink, same fd */
+    conn:close();
+}):listen(7000);
+```
+
+### Producer / consumer across threads
+
+```cando
+VAR ch = stream.channel(64);        /* 64-byte buffer applies backpressure */
+
+thread {
+    FOR i OF 1 -> 1000 {
+        ch:writeAll("line " + i + "\n");
+    }
+    ch:end();
+};
+
+/* Main thread drains as fast as it can; the producer blocks when full. */
+VAR sink = stream.memory();
+ch:pipeTo(sink);
+print(sink:bytesIn());
+```
+
+### Capture a subprocess's stdout
+
+```cando
+VAR p = process.spawn(["ls", "-la"], { stdout: "pipe" });
+VAR out = stream.memory();
+p:stdout():pipeTo(out);
+print(p:wait());                    /* exit code */
+print(out:readAll());
+```
+
+### Pipe a file out as the body of an HTTP response
+
+```cando
+http.createServer(FUNCTION(req, res) {
+    VAR f = file.open("download.zip", "rb");
+    VAR rs = res:stream();
+    f:pipeTo(rs);
+    rs:end();                       /* flush the buffered response */
+    f:close();
+}):listen(8080);
+```
+
+## Threading and lifetimes
+
+A stream is a thin handle into a global pool slot; its meaningful state
+lives in the slot.  Capabilities (`readable`, `writable`, `seekable`)
+are fixed at construction.
+
+* The slot is reference-checked on every method call — once `:close()`
+  fires, subsequent calls on any handle pointing at it see "closed".
+* Adapters that may *block* inside `read`/`write` (channel, full-duplex
+  socket) skip the slot lock and rely on their own internal mutex.  All
+  other adapters serialise read against write via the slot lock so a
+  stream handed to a child thread can't tear.
+* `:pipeTo` runs on whatever thread invoked it.  To do it in the
+  background, wrap it: `thread { src:pipeTo(dst); }`.  The existing
+  `cando_vm_wait_all_threads` machinery ensures the process won't exit
+  before the pipe finishes.
+
+## Limitations
+
+* **HTTP bodies are still buffered.**  Both `clientResponse:stream()`
+  and `res:stream()` work over the existing buffered body.  True
+  on-the-wire streaming (chunked downloads, chunked sends) is a
+  follow-up that requires teaching `http_read_response` to expose the
+  unread connection.
+* **`process.spawn` is POSIX-only.**  The Windows path errors with
+  "not implemented".  `process.pid()` / `process.ppid()` work
+  everywhere.
+* **No transform streams yet.**  If you need to map / filter bytes mid-
+  pipe, drain into a `stream.memory()`, transform, and pipe out.  A
+  proper transform adapter will follow once the use cases are clearer.

--- a/include/cando.h
+++ b/include/cando.h
@@ -161,6 +161,7 @@ CANDO_API void cando_open_includelib(CandoVM *vm);   /**< include()         */
 CANDO_API void cando_open_httplib(CandoVM *vm);      /**< http.* + fetch()  */
 CANDO_API void cando_open_httpslib(CandoVM *vm);     /**< https.*           */
 CANDO_API void cando_open_metalib(CandoVM *vm);      /**< _meta registry    */
+CANDO_API void cando_open_streamlib(CandoVM *vm);    /**< stream.*          */
 
 /* =========================================================================
  * Load and execute

--- a/source/cando_lib.c
+++ b/source/cando_lib.c
@@ -56,6 +56,7 @@
 #include "lib/secure_socket.h"
 #include "lib/http.h"
 #include "lib/https.h"
+#include "lib/stream.h"
 #include "lib/meta.h"
 
 /* cando.h error codes and CANDO_API */
@@ -188,6 +189,10 @@ CANDO_API void cando_openlibs(CandoVM *vm)
      * the json.stringify method on the child VM's shared globals. */
     cando_lib_http_register(vm);
     cando_lib_https_register(vm);
+    /* Stream registers last so any earlier library can later expose
+     * `:stream()` accessors that build on it without registration ordering
+     * concerns. */
+    cando_lib_stream_register(vm);
 }
 
 CANDO_API void cando_open_mathlib(CandoVM *vm)     { cando_lib_math_register(vm);     }
@@ -210,6 +215,7 @@ CANDO_API void cando_open_includelib(CandoVM *vm)  { cando_lib_include_register(
 CANDO_API void cando_open_httplib(CandoVM *vm)     { cando_lib_http_register(vm);     }
 CANDO_API void cando_open_httpslib(CandoVM *vm)    { cando_lib_https_register(vm);    }
 CANDO_API void cando_open_metalib(CandoVM *vm)     { cando_lib_meta_register(vm);     }
+CANDO_API void cando_open_streamlib(CandoVM *vm)   { cando_lib_stream_register(vm);   }
 
 /* =========================================================================
  * Internal: compile source into a chunk

--- a/source/lib/file.c
+++ b/source/lib/file.c
@@ -6,6 +6,7 @@
 
 #include "file.h"
 #include "libutil.h"
+#include "stream.h"
 #include "../vm/bridge.h"
 #include "../vm/vm.h"
 #include "../object/object.h"
@@ -326,6 +327,186 @@ static int file_list(CandoVM *vm, int argc, CandoValue *args)
 }
 
 /* =========================================================================
+ * file.open(path, mode) -- streaming adapter
+ *
+ * mode strings (chosen for least surprise vs. C's fopen):
+ *   "r"  / "rb"   -- read-only
+ *   "w"  / "wb"   -- truncate and write
+ *   "a"  / "ab"   -- append (write-only, position at end)
+ *   "r+" / "rb+"  -- read+write, file must exist
+ *   "w+" / "wb+"  -- read+write, truncate
+ *
+ * Returns a stream backed by a `FILE *`.  The vtable wires read/write/seek/
+ * tell/flush/close into stdio so the same script API works as for any
+ * other adapter.
+ * ======================================================================= */
+
+typedef struct FileCtx {
+    FILE       *fp;
+    StreamSlot *owner;
+} FileCtx;
+
+static StreamCaps caps_from_mode(const char *m)
+{
+    /* Caps follow the standard fopen interpretation. */
+    if (!m) return STREAM_CAP_READABLE;
+    bool plus = strchr(m, '+') != NULL;
+    if (plus) return STREAM_CAP_DUPLEX | STREAM_CAP_SEEKABLE;
+    if (m[0] == 'r') return STREAM_CAP_READABLE | STREAM_CAP_SEEKABLE;
+    return STREAM_CAP_WRITABLE | STREAM_CAP_SEEKABLE;
+}
+
+static StreamStatus file_stream_read(void *vctx, u8 *out, usize cap, usize *n_out)
+{
+    FileCtx *fc = (FileCtx *)vctx;
+    if (!fc->fp) { *n_out = 0; return STREAM_EOF; }
+    usize n = fread(out, 1, cap, fc->fp);
+    *n_out  = n;
+    if (n == 0) {
+        if (feof(fc->fp))    return STREAM_EOF;
+        if (ferror(fc->fp)) {
+            stream_set_error(fc->owner, "file read error");
+            return STREAM_ERR;
+        }
+    }
+    return STREAM_OK;
+}
+
+static StreamStatus file_stream_write(void *vctx, const u8 *buf, usize len,
+                                      usize *n_out)
+{
+    FileCtx *fc = (FileCtx *)vctx;
+    if (!fc->fp) {
+        *n_out = 0;
+        stream_set_error(fc->owner, "file is closed");
+        return STREAM_ERR;
+    }
+    usize n = fwrite(buf, 1, len, fc->fp);
+    *n_out  = n;
+    if (n < len) {
+        stream_set_error(fc->owner, "file write error");
+        return STREAM_ERR;
+    }
+    return STREAM_OK;
+}
+
+static StreamStatus file_stream_flush(void *vctx)
+{
+    FileCtx *fc = (FileCtx *)vctx;
+    if (!fc->fp) return STREAM_OK;
+    if (fflush(fc->fp) != 0) {
+        stream_set_error(fc->owner, "file flush error");
+        return STREAM_ERR;
+    }
+    return STREAM_OK;
+}
+
+static StreamStatus file_stream_seek(void *vctx, i64 off, int whence)
+{
+    FileCtx *fc = (FileCtx *)vctx;
+    if (!fc->fp) return STREAM_ERR;
+    int w = (whence == 1) ? SEEK_CUR : (whence == 2) ? SEEK_END : SEEK_SET;
+    if (fseek(fc->fp, (long)off, w) != 0) {
+        stream_set_error(fc->owner, "file seek error");
+        return STREAM_ERR;
+    }
+    return STREAM_OK;
+}
+
+static i64 file_stream_tell(void *vctx)
+{
+    FileCtx *fc = (FileCtx *)vctx;
+    if (!fc->fp) return -1;
+    long p = ftell(fc->fp);
+    return (i64)p;
+}
+
+static void file_stream_destroy(void *vctx)
+{
+    FileCtx *fc = (FileCtx *)vctx;
+    if (!fc) return;
+    if (fc->fp) {
+        fclose(fc->fp);
+        fc->fp = NULL;
+    }
+    cando_free(fc);
+}
+
+static const StreamVTable g_file_stream_vt = {
+    .read       = file_stream_read,
+    .write      = file_stream_write,
+    .flush      = file_stream_flush,
+    .end        = NULL,
+    .destroy    = file_stream_destroy,
+    .seek       = file_stream_seek,
+    .tell       = file_stream_tell,
+    .kind_name  = "file",
+};
+
+static bool valid_mode(const char *m)
+{
+    if (!m || !*m) return false;
+    if (m[0] != 'r' && m[0] != 'w' && m[0] != 'a') return false;
+    /* Accept any combination of trailing 'b' and '+' in any order. */
+    for (const char *p = m + 1; *p; p++) {
+        if (*p != 'b' && *p != '+') return false;
+    }
+    return true;
+}
+
+CandoValue cando_lib_file_stream_from_fp(CandoVM *vm, FILE *fp, unsigned caps)
+{
+    if (!fp) return cando_null();
+    FileCtx *fc = (FileCtx *)cando_alloc(sizeof(FileCtx));
+    memset(fc, 0, sizeof(*fc));
+    fc->fp = fp;
+    int idx = stream_pool_alloc(&g_file_stream_vt, fc, (StreamCaps)caps);
+    if (idx < 0) {
+        /* Caller-owned fp: close it on failure to avoid a leak. */
+        fclose(fp);
+        cando_free(fc);
+        return cando_null();
+    }
+    fc->owner = stream_pool_get(idx);
+    return stream_create_instance(vm, idx);
+}
+
+static int file_open(CandoVM *vm, int argc, CandoValue *args)
+{
+    const char *path = libutil_arg_cstr_at(args, argc, 0);
+    if (!path) {
+        cando_vm_error(vm, "file.open: path (string) required");
+        return -1;
+    }
+    const char *mode = libutil_arg_cstr_at(args, argc, 1);
+    if (!mode) mode = "r";
+    if (!valid_mode(mode)) {
+        cando_vm_error(vm, "file.open: invalid mode '%s'", mode);
+        return -1;
+    }
+    FILE *fp = fopen(path, mode);
+    if (!fp) {
+        cando_vm_error(vm, "file.open: cannot open '%s'", path);
+        return -1;
+    }
+
+    FileCtx *fc = (FileCtx *)cando_alloc(sizeof(FileCtx));
+    memset(fc, 0, sizeof(*fc));
+    fc->fp = fp;
+
+    int idx = stream_pool_alloc(&g_file_stream_vt, fc, caps_from_mode(mode));
+    if (idx < 0) {
+        fclose(fp);
+        cando_free(fc);
+        cando_vm_error(vm, "file.open: too many active streams");
+        return -1;
+    }
+    fc->owner = stream_pool_get(idx);
+    cando_vm_push(vm, stream_create_instance(vm, idx));
+    return 1;
+}
+
+/* =========================================================================
  * Registration
  * ======================================================================= */
 
@@ -345,6 +526,7 @@ void cando_lib_file_register(CandoVM *vm)
     libutil_set_method(vm, file_obj, "lines",  file_lines);
     libutil_set_method(vm, file_obj, "mkdir",  file_mkdir);
     libutil_set_method(vm, file_obj, "list",   file_list);
+    libutil_set_method(vm, file_obj, "open",   file_open);
 
     cando_vm_set_global(vm, "file", file_val, true);
 }

--- a/source/lib/file.h
+++ b/source/lib/file.h
@@ -33,4 +33,23 @@
  */
 CANDO_API void cando_lib_file_register(CandoVM *vm);
 
+/* =========================================================================
+ * Internal: build a file-stream around an existing FILE*.
+ *
+ * Used by other libraries (process, etc.) that already have a FILE* — for
+ * example after fdopen()ing a pipe — and want to expose it through the
+ * unified `stream` API without re-implementing the file vtable.
+ *
+ * The returned stream takes ownership of `fp`: closing the stream closes
+ * the file.  `caps` should match the open mode (READABLE for read-pipes,
+ * WRITABLE for write-pipes).  Returns cando_null() on pool exhaustion.
+ *
+ * Not part of the public CanDo API — declared here so process.c can call
+ * it without copy/pasting the file_stream vtable.
+ */
+#include <stdio.h>
+CANDO_API CandoValue cando_lib_file_stream_from_fp(CandoVM *vm,
+                                                   FILE *fp,
+                                                   unsigned caps);
+
 #endif /* CANDO_LIB_FILE_H */

--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -19,6 +19,7 @@
 #include "httputil.h"
 #include "libutil.h"
 #include "meta.h"
+#include "stream.h"
 #include "../vm/bridge.h"
 #include "../vm/vm.h"
 #include "../object/object.h"
@@ -670,6 +671,139 @@ static int res_send_fn(CandoVM *vm, int argc, CandoValue *args)
     return 1;
 }
 
+/* res:stream() -> writable stream that buffers body bytes and sends the
+ * full response on `:end()`.
+ *
+ * Like `res:send()`, this is a one-shot — calling :end() (or :close()
+ * after writes) flushes whatever was buffered as a single Content-Length
+ * response.  True chunked sending is deferred to a follow-up; the win
+ * here is the unified API so callers can `file:pipeTo(res:stream())` to
+ * stream a download out without manually slurping the file first.
+ */
+typedef struct ResStreamCtx {
+    HttpResCtx *res;
+    HttpBuf     buf;
+    StreamSlot *owner;
+} ResStreamCtx;
+
+static StreamStatus res_stream_write(void *vctx, const u8 *buf, usize len,
+                                     usize *n_out)
+{
+    ResStreamCtx *rs = (ResStreamCtx *)vctx;
+    if (rs->res->sent) {
+        *n_out = 0;
+        stream_set_error(rs->owner, "response already sent");
+        return STREAM_ERR;
+    }
+    httpbuf_append(&rs->buf, (const char *)buf, len);
+    *n_out = len;
+    return STREAM_OK;
+}
+
+static StreamStatus res_stream_end(void *vctx)
+{
+    ResStreamCtx *rs = (ResStreamCtx *)vctx;
+    if (rs->res->sent) return STREAM_OK;
+    if (!res_send_impl(rs->res, rs->buf.data, rs->buf.len)) {
+        stream_set_error(rs->owner, "response send failed");
+        return STREAM_ERR;
+    }
+    return STREAM_OK;
+}
+
+static void res_stream_destroy(void *vctx)
+{
+    ResStreamCtx *rs = (ResStreamCtx *)vctx;
+    if (!rs) return;
+    /* If the script closed without :end(), don't auto-send — they may
+     * have intentionally abandoned the response.  The connection thread
+     * is still blocked in res_wait_until_sent and will eventually pick up
+     * any explicit res:send call. */
+    httpbuf_free(&rs->buf);
+    cando_free(rs);
+}
+
+static const StreamVTable g_res_stream_vt = {
+    .read       = NULL,
+    .write      = res_stream_write,
+    .flush      = NULL,
+    .end        = res_stream_end,
+    .destroy    = res_stream_destroy,
+    .seek       = NULL,
+    .tell       = NULL,
+    .kind_name  = "http_response",
+};
+
+static int res_stream_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    HttpResCtx *ctx = res_get_ctx_from(vm,
+                          argc > 0 ? args[0] : cando_null());
+    if (!ctx) {
+        cando_vm_error(vm, "res:stream: invalid receiver");
+        return -1;
+    }
+    ResStreamCtx *rs = (ResStreamCtx *)cando_alloc(sizeof(ResStreamCtx));
+    memset(rs, 0, sizeof(*rs));
+    rs->res = ctx;
+    httpbuf_init(&rs->buf);
+
+    int idx = stream_pool_alloc(&g_res_stream_vt, rs, STREAM_CAP_WRITABLE);
+    if (idx < 0) {
+        httpbuf_free(&rs->buf);
+        cando_free(rs);
+        cando_vm_error(vm, "res:stream: too many active streams");
+        return -1;
+    }
+    rs->owner = stream_pool_get(idx);
+    cando_vm_push(vm, stream_create_instance(vm, idx));
+    return 1;
+}
+
+/* clientResponse:stream() -> readable stream over the buffered body
+ *
+ * The HTTP client buffers the full response body before returning, so this
+ * adapter presents it as a pre-filled, write-ended memory stream.  The
+ * point is uniformity: downstream code can `:pipeTo(file)` /
+ * `:pipeTo(channel)` on an HTTP body the same way it does on any other
+ * source.
+ *
+ * On-the-fly streaming (skip the body buffer entirely) requires teaching
+ * `http_read_response` to hand back an unread `HttpConn`; that's deferred
+ * to a follow-up because it touches the parser surface area.
+ */
+static int http_client_response_stream_fn(CandoVM *vm, int argc,
+                                          CandoValue *args)
+{
+    if (argc < 1 || !cando_is_object(args[0])) {
+        cando_vm_error(vm, "clientResponse:stream: invalid receiver");
+        return -1;
+    }
+    CdoObject *obj = cando_bridge_resolve(vm, args[0].as.handle);
+    if (!obj) {
+        cando_vm_error(vm, "clientResponse:stream: invalid receiver");
+        return -1;
+    }
+    CdoString *kbody = cdo_string_intern("body", 4);
+    CdoValue   bv    = cdo_null();
+    bool       have  = cdo_object_get(obj, kbody, &bv);
+    cdo_string_release(kbody);
+
+    const void *data = "";
+    usize       len  = 0;
+    if (have && bv.tag == CDO_STRING && bv.as.string) {
+        data = bv.as.string->data;
+        len  = bv.as.string->length;
+    }
+
+    CandoValue sv = cando_stream_from_bytes(vm, data, len);
+    if (cando_is_null(sv)) {
+        cando_vm_error(vm, "clientResponse:stream: too many active streams");
+        return -1;
+    }
+    cando_vm_push(vm, sv);
+    return 1;
+}
+
 /* res.json(value) — uses the `json` global's stringify method. */
 static int res_json_fn(CandoVM *vm, int argc, CandoValue *args)
 {
@@ -1086,11 +1220,17 @@ void http_register_meta_tables(CandoVM *vm)
         cando_lib_meta_define(vm, res_meta, "setHeader", res_setHeader_fn);
         cando_lib_meta_define(vm, res_meta, "send",      res_send_fn);
         cando_lib_meta_define(vm, res_meta, "json",      res_json_fn);
+        cando_lib_meta_define(vm, res_meta, "stream",    res_stream_fn);
     }
     /* http_request currently has no native methods.  The table is created
      * eagerly so user code can attach methods reliably at script startup. */
     (void)cando_lib_meta_table(vm, "http_request");
-    (void)cando_lib_meta_table(vm, "http_client_response");
+
+    CdoObject *cres_meta = cando_lib_meta_table(vm, "http_client_response");
+    if (cres_meta) {
+        cando_lib_meta_define(vm, cres_meta, "stream",
+                              http_client_response_stream_fn);
+    }
 
     CdoObject *server_meta = cando_lib_meta_table(vm, "http_server");
     if (server_meta) {

--- a/source/lib/process.c
+++ b/source/lib/process.c
@@ -1,19 +1,504 @@
 /*
  * lib/process.c -- Subprocess management standard library for Cando.
  *
+ * Surface:
+ *   process.pid()                       -- current process ID
+ *   process.ppid()                      -- parent process ID
+ *   process.spawn(argv [, opts])        -- spawn a child process; returns
+ *                                          a `proc` instance
+ *
+ * On a `proc`:
+ *   proc:pid()                          -- child's pid
+ *   proc:stdin()  / :stdout() / :stderr() -- streams for the requested
+ *                                          piped fds (`null` if "inherit"
+ *                                          or "null" was selected)
+ *   proc:wait()                         -- waitpid; returns exit code
+ *   proc:kill([sig])                    -- signal the child (default SIGTERM)
+ *
+ * Spawning is POSIX-only at the moment.  The Windows path returns an
+ * error; a follow-up will add a CreateProcess implementation.
+ *
  * Must compile with gcc -std=c11.
  */
 
 #include "process.h"
 #include "libutil.h"
+#include "meta.h"
+#include "stream.h"
+#include "file.h"
 #include "../vm/bridge.h"
 #include "../object/object.h"
+#include "../object/array.h"
+#include "../object/string.h"
+#include "../core/thread_platform.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
 
 #include <unistd.h>
 #include <sys/types.h>
 #if defined(_WIN32) || defined(_WIN64)
-#include <process.h>
+#  include <process.h>
+#else
+#  include <sys/wait.h>
+#  include <fcntl.h>
+extern char **environ;
 #endif
+
+/* =========================================================================
+ * Pool
+ * ===================================================================== */
+
+#define PROC_MAX_INSTANCES 64
+
+typedef struct ProcSlot {
+    bool             in_use;
+    int              pid;
+    int              stdin_fd;        /* parent write end, -1 if not piped  */
+    int              stdout_fd;       /* parent read end                    */
+    int              stderr_fd;       /* parent read end                    */
+    int              exit_code;
+    bool             waited;
+    /* Cached stream slot indices so :stdin/:stdout/:stderr return the same
+     * underlying stream on repeated calls.  -1 means "not created yet". */
+    int              stdin_stream_idx;
+    int              stdout_stream_idx;
+    int              stderr_stream_idx;
+} ProcSlot;
+
+static ProcSlot      g_proc_pool[PROC_MAX_INSTANCES];
+static cando_mutex_t g_proc_pool_mutex;
+static _Atomic(int)  g_proc_pool_inited = 0;
+
+static void ensure_pool_inited(void)
+{
+    int expected = 0;
+    if (atomic_compare_exchange_strong(&g_proc_pool_inited, &expected, 1)) {
+        cando_os_mutex_init(&g_proc_pool_mutex);
+        for (int i = 0; i < PROC_MAX_INSTANCES; i++) {
+            memset(&g_proc_pool[i], 0, sizeof(ProcSlot));
+            g_proc_pool[i].stdin_fd          = -1;
+            g_proc_pool[i].stdout_fd         = -1;
+            g_proc_pool[i].stderr_fd         = -1;
+            g_proc_pool[i].stdin_stream_idx  = -1;
+            g_proc_pool[i].stdout_stream_idx = -1;
+            g_proc_pool[i].stderr_stream_idx = -1;
+        }
+    }
+}
+
+static int proc_pool_alloc(void)
+{
+    ensure_pool_inited();
+    cando_os_mutex_lock(&g_proc_pool_mutex);
+    int idx = -1;
+    for (int i = 0; i < PROC_MAX_INSTANCES; i++) {
+        if (!g_proc_pool[i].in_use) {
+            memset(&g_proc_pool[i], 0, sizeof(ProcSlot));
+            g_proc_pool[i].in_use            = true;
+            g_proc_pool[i].pid               = -1;
+            g_proc_pool[i].stdin_fd          = -1;
+            g_proc_pool[i].stdout_fd         = -1;
+            g_proc_pool[i].stderr_fd         = -1;
+            g_proc_pool[i].stdin_stream_idx  = -1;
+            g_proc_pool[i].stdout_stream_idx = -1;
+            g_proc_pool[i].stderr_stream_idx = -1;
+            idx = i;
+            break;
+        }
+    }
+    cando_os_mutex_unlock(&g_proc_pool_mutex);
+    return idx;
+}
+
+static ProcSlot *proc_pool_get(int idx)
+{
+    if (idx < 0 || idx >= PROC_MAX_INSTANCES) return NULL;
+    if (!g_proc_pool[idx].in_use) return NULL;
+    return &g_proc_pool[idx];
+}
+
+/* =========================================================================
+ * Field helpers (same shape as socket.c)
+ * ===================================================================== */
+
+static bool get_int_field(CdoObject *obj, const char *name, int *out)
+{
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    CdoValue   v   = cdo_null();
+    bool ok = cdo_object_rawget(obj, key, &v);
+    cdo_string_release(key);
+    if (!ok || v.tag != CDO_NUMBER) return false;
+    *out = (int)v.as.number;
+    return true;
+}
+
+static void set_num_field(CdoObject *obj, const char *name, f64 n)
+{
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    cdo_object_rawset(obj, key, cdo_number(n), FIELD_NONE);
+    cdo_string_release(key);
+}
+
+static ProcSlot *proc_resolve_receiver(CandoVM *vm, CandoValue receiver)
+{
+    if (!cando_is_object(receiver)) return NULL;
+    CdoObject *obj = cando_bridge_resolve(vm, receiver.as.handle);
+    if (!obj) return NULL;
+    int idx = -1;
+    if (!get_int_field(obj, "__proc_id", &idx)) return NULL;
+    return proc_pool_get(idx);
+}
+
+static CandoValue proc_create_instance(CandoVM *vm, int slot_idx)
+{
+    CandoValue val = cando_bridge_new_object(vm);
+    CdoObject *obj = cando_bridge_resolve(vm, val.as.handle);
+    set_num_field(obj, "__proc_id", (f64)slot_idx);
+    cando_lib_meta_attach(vm, obj, "proc");
+    return val;
+}
+
+/* =========================================================================
+ * Spawn
+ * ===================================================================== */
+
+typedef enum { STDIO_INHERIT = 0, STDIO_PIPE = 1, STDIO_NULL = 2 } StdioMode;
+
+static StdioMode parse_stdio(CdoObject *opts, const char *key, StdioMode def)
+{
+    if (!opts) return def;
+    CdoString *k = cdo_string_intern(key, (u32)strlen(key));
+    CdoValue   v = cdo_null();
+    bool       ok = cdo_object_rawget(opts, k, &v);
+    cdo_string_release(k);
+    if (!ok || v.tag != CDO_STRING || !v.as.string) return def;
+    const char *s = v.as.string->data;
+    if (strcmp(s, "pipe")    == 0) return STDIO_PIPE;
+    if (strcmp(s, "null")    == 0) return STDIO_NULL;
+    if (strcmp(s, "inherit") == 0) return STDIO_INHERIT;
+    return def;
+}
+
+#if !defined(_WIN32) && !defined(_WIN64)
+/*
+ * spawn_posix -- fork + exec on POSIX.  Returns the parent's slot index, or
+ * -1 with `err` populated on failure.  argv must be NULL-terminated.
+ */
+static int spawn_posix(char *const argv[],
+                       StdioMode in_mode, StdioMode out_mode, StdioMode err_mode,
+                       const char *cwd,
+                       char *err, usize errlen)
+{
+    int in_pipe[2]  = { -1, -1 };
+    int out_pipe[2] = { -1, -1 };
+    int err_pipe[2] = { -1, -1 };
+
+    if (in_mode  == STDIO_PIPE && pipe(in_pipe)  != 0) goto pipe_err;
+    if (out_mode == STDIO_PIPE && pipe(out_pipe) != 0) goto pipe_err;
+    if (err_mode == STDIO_PIPE && pipe(err_pipe) != 0) goto pipe_err;
+
+    int slot_idx = proc_pool_alloc();
+    if (slot_idx < 0) {
+        snprintf(err, errlen, "process.spawn: pool exhausted");
+        goto cleanup;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        snprintf(err, errlen, "process.spawn: fork failed: %s", strerror(errno));
+        g_proc_pool[slot_idx].in_use = false;
+        goto cleanup;
+    }
+
+    if (pid == 0) {
+        /* Child.  Wire stdio. */
+        if (in_mode == STDIO_PIPE) {
+            dup2(in_pipe[0], 0);
+            close(in_pipe[0]);
+            close(in_pipe[1]);
+        } else if (in_mode == STDIO_NULL) {
+            int dn = open("/dev/null", O_RDONLY);
+            if (dn >= 0) { dup2(dn, 0); close(dn); }
+        }
+        if (out_mode == STDIO_PIPE) {
+            dup2(out_pipe[1], 1);
+            close(out_pipe[0]);
+            close(out_pipe[1]);
+        } else if (out_mode == STDIO_NULL) {
+            int dn = open("/dev/null", O_WRONLY);
+            if (dn >= 0) { dup2(dn, 1); close(dn); }
+        }
+        if (err_mode == STDIO_PIPE) {
+            dup2(err_pipe[1], 2);
+            close(err_pipe[0]);
+            close(err_pipe[1]);
+        } else if (err_mode == STDIO_NULL) {
+            int dn = open("/dev/null", O_WRONLY);
+            if (dn >= 0) { dup2(dn, 2); close(dn); }
+        }
+        if (cwd && *cwd) {
+            if (chdir(cwd) != 0) _exit(127);
+        }
+        execvp(argv[0], argv);
+        /* exec failed. */
+        _exit(127);
+    }
+
+    /* Parent. */
+    ProcSlot *p = &g_proc_pool[slot_idx];
+    p->pid = pid;
+    if (in_mode  == STDIO_PIPE) { close(in_pipe[0]);  p->stdin_fd  = in_pipe[1];  }
+    if (out_mode == STDIO_PIPE) { close(out_pipe[1]); p->stdout_fd = out_pipe[0]; }
+    if (err_mode == STDIO_PIPE) { close(err_pipe[1]); p->stderr_fd = err_pipe[0]; }
+    return slot_idx;
+
+pipe_err:
+    snprintf(err, errlen, "process.spawn: pipe failed: %s", strerror(errno));
+cleanup:
+    if (in_pipe[0]  >= 0) close(in_pipe[0]);
+    if (in_pipe[1]  >= 0) close(in_pipe[1]);
+    if (out_pipe[0] >= 0) close(out_pipe[0]);
+    if (out_pipe[1] >= 0) close(out_pipe[1]);
+    if (err_pipe[0] >= 0) close(err_pipe[0]);
+    if (err_pipe[1] >= 0) close(err_pipe[1]);
+    return -1;
+}
+#endif
+
+/* process.spawn(argv [, opts]) -> proc */
+static int process_spawn_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    (void)argc; (void)args;
+    cando_vm_error(vm, "process.spawn: not implemented on Windows yet");
+    return -1;
+#else
+    if (argc < 1 || !cando_is_object(args[0])) {
+        cando_vm_error(vm, "process.spawn: argv (array) required");
+        return -1;
+    }
+    CdoObject *argv_obj = cando_bridge_resolve(vm, args[0].as.handle);
+    if (!argv_obj) {
+        cando_vm_error(vm, "process.spawn: argv is invalid");
+        return -1;
+    }
+    u32 nargs = cdo_array_len(argv_obj);
+    if (nargs == 0) {
+        cando_vm_error(vm, "process.spawn: argv is empty");
+        return -1;
+    }
+
+    /* Materialise argv into a NULL-terminated char* array.  We dup each
+     * string so the child has stable storage even if the script GC moves
+     * underlying CdoString memory between fork() and exec(). */
+    char **argv = (char **)cando_alloc(sizeof(char *) * (nargs + 1));
+    for (u32 i = 0; i < nargs; i++) {
+        CdoValue v = cdo_null();
+        cdo_array_rawget_idx(argv_obj, i, &v);
+        if (v.tag != CDO_STRING || !v.as.string) {
+            for (u32 j = 0; j < i; j++) cando_free(argv[j]);
+            cando_free(argv);
+            cando_vm_error(vm, "process.spawn: argv[%u] must be a string", i);
+            return -1;
+        }
+        usize len = v.as.string->length;
+        argv[i] = (char *)cando_alloc(len + 1);
+        memcpy(argv[i], v.as.string->data, len);
+        argv[i][len] = '\0';
+    }
+    argv[nargs] = NULL;
+
+    StdioMode  in_mode  = STDIO_INHERIT;
+    StdioMode  out_mode = STDIO_INHERIT;
+    StdioMode  err_mode = STDIO_INHERIT;
+    const char *cwd     = NULL;
+    if (argc >= 2 && cando_is_object(args[1])) {
+        CdoObject *opts = cando_bridge_resolve(vm, args[1].as.handle);
+        in_mode  = parse_stdio(opts, "stdin",  STDIO_INHERIT);
+        out_mode = parse_stdio(opts, "stdout", STDIO_INHERIT);
+        err_mode = parse_stdio(opts, "stderr", STDIO_INHERIT);
+        CdoString *kcwd = cdo_string_intern("cwd", 3);
+        CdoValue   vcwd = cdo_null();
+        bool ok = cdo_object_rawget(opts, kcwd, &vcwd);
+        cdo_string_release(kcwd);
+        if (ok && vcwd.tag == CDO_STRING && vcwd.as.string)
+            cwd = vcwd.as.string->data;
+    }
+
+    char errbuf[160] = {0};
+    int slot_idx = spawn_posix(argv, in_mode, out_mode, err_mode, cwd,
+                               errbuf, sizeof(errbuf));
+
+    for (u32 i = 0; i < nargs; i++) cando_free(argv[i]);
+    cando_free(argv);
+
+    if (slot_idx < 0) {
+        cando_vm_error(vm, "%s", errbuf[0] ? errbuf : "process.spawn failed");
+        return -1;
+    }
+    cando_vm_push(vm, proc_create_instance(vm, slot_idx));
+    return 1;
+#endif
+}
+
+/* =========================================================================
+ * proc instance methods
+ * ===================================================================== */
+
+/* proc:pid() */
+static int proc_pid_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
+    cando_vm_push(vm, cando_number(p ? (f64)p->pid : -1.0));
+    return 1;
+}
+
+/* Build (or return cached) stream over one of the proc's piped fds. */
+static int proc_stream_for(CandoVM *vm, ProcSlot *p, int *cache_idx,
+                           int fd, const char *fmode, unsigned caps,
+                           const char *method)
+{
+    if (!p) {
+        cando_vm_error(vm, "%s: invalid receiver", method);
+        return -1;
+    }
+    if (fd < 0) {
+        cando_vm_push(vm, cando_null());
+        return 1;
+    }
+    /* Reuse the cached stream slot if it's still alive. */
+    if (*cache_idx >= 0) {
+        StreamSlot *s = stream_pool_get(*cache_idx);
+        if (s) {
+            cando_vm_push(vm, stream_create_instance(vm, *cache_idx));
+            return 1;
+        }
+        /* Cached slot was released — fall through and create a fresh one
+         * IF we still have the fd.  But since file_stream's destroy
+         * fclose's the underlying FILE* (which closes the fd), the fd is
+         * already invalid in that case. */
+        cando_vm_error(vm, "%s: stream was closed", method);
+        return -1;
+    }
+    FILE *fp = fdopen(fd, fmode);
+    if (!fp) {
+        cando_vm_error(vm, "%s: fdopen failed: %s", method, strerror(errno));
+        return -1;
+    }
+    /* From here the FILE* owns the fd; clear it on the slot so :wait()
+     * doesn't try to close it again. */
+    if (cache_idx == &p->stdin_stream_idx)  p->stdin_fd  = -1;
+    if (cache_idx == &p->stdout_stream_idx) p->stdout_fd = -1;
+    if (cache_idx == &p->stderr_stream_idx) p->stderr_fd = -1;
+
+    CandoValue sv = cando_lib_file_stream_from_fp(vm, fp, caps);
+    if (cando_is_null(sv)) {
+        cando_vm_error(vm, "%s: too many active streams", method);
+        return -1;
+    }
+    /* Recover the slot index from the returned object so we can cache it. */
+    CdoObject *obj = cando_bridge_resolve(vm, sv.as.handle);
+    int idx = -1;
+    get_int_field(obj, "__stream_id", &idx);
+    *cache_idx = idx;
+    cando_vm_push(vm, sv);
+    return 1;
+}
+
+/* proc:stdin() -> writable stream | null */
+static int proc_stdin_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
+    return proc_stream_for(vm, p, p ? &p->stdin_stream_idx : NULL,
+                           p ? p->stdin_fd : -1,
+                           "wb", STREAM_CAP_WRITABLE, "proc:stdin");
+}
+
+/* proc:stdout() -> readable stream | null */
+static int proc_stdout_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
+    return proc_stream_for(vm, p, p ? &p->stdout_stream_idx : NULL,
+                           p ? p->stdout_fd : -1,
+                           "rb", STREAM_CAP_READABLE, "proc:stdout");
+}
+
+/* proc:stderr() -> readable stream | null */
+static int proc_stderr_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
+    return proc_stream_for(vm, p, p ? &p->stderr_stream_idx : NULL,
+                           p ? p->stderr_fd : -1,
+                           "rb", STREAM_CAP_READABLE, "proc:stderr");
+}
+
+/* proc:wait() -> exit code (POSIX waitpid) */
+static int proc_wait_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
+    if (!p) {
+        cando_vm_error(vm, "proc:wait: invalid receiver");
+        return -1;
+    }
+    if (p->waited) {
+        cando_vm_push(vm, cando_number((f64)p->exit_code));
+        return 1;
+    }
+#if defined(_WIN32) || defined(_WIN64)
+    cando_vm_error(vm, "proc:wait: not implemented on Windows");
+    return -1;
+#else
+    int status = 0;
+    if (waitpid(p->pid, &status, 0) < 0) {
+        cando_vm_error(vm, "proc:wait: waitpid failed: %s", strerror(errno));
+        return -1;
+    }
+    int code = WIFEXITED(status) ? WEXITSTATUS(status)
+            : WIFSIGNALED(status) ? -WTERMSIG(status)
+            : -1;
+    p->exit_code = code;
+    p->waited    = true;
+    /* Close any fds the user never asked for via :stdin/:stdout/:stderr.
+     * Fds promoted into a stream are already owned by that stream. */
+    if (p->stdin_fd  >= 0) { close(p->stdin_fd);  p->stdin_fd  = -1; }
+    if (p->stdout_fd >= 0) { close(p->stdout_fd); p->stdout_fd = -1; }
+    if (p->stderr_fd >= 0) { close(p->stderr_fd); p->stderr_fd = -1; }
+    cando_vm_push(vm, cando_number((f64)code));
+    return 1;
+#endif
+}
+
+/* proc:kill([sig]) */
+static int proc_kill_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
+    if (!p) {
+        cando_vm_error(vm, "proc:kill: invalid receiver");
+        return -1;
+    }
+#if defined(_WIN32) || defined(_WIN64)
+    (void)argc;
+    cando_vm_error(vm, "proc:kill: not implemented on Windows");
+    return -1;
+#else
+    int sig = (int)libutil_arg_num_at(args, argc, 1, (f64)SIGTERM);
+    if (kill(p->pid, sig) != 0) {
+        cando_vm_error(vm, "proc:kill: %s", strerror(errno));
+        return -1;
+    }
+    cando_vm_push(vm, args[0]);
+    return 1;
+#endif
+}
+
+/* =========================================================================
+ * Module entry
+ * ===================================================================== */
 
 static int process_pid(CandoVM *vm, int argc, CandoValue *args)
 {
@@ -26,7 +511,7 @@ static int process_ppid(CandoVM *vm, int argc, CandoValue *args)
 {
     (void)argc; (void)args;
 #if defined(_WIN32) || defined(_WIN64)
-    cando_vm_push(vm, cando_number(0.0)); /* getppid not standard on Windows */
+    cando_vm_push(vm, cando_number(0.0));
 #else
     cando_vm_push(vm, cando_number((f64)getppid()));
 #endif
@@ -35,11 +520,26 @@ static int process_ppid(CandoVM *vm, int argc, CandoValue *args)
 
 void cando_lib_process_register(CandoVM *vm)
 {
+    ensure_pool_inited();
+    cando_lib_meta_register(vm);
+
     CandoValue proc_val = cando_bridge_new_object(vm);
     CdoObject *proc_obj = cando_bridge_resolve(vm, proc_val.as.handle);
 
-    libutil_set_method(vm, proc_obj, "pid",  process_pid);
-    libutil_set_method(vm, proc_obj, "ppid", process_ppid);
+    libutil_set_method(vm, proc_obj, "pid",   process_pid);
+    libutil_set_method(vm, proc_obj, "ppid",  process_ppid);
+    libutil_set_method(vm, proc_obj, "spawn", process_spawn_fn);
 
     cando_vm_set_global(vm, "process", proc_val, true);
+
+    /* Per-instance meta table for spawned children. */
+    CdoObject *meta = cando_lib_meta_table(vm, "proc");
+    if (meta) {
+        cando_lib_meta_define(vm, meta, "pid",    proc_pid_fn);
+        cando_lib_meta_define(vm, meta, "stdin",  proc_stdin_fn);
+        cando_lib_meta_define(vm, meta, "stdout", proc_stdout_fn);
+        cando_lib_meta_define(vm, meta, "stderr", proc_stderr_fn);
+        cando_lib_meta_define(vm, meta, "wait",   proc_wait_fn);
+        cando_lib_meta_define(vm, meta, "kill",   proc_kill_fn);
+    }
 }

--- a/source/lib/socket.c
+++ b/source/lib/socket.c
@@ -20,6 +20,7 @@
 #include "sockutil.h"
 #include "libutil.h"
 #include "meta.h"
+#include "stream.h"
 #include "../vm/bridge.h"
 #include "../vm/vm.h"
 #include "../object/object.h"
@@ -32,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <limits.h>
 
 /* =========================================================================
  * Pool
@@ -650,6 +652,113 @@ static int tcp_remoteAddress_fn(CandoVM *vm, int argc, CandoValue *args)
     return push_addr_object(vm, &sa, len);
 }
 
+/* =========================================================================
+ * Stream adapter (registered as `tcp_socket:stream()`)
+ *
+ * Wraps an existing SocketSlot fd (and SSL*, for TLS) behind the unified
+ * stream vtable.  The stream does NOT own the underlying socket — the
+ * tcp_socket script object retains ownership.  When the user closes the
+ * socket independently the next read/write on the stream surfaces a
+ * STREAM_ERR with "socket closed".
+ *
+ * `self_locked = true` because sockets are full-duplex and a blocked
+ * recv() must not hold the slot lock against a concurrent send().
+ * ===================================================================== */
+
+typedef struct SockStreamCtx {
+    int  socket_idx;        /* index into the socket pool                 */
+} SockStreamCtx;
+
+static StreamStatus sock_stream_read(void *vctx, u8 *out, usize cap, usize *n_out)
+{
+    SockStreamCtx *sc = (SockStreamCtx *)vctx;
+    SocketSlot    *s  = socket_pool_get(sc->socket_idx);
+    if (!s || s->fd == SOCKUTIL_INVALID_SOCKET || !s->connected) {
+        *n_out = 0;
+        return STREAM_EOF;
+    }
+    int ilen = (int)(cap > (usize)INT_MAX ? INT_MAX : cap);
+    int n = s->ssl ? sockutil_tls_recv(s->ssl, out, ilen)
+                   : sockutil_recv_raw(s->fd,  out, ilen);
+    if (n < 0)  { *n_out = 0; return STREAM_ERR; }
+    if (n == 0) { *n_out = 0; return STREAM_EOF; }
+    *n_out = (usize)n;
+    return STREAM_OK;
+}
+
+static StreamStatus sock_stream_write(void *vctx, const u8 *buf, usize len,
+                                      usize *n_out)
+{
+    SockStreamCtx *sc = (SockStreamCtx *)vctx;
+    SocketSlot    *s  = socket_pool_get(sc->socket_idx);
+    if (!s || s->fd == SOCKUTIL_INVALID_SOCKET || !s->connected) {
+        *n_out = 0;
+        return STREAM_ERR;
+    }
+    /* sockutil_send_all loops until done; that gives the caller the same
+     * "writeAll succeeds in one hop" semantics they get from
+     * tcp_socket:sendAll, which is what the stream contract expects. */
+    if (!sockutil_send_all(s->fd, s->ssl, (const char *)buf, len)) {
+        *n_out = 0;
+        return STREAM_ERR;
+    }
+    *n_out = len;
+    return STREAM_OK;
+}
+
+static void sock_stream_destroy(void *vctx)
+{
+    /* We do NOT close the underlying socket — the tcp_socket script object
+     * still owns it.  Just free our wrapper. */
+    cando_free(vctx);
+}
+
+static const StreamVTable g_sock_stream_vt = {
+    .read        = sock_stream_read,
+    .write       = sock_stream_write,
+    .flush       = NULL,
+    .end         = NULL,
+    .destroy     = sock_stream_destroy,
+    .seek        = NULL,
+    .tell        = NULL,
+    .kind_name   = "tcp",
+    .self_locked = true,
+};
+
+static const StreamVTable g_tls_stream_vt = {
+    .read        = sock_stream_read,
+    .write       = sock_stream_write,
+    .flush       = NULL,
+    .end         = NULL,
+    .destroy     = sock_stream_destroy,
+    .seek        = NULL,
+    .tell        = NULL,
+    .kind_name   = "tls",
+    .self_locked = true,
+};
+
+/* tcp_socket:stream() -> stream */
+static int tcp_stream_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    SocketSlot *s = conn_check(vm, argc > 0 ? args[0] : cando_null(),
+                               "socket:stream", true);
+    if (!s) return -1;
+    int sock_idx = (int)(s - g_socket_pool);
+
+    SockStreamCtx *ctx = (SockStreamCtx *)cando_alloc(sizeof(SockStreamCtx));
+    ctx->socket_idx = sock_idx;
+
+    const StreamVTable *vt = s->ssl ? &g_tls_stream_vt : &g_sock_stream_vt;
+    int idx = stream_pool_alloc(vt, ctx, STREAM_CAP_DUPLEX);
+    if (idx < 0) {
+        cando_free(ctx);
+        cando_vm_error(vm, "socket:stream: too many active streams");
+        return -1;
+    }
+    cando_vm_push(vm, stream_create_instance(vm, idx));
+    return 1;
+}
+
 void socket_meta_define_common(CandoVM *vm, CdoObject *tbl)
 {
     if (!tbl) return;
@@ -667,6 +776,7 @@ void socket_meta_define_common(CandoVM *vm, CdoObject *tbl)
     cando_lib_meta_define(vm, tbl, "fd",            tcp_fd_fn);
     cando_lib_meta_define(vm, tbl, "localAddress",  tcp_localAddress_fn);
     cando_lib_meta_define(vm, tbl, "remoteAddress", tcp_remoteAddress_fn);
+    cando_lib_meta_define(vm, tbl, "stream",        tcp_stream_fn);
 }
 
 

--- a/source/lib/stream.c
+++ b/source/lib/stream.c
@@ -1,0 +1,917 @@
+/*
+ * lib/stream.c -- Unified streaming subsystem (step 1: pool + mem adapter).
+ *
+ * Layered structure:
+ *   1. Pool of StreamSlot, with mutex-guarded alloc/free (mirrors socket.c).
+ *   2. Receiver helpers (look up StreamSlot from CanDo `__stream_id` field).
+ *   3. Common method implementations (read/write/close/etc.) that dispatch
+ *      to the slot's vtable under the slot's R/W lock.
+ *   4. The in-memory adapter (`stream.memory`).
+ *   5. Module registration and the `_meta.stream` table.
+ *
+ * Subsequent steps add file/socket/http/process adapters in their own
+ * library files; they all call back into this module's pool/instance API.
+ *
+ * Must compile with gcc -std=c11.
+ */
+
+#include "stream.h"
+#include "libutil.h"
+#include "meta.h"
+#include "../vm/bridge.h"
+#include "../vm/vm.h"
+#include "../object/object.h"
+#include "../object/string.h"
+#include "../core/thread_platform.h"
+#include "../core/lock.h"
+#include "../core/common.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* =========================================================================
+ * Pool
+ * ===================================================================== */
+
+static StreamSlot      g_stream_pool[STREAM_MAX_INSTANCES];
+static cando_mutex_t   g_stream_pool_mutex;
+static _Atomic(int)    g_stream_pool_inited = 0;
+
+static void ensure_pool_inited(void)
+{
+    int expected = 0;
+    if (atomic_compare_exchange_strong(&g_stream_pool_inited, &expected, 1)) {
+        cando_os_mutex_init(&g_stream_pool_mutex);
+        for (int i = 0; i < STREAM_MAX_INSTANCES; i++) {
+            memset(&g_stream_pool[i], 0, sizeof(StreamSlot));
+        }
+    }
+}
+
+int stream_pool_alloc(const StreamVTable *vt, void *ctx, StreamCaps caps)
+{
+    if (!vt) return -1;
+    ensure_pool_inited();
+    cando_os_mutex_lock(&g_stream_pool_mutex);
+    int idx = -1;
+    for (int i = 0; i < STREAM_MAX_INSTANCES; i++) {
+        if (!g_stream_pool[i].in_use) {
+            memset(&g_stream_pool[i], 0, sizeof(StreamSlot));
+            g_stream_pool[i].in_use = true;
+            g_stream_pool[i].vt     = vt;
+            g_stream_pool[i].ctx    = ctx;
+            g_stream_pool[i].caps   = caps;
+            cando_lock_init(&g_stream_pool[i].lock);
+            atomic_store(&g_stream_pool[i].closed,      false);
+            atomic_store(&g_stream_pool[i].write_ended, false);
+            atomic_store(&g_stream_pool[i].bytes_in,    0);
+            atomic_store(&g_stream_pool[i].bytes_out,   0);
+            idx = i;
+            break;
+        }
+    }
+    cando_os_mutex_unlock(&g_stream_pool_mutex);
+    return idx;
+}
+
+StreamSlot *stream_pool_get(int idx)
+{
+    if (idx < 0 || idx >= STREAM_MAX_INSTANCES) return NULL;
+    if (!g_stream_pool[idx].in_use) return NULL;
+    return &g_stream_pool[idx];
+}
+
+void stream_pool_release(int idx)
+{
+    if (idx < 0 || idx >= STREAM_MAX_INSTANCES) return;
+    cando_os_mutex_lock(&g_stream_pool_mutex);
+    StreamSlot *s = &g_stream_pool[idx];
+    if (!s->in_use) {
+        cando_os_mutex_unlock(&g_stream_pool_mutex);
+        return;
+    }
+    /* Mark closed before destroying so any concurrent observer sees it.
+     * The pool mutex serialises against further alloc/release; the per-slot
+     * R/W lock is intentionally bypassed because destroy() must be free to
+     * tear down the underlying handle without a deadlock. */
+    atomic_store(&s->closed,      true);
+    atomic_store(&s->write_ended, true);
+    if (s->vt && s->vt->destroy) s->vt->destroy(s->ctx);
+    s->ctx    = NULL;
+    s->vt     = NULL;
+    s->in_use = false;
+    cando_os_mutex_unlock(&g_stream_pool_mutex);
+}
+
+void stream_set_error(StreamSlot *s, const char *msg)
+{
+    if (!s || !msg) return;
+    /* No lock needed: writers race only on the same byte range; readers may
+     * see a partial overwrite, which is acceptable for a diagnostic field. */
+    snprintf(s->last_err, sizeof(s->last_err), "%s", msg);
+}
+
+/* =========================================================================
+ * Field helpers (same shape as socket.c)
+ * ===================================================================== */
+
+static bool get_int_field(CdoObject *obj, const char *name, int *out)
+{
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    CdoValue   v   = cdo_null();
+    bool ok = cdo_object_rawget(obj, key, &v);
+    cdo_string_release(key);
+    if (!ok || v.tag != CDO_NUMBER) return false;
+    *out = (int)v.as.number;
+    return true;
+}
+
+static void set_num_field(CdoObject *obj, const char *name, f64 n)
+{
+    CdoString *key = cdo_string_intern(name, (u32)strlen(name));
+    cdo_object_rawset(obj, key, cdo_number(n), FIELD_NONE);
+    cdo_string_release(key);
+}
+
+/* =========================================================================
+ * Receiver resolution
+ * ===================================================================== */
+
+StreamSlot *stream_resolve_receiver(CandoVM *vm, CandoValue receiver)
+{
+    if (!cando_is_object(receiver)) return NULL;
+    CdoObject *obj = cando_bridge_resolve(vm, receiver.as.handle);
+    if (!obj) return NULL;
+    int idx = -1;
+    if (!get_int_field(obj, "__stream_id", &idx)) return NULL;
+    return stream_pool_get(idx);
+}
+
+CandoValue stream_create_instance(CandoVM *vm, int slot_idx)
+{
+    CandoValue val = cando_bridge_new_object(vm);
+    CdoObject *obj = cando_bridge_resolve(vm, val.as.handle);
+    set_num_field(obj, "__stream_id", (f64)slot_idx);
+    cando_lib_meta_attach(vm, obj, "stream");
+    return val;
+}
+
+/* =========================================================================
+ * Common method implementations
+ *
+ * Every method takes the slot's write lock for the duration of the vtable
+ * call.  This makes streams safe to share between parent and child VMs
+ * without each adapter having to re-implement locking.
+ * ===================================================================== */
+
+static StreamSlot *receiver_or_throw(CandoVM *vm, int argc, CandoValue *args,
+                                     const char *method)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    if (!s) {
+        cando_vm_error(vm, "%s: invalid stream receiver", method);
+        return NULL;
+    }
+    return s;
+}
+
+/*
+ * Helpers that bracket a single vtable call with the slot's R/W lock,
+ * honouring the adapter's `self_locked` opt-out.  Adapters that may block
+ * inside read/write (channel, full-duplex socket) MUST set self_locked or
+ * a blocked reader will hold the slot lock against any writer.
+ */
+static StreamStatus dispatch_read(StreamSlot *s, u8 *out, usize cap, usize *n_out)
+{
+    if (s->vt->self_locked) {
+        return s->vt->read(s->ctx, out, cap, n_out);
+    }
+    StreamStatus st;
+    CANDO_WITH_WRITE_LOCK(&s->lock) {
+        st = s->vt->read(s->ctx, out, cap, n_out);
+    }
+    return st;
+}
+
+static StreamStatus dispatch_write(StreamSlot *s, const u8 *buf, usize len,
+                                   usize *n_out)
+{
+    if (s->vt->self_locked) {
+        return s->vt->write(s->ctx, buf, len, n_out);
+    }
+    StreamStatus st;
+    CANDO_WITH_WRITE_LOCK(&s->lock) {
+        st = s->vt->write(s->ctx, buf, len, n_out);
+    }
+    return st;
+}
+
+/* stream:read(maxLen) -> string ("" on EOF) */
+static int stream_read_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = receiver_or_throw(vm, argc, args, "stream:read");
+    if (!s) return -1;
+    if (!(s->caps & STREAM_CAP_READABLE)) {
+        cando_vm_error(vm, "stream:read: not a readable stream");
+        return -1;
+    }
+    if (atomic_load(&s->closed)) {
+        libutil_push_str(vm, "", 0);
+        return 1;
+    }
+    int maxlen = (int)libutil_arg_num_at(args, argc, 1, 4096);
+    if (maxlen <= 0) {
+        cando_vm_error(vm, "stream:read: maxLen must be positive");
+        return -1;
+    }
+    if (maxlen > 16 * 1024 * 1024) maxlen = 16 * 1024 * 1024;
+
+    u8 *buf = (u8 *)cando_alloc((usize)maxlen);
+    usize n = 0;
+    StreamStatus st = dispatch_read(s, buf, (usize)maxlen, &n);
+
+    if (st == STREAM_ERR) {
+        cando_free(buf);
+        cando_vm_error(vm, "stream:read: %s",
+                       s->last_err[0] ? s->last_err : "read failed");
+        return -1;
+    }
+    /* STREAM_AGAIN with n == 0 surfaces as "" — matches socket recv contract. */
+    atomic_fetch_add(&s->bytes_in, (u64)n);
+    libutil_push_str(vm, (const char *)buf, (u32)n);
+    cando_free(buf);
+    return 1;
+}
+
+/* stream:readAll() -> string (drain to EOF) */
+static int stream_readAll_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = receiver_or_throw(vm, argc, args, "stream:readAll");
+    if (!s) return -1;
+    if (!(s->caps & STREAM_CAP_READABLE)) {
+        cando_vm_error(vm, "stream:readAll: not a readable stream");
+        return -1;
+    }
+    usize cap = 4096, len = 0;
+    u8   *buf = (u8 *)cando_alloc(cap);
+    while (!atomic_load(&s->closed)) {
+        if (len + 4096 > cap) {
+            usize ncap = cap * 2;
+            buf = (u8 *)cando_realloc(buf, ncap);
+            cap = ncap;
+        }
+        usize n = 0;
+        StreamStatus st = dispatch_read(s, buf + len, 4096, &n);
+        if (st == STREAM_ERR) {
+            cando_free(buf);
+            cando_vm_error(vm, "stream:readAll: %s",
+                           s->last_err[0] ? s->last_err : "read failed");
+            return -1;
+        }
+        len += n;
+        if (st == STREAM_EOF) break;
+        if (st == STREAM_AGAIN && n == 0) break;
+    }
+    atomic_fetch_add(&s->bytes_in, (u64)len);
+    libutil_push_str(vm, (const char *)buf, (u32)len);
+    cando_free(buf);
+    return 1;
+}
+
+/* stream:write(data) -> bytesWritten */
+static int stream_write_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = receiver_or_throw(vm, argc, args, "stream:write");
+    if (!s) return -1;
+    if (!(s->caps & STREAM_CAP_WRITABLE)) {
+        cando_vm_error(vm, "stream:write: not a writable stream");
+        return -1;
+    }
+    if (atomic_load(&s->write_ended) || atomic_load(&s->closed)) {
+        cando_vm_error(vm, "stream:write: write side is closed");
+        return -1;
+    }
+    CandoString *data = libutil_arg_str_at(args, argc, 1);
+    if (!data) {
+        cando_vm_error(vm, "stream:write: expected string");
+        return -1;
+    }
+    usize n = 0;
+    StreamStatus st = dispatch_write(s, (const u8 *)data->data,
+                                     data->length, &n);
+    if (st == STREAM_ERR) {
+        cando_vm_error(vm, "stream:write: %s",
+                       s->last_err[0] ? s->last_err : "write failed");
+        return -1;
+    }
+    atomic_fetch_add(&s->bytes_out, (u64)n);
+    cando_vm_push(vm, cando_number((f64)n));
+    return 1;
+}
+
+/* stream:writeAll(data) -> self  (loops until all bytes consumed) */
+static int stream_writeAll_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = receiver_or_throw(vm, argc, args, "stream:writeAll");
+    if (!s) return -1;
+    if (!(s->caps & STREAM_CAP_WRITABLE)) {
+        cando_vm_error(vm, "stream:writeAll: not a writable stream");
+        return -1;
+    }
+    if (atomic_load(&s->write_ended) || atomic_load(&s->closed)) {
+        cando_vm_error(vm, "stream:writeAll: write side is closed");
+        return -1;
+    }
+    CandoString *data = libutil_arg_str_at(args, argc, 1);
+    if (!data) {
+        cando_vm_error(vm, "stream:writeAll: expected string");
+        return -1;
+    }
+    usize off = 0;
+    while (off < data->length) {
+        usize n = 0;
+        StreamStatus st = dispatch_write(s, (const u8 *)data->data + off,
+                                         data->length - off, &n);
+        if (st == STREAM_ERR) {
+            cando_vm_error(vm, "stream:writeAll: %s",
+                           s->last_err[0] ? s->last_err : "write failed");
+            return -1;
+        }
+        off += n;
+        if (st == STREAM_EOF) break;
+        if (n == 0 && st != STREAM_AGAIN) break;
+    }
+    atomic_fetch_add(&s->bytes_out, (u64)off);
+    cando_vm_push(vm, args[0]);
+    return 1;
+}
+
+/* stream:flush() -> self */
+static int stream_flush_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = receiver_or_throw(vm, argc, args, "stream:flush");
+    if (!s) return -1;
+    if (s->vt->flush) {
+        StreamStatus st;
+        if (s->vt->self_locked) {
+            st = s->vt->flush(s->ctx);
+        } else {
+            CANDO_WITH_WRITE_LOCK(&s->lock) { st = s->vt->flush(s->ctx); }
+        }
+        if (st == STREAM_ERR) {
+            cando_vm_error(vm, "stream:flush: %s",
+                           s->last_err[0] ? s->last_err : "flush failed");
+            return -1;
+        }
+    }
+    cando_vm_push(vm, args[0]);
+    return 1;
+}
+
+/* stream:end() -> self  (half-close write side) */
+static int stream_end_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = receiver_or_throw(vm, argc, args, "stream:end");
+    if (!s) return -1;
+    bool was = atomic_exchange(&s->write_ended, true);
+    if (!was && s->vt->end) {
+        StreamStatus st;
+        if (s->vt->self_locked) {
+            st = s->vt->end(s->ctx);
+        } else {
+            CANDO_WITH_WRITE_LOCK(&s->lock) { st = s->vt->end(s->ctx); }
+        }
+        if (st == STREAM_ERR) {
+            cando_vm_error(vm, "stream:end: %s",
+                           s->last_err[0] ? s->last_err : "end failed");
+            return -1;
+        }
+    }
+    cando_vm_push(vm, args[0]);
+    return 1;
+}
+
+/* stream:close() -> self  (full close, idempotent) */
+static int stream_close_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    if (s) {
+        /* Find the slot index so we can release through the pool API.  We
+         * have the pointer; recover the index by pointer arithmetic. */
+        int idx = (int)(s - g_stream_pool);
+        stream_pool_release(idx);
+    }
+    cando_vm_push(vm, argc > 0 ? args[0] : cando_null());
+    return 1;
+}
+
+/* stream:isClosed() -> bool */
+static int stream_isClosed_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    cando_vm_push(vm, cando_bool(!s || atomic_load(&s->closed)));
+    return 1;
+}
+
+/* stream:error() -> string ("" if no error) */
+static int stream_error_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    if (!s || s->last_err[0] == '\0') {
+        libutil_push_str(vm, "", 0);
+        return 1;
+    }
+    libutil_push_cstr(vm, s->last_err);
+    return 1;
+}
+
+/* stream:bytesIn() -> number */
+static int stream_bytesIn_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    cando_vm_push(vm, cando_number(s ? (f64)atomic_load(&s->bytes_in) : 0.0));
+    return 1;
+}
+
+/* stream:bytesOut() -> number */
+static int stream_bytesOut_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    cando_vm_push(vm, cando_number(s ? (f64)atomic_load(&s->bytes_out) : 0.0));
+    return 1;
+}
+
+/* stream:kind() -> string */
+static int stream_kind_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *s = stream_resolve_receiver(vm,
+                        argc > 0 ? args[0] : cando_null());
+    const char *name = (s && s->vt && s->vt->kind_name) ? s->vt->kind_name : "";
+    libutil_push_cstr(vm, name);
+    return 1;
+}
+
+/* =========================================================================
+ * Pipe driver
+ * ===================================================================== */
+
+int cando_stream_pipe(int src_idx, int dst_idx, usize chunk, u64 *copied)
+{
+    StreamSlot *src = stream_pool_get(src_idx);
+    StreamSlot *dst = stream_pool_get(dst_idx);
+    if (!src || !dst) return -1;
+    if (!(src->caps & STREAM_CAP_READABLE)) return -1;
+    if (!(dst->caps & STREAM_CAP_WRITABLE)) return -1;
+
+    /* Clamp chunk size: too small is wasteful, too large pins too much
+     * scratch RAM during long-running transfers. */
+    if (chunk == 0)              chunk = 64 * 1024;
+    if (chunk < 256)             chunk = 256;
+    if (chunk > 4 * 1024 * 1024) chunk = 4 * 1024 * 1024;
+
+    u8  *buf   = (u8 *)cando_alloc(chunk);
+    u64  total = 0;
+    int  rc    = 0;
+
+    while (!atomic_load(&src->closed) && !atomic_load(&dst->closed)) {
+        usize n = 0;
+        StreamStatus rs = dispatch_read(src, buf, chunk, &n);
+        if (rs == STREAM_ERR) { rc = -1; break; }
+        if (n > 0) {
+            atomic_fetch_add(&src->bytes_in, (u64)n);
+            usize off = 0;
+            bool  werr = false;
+            while (off < n) {
+                usize w = 0;
+                StreamStatus ws = dispatch_write(dst, buf + off, n - off, &w);
+                if (ws == STREAM_ERR) { werr = true; break; }
+                off += w;
+                /* For non-blocking sinks STREAM_AGAIN with no progress means
+                 * "stop trying"; fall through to the outer loop. */
+                if (w == 0 && ws == STREAM_AGAIN) break;
+                if (w == 0 && ws == STREAM_EOF)   break;
+            }
+            atomic_fetch_add(&dst->bytes_out, (u64)off);
+            total += off;
+            if (werr) { rc = -1; break; }
+        }
+        if (rs == STREAM_EOF)                 break;
+        if (rs == STREAM_AGAIN && n == 0)     break;
+    }
+
+    cando_free(buf);
+    if (copied) *copied = total;
+    return rc;
+}
+
+/* stream:pipeTo(dst [, opts]) -> bytesCopied
+ *
+ * Named `pipeTo` rather than `pipe` because `pipe` is a CanDo keyword (the
+ * implicit loop variable in `~>` pipe expressions) and isn't permitted
+ * after `:` in method-call syntax.
+ */
+static int stream_pipe_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    StreamSlot *src = receiver_or_throw(vm, argc, args, "stream:pipeTo");
+    if (!src) return -1;
+    if (argc < 2 || !cando_is_object(args[1])) {
+        cando_vm_error(vm, "stream:pipeTo: destination stream required");
+        return -1;
+    }
+    StreamSlot *dst = stream_resolve_receiver(vm, args[1]);
+    if (!dst) {
+        cando_vm_error(vm, "stream:pipeTo: invalid destination stream");
+        return -1;
+    }
+    if (!(src->caps & STREAM_CAP_READABLE)) {
+        cando_vm_error(vm, "stream:pipeTo: source is not readable");
+        return -1;
+    }
+    if (!(dst->caps & STREAM_CAP_WRITABLE)) {
+        cando_vm_error(vm, "stream:pipeTo: destination is not writable");
+        return -1;
+    }
+
+    usize chunk = 64 * 1024;
+    if (argc >= 3 && cando_is_object(args[2])) {
+        CdoObject *opts = cando_bridge_resolve(vm, args[2].as.handle);
+        int c = 0;
+        if (opts && get_int_field(opts, "chunk", &c) && c > 0) {
+            chunk = (usize)c;
+        }
+    }
+
+    int src_idx = (int)(src - g_stream_pool);
+    int dst_idx = (int)(dst - g_stream_pool);
+    u64 copied  = 0;
+    int rc = cando_stream_pipe(src_idx, dst_idx, chunk, &copied);
+    if (rc < 0) {
+        cando_vm_error(vm, "stream:pipeTo: %s",
+                       src->last_err[0] ? src->last_err :
+                       dst->last_err[0] ? dst->last_err : "pipe failed");
+        return -1;
+    }
+    cando_vm_push(vm, cando_number((f64)copied));
+    return 1;
+}
+
+/* =========================================================================
+ * In-memory adapter (`stream.memory`)
+ *
+ * Append-only growing byte buffer with a read cursor.  Reads consume from
+ * the cursor; writes append at the tail.  When the cursor catches up to
+ * the tail and `write_ended` is set, reads return EOF.
+ *
+ * This is single-process scratch storage; the per-slot R/W lock taken by
+ * the common methods makes it safe to use from a child VM.
+ * ===================================================================== */
+
+typedef struct MemCtx {
+    u8       *buf;
+    usize     cap;
+    usize     len;       /* total bytes ever written                  */
+    usize     read_pos;  /* read cursor; bytes 0..read_pos consumed   */
+    bool      write_ended;
+    StreamSlot *owner;   /* back-pointer for setting last_err         */
+} MemCtx;
+
+static void mem_compact_if_drained(MemCtx *m)
+{
+    /* If the reader has consumed everything, reset both cursors so the
+     * buffer doesn't grow without bound during long-running pipes. */
+    if (m->read_pos > 0 && m->read_pos == m->len) {
+        m->read_pos = 0;
+        m->len      = 0;
+    }
+}
+
+static StreamStatus mem_read(void *vctx, u8 *out, usize cap, usize *n_out)
+{
+    MemCtx *m = (MemCtx *)vctx;
+    usize avail = m->len - m->read_pos;
+    if (avail == 0) {
+        *n_out = 0;
+        return m->write_ended ? STREAM_EOF : STREAM_AGAIN;
+    }
+    usize n = cap < avail ? cap : avail;
+    memcpy(out, m->buf + m->read_pos, n);
+    m->read_pos += n;
+    *n_out = n;
+    mem_compact_if_drained(m);
+    return STREAM_OK;
+}
+
+static StreamStatus mem_write(void *vctx, const u8 *buf, usize len, usize *n_out)
+{
+    MemCtx *m = (MemCtx *)vctx;
+    if (m->write_ended) {
+        *n_out = 0;
+        stream_set_error(m->owner, "memory stream: write after end");
+        return STREAM_ERR;
+    }
+    /* Compact first so a steady-state pipe stays bounded by `cap`. */
+    mem_compact_if_drained(m);
+    if (m->len + len > m->cap) {
+        usize ncap = m->cap ? m->cap : 4096;
+        while (m->len + len > ncap) ncap *= 2;
+        m->buf = (u8 *)cando_realloc(m->buf, ncap);
+        m->cap = ncap;
+    }
+    memcpy(m->buf + m->len, buf, len);
+    m->len += len;
+    *n_out  = len;
+    return STREAM_OK;
+}
+
+static StreamStatus mem_end(void *vctx)
+{
+    MemCtx *m = (MemCtx *)vctx;
+    m->write_ended = true;
+    return STREAM_OK;
+}
+
+static void mem_destroy(void *vctx)
+{
+    MemCtx *m = (MemCtx *)vctx;
+    if (!m) return;
+    cando_free(m->buf);
+    cando_free(m);
+}
+
+static const StreamVTable g_mem_vt = {
+    .read       = mem_read,
+    .write      = mem_write,
+    .flush      = NULL,
+    .end        = mem_end,
+    .destroy    = mem_destroy,
+    .seek       = NULL,
+    .tell       = NULL,
+    .kind_name  = "memory",
+};
+
+/* =========================================================================
+ * Channel adapter (`stream.channel`)
+ *
+ * Bounded thread channel: a circular byte buffer guarded by one mutex and
+ * two condvars (`not_empty`, `not_full`).  The vtable is `self_locked` so
+ * a blocked reader/writer does not hold the slot lock against its peer.
+ *
+ * Lifecycle:
+ *   - read blocks while empty AND !write_ended; drains then returns EOF.
+ *   - write blocks while full AND !closed; errors after `:end()`.
+ *   - destroy wakes any waiter so close() / pool release returns promptly.
+ *
+ * The channel is by design the supported way to *transfer* bytes between
+ * VM threads — it has no underlying transport.
+ * ===================================================================== */
+
+typedef struct ChanCtx {
+    u8              *buf;
+    usize            cap;
+    usize            head;          /* read cursor                          */
+    usize            tail;          /* write cursor                         */
+    usize            len;           /* bytes available to read              */
+    bool             write_ended;
+    bool             destroyed;
+    cando_mutex_t    mu;
+    cando_cond_t     not_empty;
+    cando_cond_t     not_full;
+    StreamSlot      *owner;
+} ChanCtx;
+
+static StreamStatus chan_read(void *vctx, u8 *out, usize cap, usize *n_out)
+{
+    ChanCtx *c = (ChanCtx *)vctx;
+    cando_os_mutex_lock(&c->mu);
+    while (c->len == 0 && !c->write_ended && !c->destroyed) {
+        cando_os_cond_wait(&c->not_empty, &c->mu);
+    }
+    if (c->len == 0) {
+        cando_os_mutex_unlock(&c->mu);
+        *n_out = 0;
+        return c->destroyed ? STREAM_ERR : STREAM_EOF;
+    }
+    /* Copy out at most `cap` bytes, possibly wrapping around the ring. */
+    usize n = cap < c->len ? cap : c->len;
+    usize first = c->cap - c->head;
+    if (first > n) first = n;
+    memcpy(out, c->buf + c->head, first);
+    if (n > first) {
+        memcpy(out + first, c->buf, n - first);
+    }
+    c->head = (c->head + n) % c->cap;
+    c->len -= n;
+    cando_os_cond_broadcast(&c->not_full);
+    cando_os_mutex_unlock(&c->mu);
+    *n_out = n;
+    return STREAM_OK;
+}
+
+static StreamStatus chan_write(void *vctx, const u8 *buf, usize len, usize *n_out)
+{
+    ChanCtx *c = (ChanCtx *)vctx;
+    if (len == 0) { *n_out = 0; return STREAM_OK; }
+    cando_os_mutex_lock(&c->mu);
+    if (c->write_ended || c->destroyed) {
+        cando_os_mutex_unlock(&c->mu);
+        *n_out = 0;
+        stream_set_error(c->owner, "channel: write after end");
+        return STREAM_ERR;
+    }
+    /* Block until at least one byte of space is free.  We accept partial
+     * writes to drain whatever space is available immediately, matching
+     * the convention of the other adapters. */
+    while (c->len == c->cap && !c->destroyed && !c->write_ended) {
+        cando_os_cond_wait(&c->not_full, &c->mu);
+    }
+    if (c->destroyed || c->write_ended) {
+        cando_os_mutex_unlock(&c->mu);
+        *n_out = 0;
+        stream_set_error(c->owner, "channel: closed during write");
+        return STREAM_ERR;
+    }
+    usize free = c->cap - c->len;
+    usize n    = len < free ? len : free;
+    usize first = c->cap - c->tail;
+    if (first > n) first = n;
+    memcpy(c->buf + c->tail, buf, first);
+    if (n > first) {
+        memcpy(c->buf, buf + first, n - first);
+    }
+    c->tail = (c->tail + n) % c->cap;
+    c->len += n;
+    cando_os_cond_broadcast(&c->not_empty);
+    cando_os_mutex_unlock(&c->mu);
+    *n_out = n;
+    return STREAM_OK;
+}
+
+static StreamStatus chan_end(void *vctx)
+{
+    ChanCtx *c = (ChanCtx *)vctx;
+    cando_os_mutex_lock(&c->mu);
+    c->write_ended = true;
+    cando_os_cond_broadcast(&c->not_empty);
+    cando_os_cond_broadcast(&c->not_full);
+    cando_os_mutex_unlock(&c->mu);
+    return STREAM_OK;
+}
+
+static void chan_destroy(void *vctx)
+{
+    ChanCtx *c = (ChanCtx *)vctx;
+    if (!c) return;
+    /* Wake any waiter, then tear down.  Caller holds the pool mutex so no
+     * fresh read/write can enter once we're past the wakeup. */
+    cando_os_mutex_lock(&c->mu);
+    c->destroyed   = true;
+    c->write_ended = true;
+    cando_os_cond_broadcast(&c->not_empty);
+    cando_os_cond_broadcast(&c->not_full);
+    cando_os_mutex_unlock(&c->mu);
+    cando_os_cond_destroy(&c->not_empty);
+    cando_os_cond_destroy(&c->not_full);
+    cando_os_mutex_destroy(&c->mu);
+    cando_free(c->buf);
+    cando_free(c);
+}
+
+static const StreamVTable g_chan_vt = {
+    .read        = chan_read,
+    .write       = chan_write,
+    .flush       = NULL,
+    .end         = chan_end,
+    .destroy     = chan_destroy,
+    .seek        = NULL,
+    .tell        = NULL,
+    .kind_name   = "channel",
+    .self_locked = true,
+};
+
+/* stream.channel(capacity?) -> stream */
+static int mod_channel_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    usize cap = (usize)libutil_arg_num_at(args, argc, 0, 65536.0);
+    if (cap < 64)              cap = 64;
+    if (cap > 64 * 1024 * 1024) cap = 64 * 1024 * 1024;
+
+    ChanCtx *c = (ChanCtx *)cando_alloc(sizeof(ChanCtx));
+    memset(c, 0, sizeof(*c));
+    c->buf = (u8 *)cando_alloc(cap);
+    c->cap = cap;
+    cando_os_mutex_init(&c->mu);
+    cando_os_cond_init(&c->not_empty);
+    cando_os_cond_init(&c->not_full);
+
+    int idx = stream_pool_alloc(&g_chan_vt, c, STREAM_CAP_DUPLEX);
+    if (idx < 0) {
+        cando_os_cond_destroy(&c->not_empty);
+        cando_os_cond_destroy(&c->not_full);
+        cando_os_mutex_destroy(&c->mu);
+        cando_free(c->buf);
+        cando_free(c);
+        cando_vm_error(vm, "stream.channel: too many active streams");
+        return -1;
+    }
+    c->owner = stream_pool_get(idx);
+    cando_vm_push(vm, stream_create_instance(vm, idx));
+    return 1;
+}
+
+/* Public helper: build a pre-filled, write-ended memory stream.  See
+ * stream.h for the contract. */
+CandoValue cando_stream_from_bytes(CandoVM *vm, const void *data, usize len)
+{
+    usize cap = len > 0 ? len : 64;
+
+    MemCtx *m = (MemCtx *)cando_alloc(sizeof(MemCtx));
+    memset(m, 0, sizeof(*m));
+    m->buf = (u8 *)cando_alloc(cap);
+    m->cap = cap;
+    if (len > 0) {
+        memcpy(m->buf, data, len);
+        m->len = len;
+    }
+    m->write_ended = true;          /* read-only view */
+
+    int idx = stream_pool_alloc(&g_mem_vt, m, STREAM_CAP_READABLE);
+    if (idx < 0) {
+        cando_free(m->buf);
+        cando_free(m);
+        return cando_null();
+    }
+    m->owner = stream_pool_get(idx);
+    return stream_create_instance(vm, idx);
+}
+
+/* stream.memory(initialBytes?) -> stream */
+static int mod_memory_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    usize initial = (usize)libutil_arg_num_at(args, argc, 0, 4096.0);
+    if (initial < 64) initial = 64;
+    if (initial > 64 * 1024 * 1024) initial = 64 * 1024 * 1024;
+
+    MemCtx *m = (MemCtx *)cando_alloc(sizeof(MemCtx));
+    memset(m, 0, sizeof(*m));
+    m->buf = (u8 *)cando_alloc(initial);
+    m->cap = initial;
+
+    int idx = stream_pool_alloc(&g_mem_vt, m, STREAM_CAP_DUPLEX);
+    if (idx < 0) {
+        cando_free(m->buf);
+        cando_free(m);
+        cando_vm_error(vm, "stream.memory: too many active streams");
+        return -1;
+    }
+    /* Wire the back-pointer so mem_write can record errors on the slot. */
+    m->owner = stream_pool_get(idx);
+    cando_vm_push(vm, stream_create_instance(vm, idx));
+    return 1;
+}
+
+/* =========================================================================
+ * Registration
+ * ===================================================================== */
+
+static void define_meta(CandoVM *vm, CdoObject *tbl)
+{
+    if (!tbl) return;
+    cando_lib_meta_define(vm, tbl, "read",      stream_read_fn);
+    cando_lib_meta_define(vm, tbl, "readAll",   stream_readAll_fn);
+    cando_lib_meta_define(vm, tbl, "write",     stream_write_fn);
+    cando_lib_meta_define(vm, tbl, "writeAll",  stream_writeAll_fn);
+    cando_lib_meta_define(vm, tbl, "flush",     stream_flush_fn);
+    cando_lib_meta_define(vm, tbl, "end",       stream_end_fn);
+    cando_lib_meta_define(vm, tbl, "close",     stream_close_fn);
+    cando_lib_meta_define(vm, tbl, "isClosed",  stream_isClosed_fn);
+    cando_lib_meta_define(vm, tbl, "error",     stream_error_fn);
+    cando_lib_meta_define(vm, tbl, "bytesIn",   stream_bytesIn_fn);
+    cando_lib_meta_define(vm, tbl, "bytesOut",  stream_bytesOut_fn);
+    cando_lib_meta_define(vm, tbl, "kind",      stream_kind_fn);
+    cando_lib_meta_define(vm, tbl, "pipeTo",    stream_pipe_fn);
+}
+
+void cando_lib_stream_register(CandoVM *vm)
+{
+    ensure_pool_inited();
+    cando_lib_meta_register(vm);
+
+    /* Module globals. */
+    CandoValue mod_val = cando_bridge_new_object(vm);
+    CdoObject *mod_obj = cando_bridge_resolve(vm, mod_val.as.handle);
+    libutil_set_method(vm, mod_obj, "memory",  mod_memory_fn);
+    libutil_set_method(vm, mod_obj, "channel", mod_channel_fn);
+    cando_vm_set_global(vm, "stream", mod_val, true);
+
+    /* Meta table for every stream instance. */
+    CdoObject *meta = cando_lib_meta_table(vm, "stream");
+    define_meta(vm, meta);
+}

--- a/source/lib/stream.h
+++ b/source/lib/stream.h
@@ -1,0 +1,204 @@
+/*
+ * lib/stream.h -- Unified streaming subsystem for CanDo.
+ *
+ * A `Stream` is a vtable-backed handle for byte-oriented I/O.  Adapters wrap
+ * concrete transports (in-memory buffer, file, TCP/TLS socket, HTTP body,
+ * process pipe, thread channel) behind a single interface so any source can
+ * be `:pipe()`d into any sink.
+ *
+ * Slot pool / instance pattern mirrors `socket.c` exactly: a global pool
+ * holds the C-side state, the script sees a CdoObject with a hidden
+ * `__stream_id` field and a meta table of native methods.
+ *
+ * This step (step 1) registers the global `stream` object with the
+ * in-memory adapter only:
+ *
+ *   stream.memory(initialBytes?)        -- duplex in-memory buffer
+ *
+ *   s:read(maxLen)        -- string ("" on EOF)
+ *   s:readAll()           -- drain to EOF
+ *   s:write(data)         -- bytes consumed
+ *   s:writeAll(data)      -- loops until done
+ *   s:flush()             -- adapter-defined
+ *   s:end()               -- half-close write side
+ *   s:close()             -- full close (idempotent)
+ *   s:isClosed() / :error() / :bytesIn() / :bytesOut() / :kind()
+ *
+ * Subsequent steps add file/socket/http/process adapters and the pipe
+ * driver; the public types declared here are stable across those steps.
+ *
+ * Must compile with gcc -std=c11.
+ */
+
+#ifndef CANDO_LIB_STREAM_H
+#define CANDO_LIB_STREAM_H
+
+#include "../vm/vm.h"
+#include "../object/object.h"
+#include "../core/lock.h"
+
+#include <stdatomic.h>
+
+/* =========================================================================
+ * Public registration
+ * ===================================================================== */
+
+CANDO_API void cando_lib_stream_register(CandoVM *vm);
+
+/* =========================================================================
+ * Capability flags and status codes
+ * ===================================================================== */
+
+typedef enum StreamCaps {
+    STREAM_CAP_READABLE = 1u << 0,
+    STREAM_CAP_WRITABLE = 1u << 1,
+    STREAM_CAP_SEEKABLE = 1u << 2,
+    STREAM_CAP_DUPLEX   = STREAM_CAP_READABLE | STREAM_CAP_WRITABLE,
+} StreamCaps;
+
+typedef enum StreamStatus {
+    STREAM_OK    = 0,   /* op succeeded; *n_out has byte count                */
+    STREAM_AGAIN = 1,   /* would-block; non-blocking sources only             */
+    STREAM_EOF   = 2,   /* clean end-of-stream; *n_out may be > 0             */
+    STREAM_ERR   = 3,   /* unrecoverable error; ctx.last_err carries detail   */
+} StreamStatus;
+
+/* =========================================================================
+ * Adapter vtable
+ *
+ * Every adapter populates one of these.  read/write/destroy are required
+ * for any practical stream; flush/end/seek/tell are optional (NULL means
+ * "not supported" and the script call is a no-op or error).
+ * ===================================================================== */
+
+typedef struct StreamVTable {
+    /* Read up to `cap` bytes into `out`.  *n_out receives the byte count.
+     * STREAM_EOF may be returned with n_out == 0 to indicate clean EOF. */
+    StreamStatus (*read)(void *ctx, u8 *out, usize cap, usize *n_out);
+
+    /* Write up to `len` bytes from `buf`.  *n_out receives bytes consumed. */
+    StreamStatus (*write)(void *ctx, const u8 *buf, usize len, usize *n_out);
+
+    /* Optional: flush adapter-internal buffers to underlying transport. */
+    StreamStatus (*flush)(void *ctx);
+
+    /* Optional: half-close the write side. */
+    StreamStatus (*end)(void *ctx);
+
+    /* Free `ctx` and underlying handle.  Required.  Idempotent. */
+    void         (*destroy)(void *ctx);
+
+    /* Optional: seekable streams.  whence: 0=SEEK_SET, 1=SEEK_CUR, 2=SEEK_END. */
+    StreamStatus (*seek)(void *ctx, i64 off, int whence);
+    i64          (*tell)(void *ctx);
+
+    const char *kind_name;          /* "memory", "file", "tcp", … */
+
+    /* When true the common methods (read/write/etc.) do NOT acquire the
+     * slot's R/W lock around the vtable call; the adapter is responsible
+     * for its own concurrency.  Required for any adapter that may *block*
+     * inside read/write (channel, full-duplex socket) — otherwise a blocked
+     * reader would hold the lock against any writer and deadlock. */
+    bool self_locked;
+} StreamVTable;
+
+/* =========================================================================
+ * Slot
+ *
+ * Pool element.  `lock` serialises read/write across VMs; `closed` is the
+ * one-shot lifecycle flag (set by close()).  `bytes_in`/`bytes_out` are
+ * advisory counters readable from script for diagnostics.
+ * ===================================================================== */
+
+#define STREAM_MAX_INSTANCES 256
+
+typedef struct StreamSlot {
+    bool                in_use;
+    StreamCaps          caps;
+    const StreamVTable *vt;
+    void               *ctx;
+    CandoLockHeader     lock;
+    _Atomic(bool)       closed;
+    _Atomic(bool)       write_ended;
+    _Atomic(u64)        bytes_in;
+    _Atomic(u64)        bytes_out;
+    char                last_err[128];
+} StreamSlot;
+
+/* =========================================================================
+ * Pool API (used by every adapter, including those defined in other
+ * library files in subsequent steps).
+ * ===================================================================== */
+
+/*
+ * stream_pool_alloc -- reserve a slot, store vt+ctx+caps, zero counters.
+ * Returns slot index in [0, STREAM_MAX_INSTANCES) or -1 on exhaustion.
+ *
+ * The slot takes ownership of `ctx`; on stream_pool_release the vtable's
+ * destroy() is invoked.
+ */
+int  stream_pool_alloc(const StreamVTable *vt, void *ctx, StreamCaps caps);
+
+/*
+ * stream_pool_get -- index → StreamSlot*.  Returns NULL if `idx` is out of
+ * range or the slot is no longer in use.
+ */
+StreamSlot *stream_pool_get(int idx);
+
+/*
+ * stream_pool_release -- mark `closed`, call vt->destroy(ctx), free the
+ * slot for reuse.  Idempotent.
+ */
+void stream_pool_release(int idx);
+
+/*
+ * stream_resolve_receiver -- given a method receiver, return the underlying
+ * StreamSlot.  Returns NULL if `receiver` is not a stream object.
+ */
+StreamSlot *stream_resolve_receiver(CandoVM *vm, CandoValue receiver);
+
+/*
+ * stream_create_instance -- build a CdoObject with hidden `__stream_id` and
+ * meta-table `_meta.stream`, returning the script-visible value.
+ */
+CandoValue stream_create_instance(CandoVM *vm, int slot_idx);
+
+/*
+ * stream_set_error -- copy a message into the slot's last_err buffer; safe
+ * to call from any thread.  Truncates to fit.
+ */
+void stream_set_error(StreamSlot *s, const char *msg);
+
+/* =========================================================================
+ * Convenience: build a read-only memory stream pre-filled with `data`.
+ *
+ * Used by adapters that already have the bytes in memory (e.g. an HTTP
+ * client response body) so the caller can hand a uniform stream object
+ * back to script even when the underlying transport doesn't support real
+ * streaming.  The returned stream is already `:end()`-ed; the next read
+ * past the data returns clean EOF.
+ *
+ * Pushes nothing onto the VM stack — the caller does that.  Returns the
+ * CandoValue for the new stream, or cando_null() on pool exhaustion.
+ * ===================================================================== */
+CandoValue cando_stream_from_bytes(CandoVM *vm, const void *data, usize len);
+
+/* =========================================================================
+ * Pipe driver
+ *
+ * Drains `src` into `dst` in `chunk`-sized hops until src signals EOF (or
+ * either side closes / errors).  Backpressure is automatic — `dst->write`
+ * blocks the loop until the sink consumes.
+ *
+ * Each chunk-read and chunk-write brackets its own R/W lock acquire/release
+ * so two concurrent pipes on disjoint endpoints cannot deadlock.
+ *
+ * Returns 0 on success, -1 on I/O error.  *copied (if non-NULL) receives
+ * the total byte count.
+ *
+ * To run a pipe off-thread, scripts use the existing `thread { … }` syntax
+ * — there is no async variant in C.
+ * ===================================================================== */
+int cando_stream_pipe(int src_idx, int dst_idx, usize chunk, u64 *copied);
+
+#endif /* CANDO_LIB_STREAM_H */

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -148,6 +148,9 @@ run_test "lib_socket" "$SCRIPTS/lib_socket.cdo" \
 run_test "lib_secure_socket" "$SCRIPTS/lib_secure_socket.cdo" \
     "$(printf 'after listen\ntls-echo:hello\ntrue\ntrue\ndone')"
 
+run_test "lib_stream" "$SCRIPTS/lib_stream.cdo" \
+    "$(printf 'memory\nhello, world\n'\'''\''\nfalse\n1600\n1600\n1600\nfinal\n'\'''\''\ntrue\nfile\nalpha-bravo\n'\'''\''\nthrew\n20\npiped through memory\n29\nCanDo streams compose nicely.\nfrom thread\nchannel\nhello-from-channel\ntcp\nECHO:hello\nfile-piped-as-response\npayload-from-http\n0\nspawned-output\n800\nok')"
+
 run_test "lib_crypto" "$SCRIPTS/lib_crypto.cdo" \
     "$(printf 'md5_ok\nsha256_ok\naGVsbG8gd29ybGQA\nhello world')"
 

--- a/tests/scripts/lib_stream.cdo
+++ b/tests/scripts/lib_stream.cdo
@@ -1,0 +1,211 @@
+/* lib_stream.cdo -- Integration tests for the unified `stream` library
+ * (step 1: in-memory adapter only).
+ *
+ * Verifies the minimal contract every adapter must satisfy:
+ *   - duplex read/write round-trip
+ *   - growth past initial capacity
+ *   - byte counters
+ *   - `:end()` flips reads from "would-block" (empty) to clean EOF
+ *   - `:close()` is idempotent and flips `:isClosed()`
+ *   - `:kind()` reports the adapter name
+ *
+ * Expected output is registered in tests/integration/run_tests.sh.
+ */
+
+/* ---- 1. Round-trip: write then read --------------------------------- */
+VAR s = stream.memory();
+print(s:kind());                    /* expected: memory */
+s:writeAll("hello, ");
+s:writeAll("world");
+print(s:read(64));                  /* expected: hello, world */
+
+/* ---- 2. Reading an empty (still-open) stream returns "" ------------- */
+print("'" + s:read(64) + "'");      /* expected: '' */
+print(s:isClosed());                /* expected: false */
+
+/* ---- 3. Growth past initial capacity -------------------------------- */
+VAR big = stream.memory(64);
+VAR chunk = "0123456789ABCDEF";    /* 16 bytes */
+FOR i OF 1 -> 100 { big:writeAll(chunk); }
+VAR drained = big:readAll();
+print(drained:length());            /* expected: 1600 */
+
+/* ---- 4. Byte counters -- bytesIn counts reads, bytesOut counts writes */
+print(big:bytesIn());               /* expected: 1600 */
+print(big:bytesOut());              /* expected: 1600 */
+
+/* ---- 5. :end() makes the next empty read return EOF -- here the script
+ *        observes EOF as readAll returning the rest and not blocking.    */
+VAR done = stream.memory();
+done:writeAll("final");
+done:end();
+print(done:readAll());              /* expected: final */
+/* After EOF a subsequent readAll still returns "" without throwing. */
+print("'" + done:readAll() + "'");  /* expected: '' */
+
+/* ---- 6. close() is idempotent -------------------------------------- */
+s:close();
+s:close();                          /* second call must be a no-op */
+print(s:isClosed());                /* expected: true */
+
+/* ---- 7. file.open round-trip --------------------------------------- */
+VAR tmpath = "/tmp/cando_stream_test.bin";
+file.delete(tmpath);
+
+VAR w = file.open(tmpath, "wb");
+print(w:kind());                    /* expected: file */
+w:writeAll("alpha-");
+w:writeAll("bravo");
+w:close();
+
+VAR r = file.open(tmpath, "rb");
+print(r:read(64));                  /* expected: alpha-bravo */
+print("'" + r:read(64) + "'");      /* expected: '' (EOF -> "") */
+r:close();
+
+/* ---- 8. file write throws after close ------------------------------ */
+VAR w2 = file.open(tmpath, "wb");
+w2:close();
+TRY {
+    w2:write("nope");
+    print("no-throw");
+} CATCH (e) {
+    print("threw");                 /* expected: threw */
+}
+
+file.delete(tmpath);
+
+/* ---- 9. mem -> mem pipe -------------------------------------------- */
+VAR p_src = stream.memory();
+VAR p_dst = stream.memory();
+p_src:writeAll("piped through memory");
+p_src:end();
+print(p_src:pipeTo(p_dst));           /* expected: 21 */
+print(p_dst:readAll());             /* expected: piped through memory */
+
+/* ---- 10. file -> mem pipe with custom chunk size ------------------- */
+VAR fpath = "/tmp/cando_stream_pipe.bin";
+file.delete(fpath);
+VAR fw = file.open(fpath, "wb");
+fw:writeAll("CanDo streams compose nicely.");
+fw:close();
+
+VAR fr = file.open(fpath, "rb");
+VAR sink = stream.memory();
+print(fr:pipeTo(sink, { chunk: 8 })); /* expected: 29 */
+fr:close();
+print(sink:readAll());              /* expected: CanDo streams compose nicely. */
+file.delete(fpath);
+
+/* ---- 11. pipe in a thread (off-main using existing thread syntax) -- */
+VAR src2 = stream.memory();
+VAR dst2 = stream.memory();
+src2:writeAll("from thread");
+src2:end();
+VAR t = thread { src2:pipeTo(dst2); };
+thread.join(t);
+print(dst2:readAll());              /* expected: from thread */
+
+/* ---- 12. channel: producer thread -> main thread reader ------------ */
+VAR ch = stream.channel(64);
+print(ch:kind());                   /* expected: channel */
+VAR producer = thread {
+    ch:writeAll("hello-from-channel");
+    ch:end();
+};
+print(ch:readAll());                /* expected: hello-from-channel */
+thread.join(producer);
+
+/* ---- 13a. tcp socket adapter: client send → server stream → echo back ---
+ *         Server reads via :stream():read into a sink buffer, then echoes
+ *         the bytes back over the same socket stream.  Verifies the
+ *         tcp_socket:stream() adapter is full-duplex (self-locked).      */
+VAR srv = socket.createServer(FUNCTION(conn) {
+    VAR cs   = conn:stream();
+    VAR sink = stream.memory();
+    /* Read until the client half-closes via shutdown of its side.  Since
+     * we don't have shutdown() in scripts, use a length-prefixed protocol
+     * instead: read exactly 5 bytes, echo them back. */
+    VAR data = cs:read(5);
+    cs:write("ECHO:" + data);
+    conn:close();
+});
+srv:listen(18901);
+thread.sleep(50);
+
+VAR cli  = socket.connect("127.0.0.1", 18901);
+VAR cls  = cli:stream();
+print(cls:kind());                  /* expected: tcp */
+cls:write("hello");
+print(cli:recvAll());               /* expected: ECHO:hello */
+cli:close();
+srv:close();
+
+/* ---- 13c. server `res:stream()` writes accumulated body on :end() --
+ *         Server reads a file via stream and pipes it directly into the
+ *         response stream — never materialising the body as a script
+ *         string.  Verifies the duplex http_response adapter.          */
+VAR src_path = "/tmp/cando_stream_src.bin";
+file.delete(src_path);
+VAR fw_src = file.open(src_path, "wb");
+fw_src:writeAll("file-piped-as-response");
+fw_src:close();
+
+VAR ssrv = http.createServer(FUNCTION(req, res) {
+    VAR f  = file.open(src_path, "rb");
+    VAR rs = res:stream();          /* one stream, reused for end()  */
+    f:pipeTo(rs);
+    rs:end();                       /* flush the buffered response   */
+    f:close();
+});
+ssrv:listen(18793);
+
+VAR resp2 = fetch("http://127.0.0.1:18793/");
+print(resp2.body);                  /* expected: file-piped-as-response */
+ssrv:close();
+file.delete(src_path);
+
+/* ---- 13b. http client response :stream() into a file ---------------
+ *         Server returns a fixed body; client pipes it via stream into
+ *         a file, then reads the file back to verify.                  */
+VAR hsrv = http.createServer(FUNCTION(req, res) {
+    res:status(200);
+    res:send("payload-from-http");
+});
+hsrv:listen(18792);
+
+VAR resp = fetch("http://127.0.0.1:18792/");
+VAR sink_path = "/tmp/cando_stream_http.bin";
+file.delete(sink_path);
+VAR fout = file.open(sink_path, "wb");
+resp:stream():pipeTo(fout);
+fout:close();
+print(file.read(sink_path));        /* expected: payload-from-http */
+file.delete(sink_path);
+hsrv:close();
+
+/* ---- 13d. process.spawn: pipe a child's stdout into a memory stream ---
+ *         `printf` (POSIX) writes deterministic bytes; we capture them
+ *         via the proc:stdout() stream and verify the round-trip.      */
+VAR proc = process.spawn(["printf", "spawned-output"],
+                         { stdout: "pipe" });
+VAR captured = stream.memory();
+proc:stdout():pipeTo(captured);
+VAR rc = proc:wait();
+print(rc);                          /* expected: 0 */
+print(captured:readAll());          /* expected: spawned-output */
+
+/* ---- 13. channel backpressure: small cap forces producer to block --
+ *        Total payload is 800 bytes; cap is 64 -- producer must block
+ *        repeatedly until reader drains.                              */
+VAR small = stream.channel(64);
+VAR collected = stream.memory();
+VAR p2 = thread {
+    FOR i OF 1 -> 50 { small:writeAll("0123456789ABCDEF"); }
+    small:end();
+};
+small:pipeTo(collected);
+thread.join(p2);
+print(collected:readAll():length());   /* expected: 800 */
+
+print("ok");                        /* expected: ok */


### PR DESCRIPTION
## Summary

Introduces a unified byte-oriented I/O abstraction (`stream`) that provides a single vtable-based interface for reading, writing, and piping data across different transports. This is step 1 of the streaming subsystem, implementing the core pool/slot infrastructure and in-memory + file adapters.

## Key Changes

- **New `lib/stream.h` and `lib/stream.c`**: Core streaming subsystem with:
  - Global pool of `StreamSlot` instances (mirrors `socket.c` pattern)
  - Mutex-guarded alloc/free and per-slot R/W locking
  - Common method implementations (`:read`, `:write`, `:readAll`, `:writeAll`, `:flush`, `:end`, `:close`, `:pipeTo`)
  - Capability flags (`STREAM_CAP_READABLE`, `STREAM_CAP_WRITABLE`, `STREAM_CAP_SEEKABLE`)
  - Status codes (`STREAM_OK`, `STREAM_AGAIN`, `STREAM_EOF`, `STREAM_ERR`)
  - In-memory adapter (`stream.memory()`) with dynamic buffer growth
  - Byte counters and error tracking

- **File streaming adapter** (`lib/file.c`):
  - `file.open(path, mode)` returns a stream-backed FILE handle
  - Supports standard modes: `r`/`w`/`a` with optional `b` (binary) and `+` (read+write)
  - Implements seek/tell for seekable streams
  - Integrates with the unified stream API

- **Process streaming integration** (`lib/process.c`):
  - `process.spawn(argv, opts)` now returns a `proc` object with piped stdio
  - `proc:stdin()`, `proc:stdout()`, `proc:stderr()` return streams (when opened with `"pipe"`)
  - Caches stream instances so repeated calls return the same underlying stream
  - POSIX-only implementation (fork/exec with pipe setup)

- **Socket streaming adapter** (`lib/socket.c`):
  - `tcp_socket:stream()` wraps an existing socket behind the stream vtable
  - Full-duplex with `self_locked = true` to avoid blocking readers holding locks
  - Does not own the underlying socket (parent retains ownership)

- **HTTP response streaming** (`lib/http.c`):
  - `res:stream()` returns a writable stream that buffers body bytes
  - Sends the full response on `:end()` with automatic Content-Length

- **Pipe driver** (`cando_stream_pipe`):
  - Blocking copy from source to destination stream
  - Configurable chunk size with sensible defaults (64 KiB)
  - Automatic backpressure handling

- **Integration**:
  - Updated `cando_lib.c` to register the stream library
  - Updated build files (CMakeLists.txt, Makefile)
  - Added comprehensive integration tests (`tests/scripts/lib_stream.cdo`)
  - Added user documentation (`docs/streaming.md`)

## Notable Implementation Details

- **Thread-safe sharing**: Streams can be safely passed between parent and child VMs; the pool slot is guarded by mutex and per-slot R/W locks
- **Adapter opt-out**: Adapters that may block (channels, full-duplex sockets) set `self_locked = true` to manage their own locking
- **Idempotent close**: `:close()` is safe to call multiple times
- **Clean EOF contract**: `:read()` returns `""` on clean EOF; `:pipeTo()` stops without error
- **Error handling**: I/O failures raise exceptions; diagnostic messages stored in `last_err` field
- **Byte accounting**: Atomic counters track bytes in/out for monitoring

https://claude.ai/code/session_01BrTYVbHrADbVj8fqHXFezk