### PR TITLE
Add streaming HTTP and process support, transform streams

### DIFF
--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -330,7 +330,7 @@ proper `strptime` shim is available.
 |---|---|
 | `process.pid() → number` | Current process ID. |
 | `process.ppid() → number` | Parent process ID. |
-| `process.spawn(argv [, opts]) → proc` | Spawn a child process (POSIX only).  `opts.stdin` / `opts.stdout` / `opts.stderr` are `"inherit"` (default), `"pipe"`, or `"null"`.  `opts.cwd` sets the child's working directory. |
+| `process.spawn(argv [, opts]) → proc` | Spawn a child process (POSIX `fork+exec` / Windows `CreateProcess`).  `opts.stdin` / `opts.stdout` / `opts.stderr` are `"inherit"` (default), `"pipe"`, or `"null"`.  `opts.cwd` sets the child's working directory. |
 
 ### Methods on a spawned `proc`
 
@@ -358,6 +358,7 @@ guide.
 |---|---|
 | `stream.memory([initialBytes]) → stream` | Duplex in-memory buffer; auto-compacts as the reader drains. |
 | `stream.channel([capacity]) → stream` | Bounded thread channel; reads block while empty, writes block while full. |
+| `stream.transform(fn) → stream` | Pipes every chunk through `fn(chunk) → chunk`.  Returns null/non-string from `fn` to drop the chunk. |
 
 ### Methods (`_meta.stream`)
 
@@ -375,7 +376,7 @@ guide.
 | `s:error() → string` | Last error message reported by the adapter; `""` if none. |
 | `s:bytesIn() → number` | Bytes read so far through any method. |
 | `s:bytesOut() → number` | Bytes written so far through any method. |
-| `s:kind() → string` | Adapter name: `"memory"`, `"file"`, `"tcp"`, `"tls"`, `"channel"`, `"http_response"`. |
+| `s:kind() → string` | Adapter name: `"memory"`, `"file"`, `"tcp"`, `"tls"`, `"channel"`, `"transform"`, `"http_body"`, `"http_response"`. |
 
 > **Naming note:** the method is `:pipeTo`, not `:pipe`, because `pipe`
 > is reserved as the implicit loop variable in CanDo's `~>` pipe
@@ -388,7 +389,7 @@ guide.
 | `file.open(path, mode)` | File-backed stream. |
 | `tcp_socket:stream()` / `tls_socket:stream()` | Duplex view of a connected TCP / TLS socket.  Does not own the socket. |
 | `res:stream()` | Writable view of a server `http_response`; `:end()` flushes the buffered response. |
-| `clientResponse:stream()` | Readable view of an HTTP client response body. |
+| `clientResponse:stream()` | Readable view of an HTTP client response body.  When the request was issued with `{ stream: TRUE }` the body is drained lazily from the live connection; otherwise it's a memory stream over the buffered body. |
 | `proc:stdin()` / `:stdout()` / `:stderr()` | Pipes for a spawned subprocess. |
 
 ---

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -41,6 +41,7 @@ Four things to keep in mind:
 |---------------------------------|-------------------------------------------------|
 | `stream.memory([initialBytes])` | Duplex in-memory buffer (compacts as it drains) |
 | `stream.channel([capacity])`    | Bounded thread channel — backpressure built-in  |
+| `stream.transform(fn)`          | Pipes every chunk through `fn(chunk) → chunk`   |
 | `file.open(path, mode)`         | File-backed stream (`r/w/a`, optional `b`/`+`)  |
 | `sock:stream()`                 | Duplex view of an open TCP / TLS socket         |
 | `res:stream()`                  | Writable view of a server `http_response`       |
@@ -82,11 +83,34 @@ dst:close();
 
 ### Download an HTTP response straight to disk
 
+The body is buffered in memory unless you opt into streaming with
+`{ stream: true }`.  In streaming mode the response object's `body`
+field is `null` and `:stream()` returns a reader that pulls bytes from
+the connection on demand — handles Content-Length, chunked, and
+connection-close framing.
+
 ```cando
-VAR resp = fetch("https://example.com/big.zip");
+VAR resp = fetch("https://example.com/big.zip", { stream: TRUE });
 VAR out  = file.open("big.zip", "wb");
-resp:stream():pipeTo(out);
+resp:stream():pipeTo(out);          /* never materialises the whole body */
 out:close();
+```
+
+### Send a chunked HTTP response from a server
+
+`res:stream()` writes `Transfer-Encoding: chunked` headers on the first
+write and emits each subsequent write as one chunk.  `:end()` writes
+the terminating zero-chunk.
+
+```cando
+http.createServer(FUNCTION(req, res) {
+    res:setHeader("Content-Type", "application/octet-stream");
+    VAR rs = res:stream();
+    VAR f  = file.open("download.zip", "rb");
+    f:pipeTo(rs);                   /* arbitrary size, no server-side buffer */
+    rs:end();
+    f:close();
+}):listen(8080);
 ```
 
 ### Echo server using socket streams
@@ -127,17 +151,25 @@ print(p:wait());                    /* exit code */
 print(out:readAll());
 ```
 
-### Pipe a file out as the body of an HTTP response
+### Transform: uppercase every chunk on its way through
 
 ```cando
-http.createServer(FUNCTION(req, res) {
-    VAR f = file.open("download.zip", "rb");
-    VAR rs = res:stream();
-    f:pipeTo(rs);
-    rs:end();                       /* flush the buffered response */
-    f:close();
-}):listen(8080);
+VAR upper = stream.transform(FUNCTION(chunk) {
+    RETURN chunk:toUpper();
+});
+
+VAR src = file.open("input.txt",  "rb");
+VAR dst = file.open("upper.txt",  "wb");
+src:pipeTo(upper);
+upper:end();                        /* tell upper there's no more input */
+upper:pipeTo(dst);
+src:close();
+dst:close();
 ```
+
+The transform owns a child VM so the function can run from any thread —
+including the pipe driver — without sharing call frames with the caller.
+Returning `null` (or anything non-string) from `fn` drops that chunk.
 
 ## Threading and lifetimes
 
@@ -156,16 +188,18 @@ are fixed at construction.
   `cando_vm_wait_all_threads` machinery ensures the process won't exit
   before the pipe finishes.
 
-## Limitations
+## Notes
 
-* **HTTP bodies are still buffered.**  Both `clientResponse:stream()`
-  and `res:stream()` work over the existing buffered body.  True
-  on-the-wire streaming (chunked downloads, chunked sends) is a
-  follow-up that requires teaching `http_read_response` to expose the
-  unread connection.
-* **`process.spawn` is POSIX-only.**  The Windows path errors with
-  "not implemented".  `process.pid()` / `process.ppid()` work
-  everywhere.
-* **No transform streams yet.**  If you need to map / filter bytes mid-
-  pipe, drain into a `stream.memory()`, transform, and pipe out.  A
-  proper transform adapter will follow once the use cases are clearer.
+* **HTTP client streaming is opt-in.**  Plain `fetch(url)` still
+  buffers the body for backward compatibility; pass
+  `{ stream: TRUE }` to drain it on demand instead.
+* **HTTP server `res:stream()` writes chunked.**  The first `:write`
+  flushes status + headers (with `Transfer-Encoding: chunked`); set
+  status / headers *before* the first write.  Any user-supplied
+  `Content-Length` or `Transfer-Encoding` header on a streamed
+  response is dropped — framing is owned by the adapter.
+* **`process.spawn` works on POSIX and Windows.**  POSIX uses
+  `fork + execvp`; Windows uses `CreateProcess` with anonymous pipes
+  converted to fds via `_open_osfhandle`.  `proc:kill([sig])` ignores
+  the signal arg on Windows and unconditionally calls
+  `TerminateProcess`.

--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -303,12 +303,67 @@ static CdoObject *get_obj_field(CdoObject *obj, const char *name)
 }
 
 /* =========================================================================
+ * Client-side streaming response body adapter
+ *
+ * Wraps an open HttpConn + HttpBodyReader so script code can drain the
+ * body lazily — `resp:stream():pipeTo(file.open("out.bin", "wb"))`
+ * downloads any size of file with a single chunk-sized buffer in flight,
+ * regardless of Content-Length or chunked encoding.
+ *
+ * The adapter owns the HttpConn and closes it on destroy.
+ * ===================================================================== */
+
+typedef struct HttpClientBodyCtx {
+    HttpConn          conn;
+    HttpResponseHead  head;
+    HttpBodyReader    reader;
+    StreamSlot       *owner;
+} HttpClientBodyCtx;
+
+static StreamStatus http_client_body_read(void *vctx, u8 *out, usize cap,
+                                          usize *n_out)
+{
+    HttpClientBodyCtx *bc = (HttpClientBodyCtx *)vctx;
+    int n = http_body_reader_read(&bc->reader, out, cap);
+    if (n < 0) {
+        *n_out = 0;
+        stream_set_error(bc->owner, "http body: read failed");
+        return STREAM_ERR;
+    }
+    *n_out = (usize)n;
+    if (n == 0 && bc->reader.eof) return STREAM_EOF;
+    return STREAM_OK;
+}
+
+static void http_client_body_destroy(void *vctx)
+{
+    HttpClientBodyCtx *bc = (HttpClientBodyCtx *)vctx;
+    if (!bc) return;
+    http_body_reader_free(&bc->reader);
+    http_response_head_free(&bc->head);
+    http_conn_close(&bc->conn);
+    cando_free(bc);
+}
+
+static const StreamVTable g_http_client_body_vt = {
+    .read       = http_client_body_read,
+    .write      = NULL,
+    .flush      = NULL,
+    .end        = NULL,
+    .destroy    = http_client_body_destroy,
+    .seek       = NULL,
+    .tell       = NULL,
+    .kind_name  = "http_body",
+};
+
+/* =========================================================================
  * Shared client workhorse: http_do_request_native
  *
  * Accepts either a bare URL string or an options object with fields
- *   { url, method, headers, body, timeout }.
+ *   { url, method, headers, body, timeout, stream }.
  * is_tls_hint forces TLS regardless of scheme (used by https.request).
- * Pushes a single result object { status, ok, body, headers } on success.
+ * Pushes a single result object { status, ok, body, headers } on success;
+ * with `stream: true` the body is null and `:stream()` lazily drains.
  * ===================================================================== */
 int http_do_request_native(CandoVM *vm, int argc, CandoValue *args,
                            bool is_tls_hint)
@@ -357,6 +412,17 @@ int http_do_request_native(CandoVM *vm, int argc, CandoValue *args,
         headers_obj = get_obj_field(opts, "headers");
         int t = 0;
         if (get_int_field(opts, "timeout", &t) && t > 0) timeout = t;
+    }
+    /* Streaming mode: callers asking for `stream: true` get the response
+     * object with body=null and an `__stream_id` hidden field; the body
+     * is drained lazily on demand via `:stream()`. */
+    bool stream_body = false;
+    if (opts) {
+        CdoString *kstream = cdo_string_intern("stream", 6);
+        CdoValue   vstream = cdo_null();
+        bool ok = cdo_object_rawget(opts, kstream, &vstream);
+        cdo_string_release(kstream);
+        if (ok && vstream.tag == CDO_BOOL) stream_body = vstream.as.boolean;
     }
 
     if (!url_cstr || url_len == 0) {
@@ -436,6 +502,69 @@ int http_do_request_native(CandoVM *vm, int argc, CandoValue *args,
         return -1;
     }
     httpbuf_free(&req);
+
+    /* ---------------------------------------------------------------
+     * Streaming path: read only the headers, then hand the open
+     * connection off to a body-stream adapter so the script can drain
+     * the body lazily without first materialising it.
+     * --------------------------------------------------------------- */
+    if (stream_body) {
+        HttpClientBodyCtx *bc =
+            (HttpClientBodyCtx *)cando_alloc(sizeof(HttpClientBodyCtx));
+        memset(bc, 0, sizeof(*bc));
+        /* Move the connection into the ctx so its destroy can close it. */
+        bc->conn = conn;
+        http_response_head_init(&bc->head);
+        if (!http_read_response_head(&bc->conn, &bc->head)) {
+            http_response_head_free(&bc->head);
+            http_conn_close(&bc->conn);
+            cando_free(bc);
+            cando_vm_error(vm, "http.request: bad or truncated response");
+            return -1;
+        }
+        http_body_reader_init(&bc->reader, &bc->head, &bc->conn);
+
+        int sidx = stream_pool_alloc(&g_http_client_body_vt, bc,
+                                     STREAM_CAP_READABLE);
+        if (sidx < 0) {
+            http_body_reader_free(&bc->reader);
+            http_response_head_free(&bc->head);
+            http_conn_close(&bc->conn);
+            cando_free(bc);
+            cando_vm_error(vm, "http.request: too many active streams");
+            return -1;
+        }
+        bc->owner = stream_pool_get(sidx);
+
+        /* Build clientResponse: status/headers populated, body=null,
+         * `__stream_id` hidden field tells :stream() to surface the
+         * lazy body adapter. */
+        CandoValue result_val = cando_bridge_new_object(vm);
+        CdoObject *result     = cando_bridge_resolve(vm, result_val.as.handle);
+        set_num_field (result, "status", (f64)bc->head.status);
+        set_bool_field(result, "ok",
+                       bc->head.status >= 200 && bc->head.status < 300);
+        set_num_field (result, "__stream_id", (f64)sidx);
+        /* Provide a `body` field for symmetry with the buffered path; in
+         * streaming mode it's null until the user drains the stream. */
+        CdoString *kbody = cdo_string_intern("body", 4);
+        cdo_object_rawset(result, kbody, cdo_null(), FIELD_NONE);
+        cdo_string_release(kbody);
+
+        CandoValue hdrs_val = cando_bridge_new_object(vm);
+        CdoObject *hdrs     = cando_bridge_resolve(vm, hdrs_val.as.handle);
+        for (u32 i = 0; i < bc->head.headers.count; i++) {
+            set_str_field(hdrs,
+                          bc->head.headers.entries[i].name,
+                          bc->head.headers.entries[i].value,
+                          (u32)strlen(bc->head.headers.entries[i].value));
+        }
+        set_obj_field(result, "headers", hdrs);
+        cando_lib_meta_attach(vm, result, "http_client_response");
+
+        cando_vm_push(vm, result_val);
+        return 1;
+    }
 
     /* Read response. */
     HttpResponse resp;
@@ -671,20 +800,88 @@ static int res_send_fn(CandoVM *vm, int argc, CandoValue *args)
     return 1;
 }
 
-/* res:stream() -> writable stream that buffers body bytes and sends the
- * full response on `:end()`.
+/* res:stream() -> writable stream that emits the response body using
+ * chunked transfer encoding.
  *
- * Like `res:send()`, this is a one-shot — calling :end() (or :close()
- * after writes) flushes whatever was buffered as a single Content-Length
- * response.  True chunked sending is deferred to a follow-up; the win
- * here is the unified API so callers can `file:pipeTo(res:stream())` to
- * stream a download out without manually slurping the file first.
+ * The first :write sends the headers + Transfer-Encoding: chunked, then
+ * each subsequent write is one chunk on the wire.  :end() sends the
+ * terminating zero-length chunk.  This means script code can hand a
+ * gigabyte response back without ever buffering it on the server.
+ *
+ * `:status()` and `:setHeader()` only have effect *before* the first
+ * :write (or :end) — that's when the headers are flushed.
  */
 typedef struct ResStreamCtx {
     HttpResCtx *res;
-    HttpBuf     buf;
+    bool        headers_sent;
     StreamSlot *owner;
 } ResStreamCtx;
+
+/* Build and emit the status line + headers with chunked framing.  Caller
+ * must NOT hold ctx->mu; we acquire it ourselves. */
+static bool res_stream_send_headers(HttpResCtx *ctx)
+{
+    cando_os_mutex_lock(&ctx->mu);
+    if (ctx->sent) { cando_os_mutex_unlock(&ctx->mu); return false; }
+
+    HttpBuf out;
+    httpbuf_init(&out);
+
+    const char *reason = http_status_text(ctx->status_code);
+    httpbuf_append_fmt(&out, "HTTP/1.1 %d %s\r\n",
+                      ctx->status_code,
+                      reason && *reason ? reason : "OK");
+
+    bool has_ct = false, has_cn = false;
+    for (u32 i = 0; i < ctx->headers.count; i++) {
+        const char *n = ctx->headers.entries[i].name;
+        if (strcmp(n, "content-type")      == 0) has_ct = true;
+        if (strcmp(n, "connection")        == 0) has_cn = true;
+        /* Drop user-supplied framing headers — we manage them. */
+        if (strcmp(n, "content-length")    == 0) continue;
+        if (strcmp(n, "transfer-encoding") == 0) continue;
+        httpbuf_append_cstr(&out, n);
+        httpbuf_append_cstr(&out, ": ");
+        httpbuf_append_cstr(&out, ctx->headers.entries[i].value);
+        httpbuf_append_cstr(&out, "\r\n");
+    }
+    if (!has_ct) httpbuf_append_cstr(&out, "Content-Type: text/html; charset=utf-8\r\n");
+    if (!has_cn) httpbuf_append_cstr(&out, "Connection: close\r\n");
+    httpbuf_append_cstr(&out, "Transfer-Encoding: chunked\r\n\r\n");
+
+    bool ok = http_conn_write_all(&ctx->conn, out.data, out.len);
+    httpbuf_free(&out);
+    cando_os_mutex_unlock(&ctx->mu);
+    return ok;
+}
+
+/* Emit one chunk: <hex-len>\r\n<bytes>\r\n */
+static bool res_stream_send_chunk(HttpResCtx *ctx, const u8 *buf, usize len)
+{
+    if (len == 0) return true;
+    cando_os_mutex_lock(&ctx->mu);
+    HttpBuf out;
+    httpbuf_init(&out);
+    httpbuf_append_fmt(&out, "%zx\r\n", len);
+    httpbuf_append(&out, buf, len);
+    httpbuf_append_cstr(&out, "\r\n");
+    bool ok = http_conn_write_all(&ctx->conn, out.data, out.len);
+    httpbuf_free(&out);
+    cando_os_mutex_unlock(&ctx->mu);
+    return ok;
+}
+
+/* Emit the terminating zero-length chunk and wake the connection thread. */
+static bool res_stream_send_terminator(HttpResCtx *ctx)
+{
+    cando_os_mutex_lock(&ctx->mu);
+    if (ctx->sent) { cando_os_mutex_unlock(&ctx->mu); return true; }
+    bool ok = http_conn_write_all(&ctx->conn, "0\r\n\r\n", 5);
+    ctx->sent = true;
+    cando_os_cond_broadcast(&ctx->cv);
+    cando_os_mutex_unlock(&ctx->mu);
+    return ok;
+}
 
 static StreamStatus res_stream_write(void *vctx, const u8 *buf, usize len,
                                      usize *n_out)
@@ -695,7 +892,19 @@ static StreamStatus res_stream_write(void *vctx, const u8 *buf, usize len,
         stream_set_error(rs->owner, "response already sent");
         return STREAM_ERR;
     }
-    httpbuf_append(&rs->buf, (const char *)buf, len);
+    if (!rs->headers_sent) {
+        if (!res_stream_send_headers(rs->res)) {
+            stream_set_error(rs->owner, "failed to send response headers");
+            *n_out = 0;
+            return STREAM_ERR;
+        }
+        rs->headers_sent = true;
+    }
+    if (!res_stream_send_chunk(rs->res, buf, len)) {
+        stream_set_error(rs->owner, "chunk send failed");
+        *n_out = 0;
+        return STREAM_ERR;
+    }
     *n_out = len;
     return STREAM_OK;
 }
@@ -704,8 +913,15 @@ static StreamStatus res_stream_end(void *vctx)
 {
     ResStreamCtx *rs = (ResStreamCtx *)vctx;
     if (rs->res->sent) return STREAM_OK;
-    if (!res_send_impl(rs->res, rs->buf.data, rs->buf.len)) {
-        stream_set_error(rs->owner, "response send failed");
+    if (!rs->headers_sent) {
+        if (!res_stream_send_headers(rs->res)) {
+            stream_set_error(rs->owner, "failed to send response headers");
+            return STREAM_ERR;
+        }
+        rs->headers_sent = true;
+    }
+    if (!res_stream_send_terminator(rs->res)) {
+        stream_set_error(rs->owner, "terminator send failed");
         return STREAM_ERR;
     }
     return STREAM_OK;
@@ -715,11 +931,19 @@ static void res_stream_destroy(void *vctx)
 {
     ResStreamCtx *rs = (ResStreamCtx *)vctx;
     if (!rs) return;
-    /* If the script closed without :end(), don't auto-send — they may
-     * have intentionally abandoned the response.  The connection thread
-     * is still blocked in res_wait_until_sent and will eventually pick up
-     * any explicit res:send call. */
-    httpbuf_free(&rs->buf);
+    /* Ensure the connection thread doesn't park forever in
+     * res_wait_until_sent if the script abandons the stream.  If we
+     * already wrote headers, finish the chunked stream cleanly; else
+     * just unblock with `sent = true` (the connection will close with
+     * no response, which is the script's responsibility). */
+    if (rs->headers_sent && !rs->res->sent) {
+        res_stream_send_terminator(rs->res);
+    } else if (!rs->res->sent) {
+        cando_os_mutex_lock(&rs->res->mu);
+        rs->res->sent = true;
+        cando_os_cond_broadcast(&rs->res->cv);
+        cando_os_mutex_unlock(&rs->res->mu);
+    }
     cando_free(rs);
 }
 
@@ -745,11 +969,9 @@ static int res_stream_fn(CandoVM *vm, int argc, CandoValue *args)
     ResStreamCtx *rs = (ResStreamCtx *)cando_alloc(sizeof(ResStreamCtx));
     memset(rs, 0, sizeof(*rs));
     rs->res = ctx;
-    httpbuf_init(&rs->buf);
 
     int idx = stream_pool_alloc(&g_res_stream_vt, rs, STREAM_CAP_WRITABLE);
     if (idx < 0) {
-        httpbuf_free(&rs->buf);
         cando_free(rs);
         cando_vm_error(vm, "res:stream: too many active streams");
         return -1;
@@ -783,6 +1005,24 @@ static int http_client_response_stream_fn(CandoVM *vm, int argc,
         cando_vm_error(vm, "clientResponse:stream: invalid receiver");
         return -1;
     }
+    /* Streaming-mode response: the request was issued with `stream: true`
+     * so the body lives in a pre-allocated stream slot.  Surface that
+     * directly — the caller may have already partially drained it. */
+    {
+        CdoString *kid = cdo_string_intern("__stream_id", 11);
+        CdoValue   vid = cdo_null();
+        bool ok = cdo_object_rawget(obj, kid, &vid);
+        cdo_string_release(kid);
+        if (ok && vid.tag == CDO_NUMBER) {
+            int sid = (int)vid.as.number;
+            if (stream_pool_get(sid)) {
+                cando_vm_push(vm, stream_create_instance(vm, sid));
+                return 1;
+            }
+        }
+    }
+
+    /* Buffered mode: build a one-shot memory stream over the body field. */
     CdoString *kbody = cdo_string_intern("body", 4);
     CdoValue   bv    = cdo_null();
     bool       have  = cdo_object_get(obj, kbody, &bv);

--- a/source/lib/httputil.c
+++ b/source/lib/httputil.c
@@ -611,6 +611,214 @@ bool http_read_response(HttpConn *conn, HttpResponse *r)
 }
 
 /* =========================================================================
+ * Streaming response: header-only parser + body state machine
+ * ===================================================================== */
+
+void http_response_head_init(HttpResponseHead *r)
+{
+    r->status     = 0;
+    r->reason[0]  = '\0';
+    r->framing    = HBF_NONE;
+    r->length_remaining = 0;
+    r->tail_off   = 0;
+    http_headers_init(&r->headers);
+    httpbuf_init(&r->tail);
+}
+
+void http_response_head_free(HttpResponseHead *r)
+{
+    http_headers_free(&r->headers);
+    httpbuf_free(&r->tail);
+}
+
+bool http_read_response_head(HttpConn *conn, HttpResponseHead *r)
+{
+    HttpBuf recv;
+    httpbuf_init(&recv);
+    usize offset = 0;
+
+    char line[8192];
+    int n = read_crlf_line(conn, &recv, &offset, line, sizeof(line));
+    if (n <= 0) { httpbuf_free(&recv); return false; }
+
+    /* HTTP/X.Y SP STATUS SP REASON */
+    char *sp1 = strchr(line, ' ');
+    if (!sp1) { httpbuf_free(&recv); return false; }
+    *sp1 = '\0';
+    char *code_s = sp1 + 1;
+    char *sp2 = strchr(code_s, ' ');
+    if (sp2) *sp2 = '\0';
+
+    r->status = (int)strtol(code_s, NULL, 10);
+    if (sp2) {
+        const char *reason = sp2 + 1;
+        usize rl = strlen(reason);
+        if (rl >= sizeof(r->reason)) rl = sizeof(r->reason) - 1;
+        memcpy(r->reason, reason, rl); r->reason[rl] = '\0';
+    }
+
+    if (!parse_headers(conn, &recv, &offset, &r->headers)) {
+        httpbuf_free(&recv);
+        return false;
+    }
+
+    /* Choose framing exactly as http_read_response does so the streamed
+     * path matches the buffered path byte-for-byte for any given server. */
+    const char *te = http_headers_get(&r->headers, "transfer-encoding");
+    const char *cl = http_headers_get(&r->headers, "content-length");
+    const char *cn = http_headers_get(&r->headers, "connection");
+    bool close_delim = (cn && strcasecmp(cn, "close") == 0);
+
+    if (te && strcasecmp(te, "chunked") == 0) {
+        r->framing = HBF_CHUNKED;
+    } else if (cl) {
+        r->framing = HBF_LENGTH;
+        r->length_remaining = strtoul(cl, NULL, 10);
+    } else if (close_delim || r->status == 200 || r->status == 204) {
+        r->framing = HBF_CLOSE;
+    } else {
+        r->framing = HBF_NONE;
+    }
+
+    /* Stash any bytes we over-read past the headers so the body reader
+     * sees them before going back to the wire. */
+    if (offset < recv.len) {
+        httpbuf_append(&r->tail, recv.data + offset, recv.len - offset);
+    }
+    r->tail_off = 0;
+    httpbuf_free(&recv);
+    return true;
+}
+
+void http_body_reader_init(HttpBodyReader *br,
+                           const HttpResponseHead *head, HttpConn *conn)
+{
+    br->conn             = conn;
+    br->framing          = head->framing;
+    br->length_remaining = head->length_remaining;
+    br->chunk_state      = 0;
+    br->chunk_remaining  = 0;
+    br->recv_off         = 0;
+    br->eof              = (head->framing == HBF_NONE) ||
+                           (head->framing == HBF_LENGTH &&
+                            head->length_remaining == 0);
+    httpbuf_init(&br->recv);
+    /* Seed the reader's recv buffer with whatever the head parser
+     * already pulled past the header terminator. */
+    if (head->tail.len > head->tail_off) {
+        httpbuf_append(&br->recv,
+                       head->tail.data + head->tail_off,
+                       head->tail.len - head->tail_off);
+    }
+}
+
+void http_body_reader_free(HttpBodyReader *br)
+{
+    httpbuf_free(&br->recv);
+    br->conn = NULL;
+}
+
+/* Drain min(cap, available) bytes out of br->recv into `out`.  Returns
+ * the number of bytes copied; advances recv_off. */
+static usize body_drain_recv(HttpBodyReader *br, void *out, usize cap)
+{
+    usize avail = br->recv.len - br->recv_off;
+    if (avail == 0) return 0;
+    usize n = cap < avail ? cap : avail;
+    memcpy(out, br->recv.data + br->recv_off, n);
+    br->recv_off += n;
+    return n;
+}
+
+int http_body_reader_read(HttpBodyReader *br, void *out, usize cap)
+{
+    if (br->eof || cap == 0) return 0;
+    u8 *outb = (u8 *)out;
+
+    if (br->framing == HBF_LENGTH) {
+        usize want = cap < br->length_remaining ? cap : br->length_remaining;
+        if (want == 0) { br->eof = true; return 0; }
+        usize taken = body_drain_recv(br, outb, want);
+        if (taken < want) {
+            int n = http_conn_read(br->conn, outb + taken,
+                                   (int)(want - taken));
+            if (n <= 0) return -1;
+            taken += (usize)n;
+        }
+        br->length_remaining -= taken;
+        if (br->length_remaining == 0) br->eof = true;
+        return (int)taken;
+    }
+
+    if (br->framing == HBF_CLOSE) {
+        usize taken = body_drain_recv(br, outb, cap);
+        if (taken == 0) {
+            int n = http_conn_read(br->conn, outb, (int)cap);
+            if (n < 0)  return -1;
+            if (n == 0) { br->eof = true; return 0; }
+            taken = (usize)n;
+        }
+        return (int)taken;
+    }
+
+    if (br->framing == HBF_CHUNKED) {
+        /* Iterate the state machine until we have at least one byte for
+         * the caller, hit clean EOF, or hit an error.  cap > 0 here so
+         * the loop terminates as soon as `taken` advances. */
+        usize taken = 0;
+        while (taken == 0 && !br->eof) {
+            if (br->chunk_state == 0) {
+                char line[64];
+                int n = read_crlf_line(br->conn, &br->recv, &br->recv_off,
+                                       line, sizeof(line));
+                if (n < 0) return -1;
+                char *semi = strchr(line, ';');
+                if (semi) *semi = '\0';
+                br->chunk_remaining = (usize)strtoul(line, NULL, 16);
+                if (br->chunk_remaining == 0) {
+                    /* Consume any trailers, then we're done. */
+                    while (1) {
+                        n = read_crlf_line(br->conn, &br->recv, &br->recv_off,
+                                           line, sizeof(line));
+                        if (n < 0) return -1;
+                        if (n == 0) break;
+                    }
+                    br->chunk_state = 3;
+                    br->eof = true;
+                    return 0;
+                }
+                br->chunk_state = 1;
+            } else if (br->chunk_state == 1) {
+                usize want = cap < br->chunk_remaining ? cap : br->chunk_remaining;
+                usize from_buf = body_drain_recv(br, outb, want);
+                taken += from_buf;
+                br->chunk_remaining -= from_buf;
+                if (br->chunk_remaining > 0 && taken < cap) {
+                    usize need = cap - taken;
+                    if (need > br->chunk_remaining) need = br->chunk_remaining;
+                    int n = http_conn_read(br->conn, outb + taken, (int)need);
+                    if (n <= 0) return -1;
+                    taken += (usize)n;
+                    br->chunk_remaining -= (usize)n;
+                }
+                if (br->chunk_remaining == 0) br->chunk_state = 2;
+            } else if (br->chunk_state == 2) {
+                char line[8];
+                int n = read_crlf_line(br->conn, &br->recv, &br->recv_off,
+                                       line, sizeof(line));
+                if (n != 0) return -1;     /* expected empty CRLF */
+                br->chunk_state = 0;
+            }
+        }
+        return (int)taken;
+    }
+
+    /* HBF_NONE — no body. */
+    br->eof = true;
+    return 0;
+}
+
+/* =========================================================================
  * Status code to reason phrase mapping
  * ===================================================================== */
 

--- a/source/lib/httputil.h
+++ b/source/lib/httputil.h
@@ -154,6 +154,79 @@ void http_response_free(HttpResponse *r);
 bool http_read_response(HttpConn *conn, HttpResponse *r);
 
 /* =========================================================================
+ * Streaming response parser + body reader
+ *
+ * For callers that want to drain the body lazily (e.g. pipe straight to a
+ * file without buffering the whole download).  Workflow:
+ *
+ *     HttpResponseHead head;
+ *     http_response_head_init(&head);
+ *     http_read_response_head(conn, &head);   // reads only status + headers
+ *     HttpBodyReader br;
+ *     http_body_reader_init(&br, &head, conn);
+ *     for (;;) {
+ *         u8 buf[4096];
+ *         int n = http_body_reader_read(&br, buf, sizeof(buf));
+ *         if (n <= 0) break;
+ *         consume(buf, n);
+ *     }
+ *     http_body_reader_free(&br);
+ *     http_response_head_free(&head);
+ *
+ * The reader supports Content-Length, Transfer-Encoding: chunked, and
+ * connection-close framing — same coverage as http_read_response.
+ * ===================================================================== */
+typedef enum {
+    HBF_NONE    = 0,
+    HBF_LENGTH  = 1,    /* Content-Length: N                  */
+    HBF_CHUNKED = 2,    /* Transfer-Encoding: chunked         */
+    HBF_CLOSE   = 3,    /* Read until peer closes (HTTP/1.0)  */
+} HttpBodyFraming;
+
+typedef struct {
+    int             status;
+    char            reason[64];
+    HttpHeaders     headers;
+    HttpBodyFraming framing;
+    usize           length_remaining; /* meaningful only if HBF_LENGTH */
+    HttpBuf         tail;             /* over-read body bytes */
+    usize           tail_off;
+} HttpResponseHead;
+
+void http_response_head_init(HttpResponseHead *r);
+void http_response_head_free(HttpResponseHead *r);
+
+/*
+ * http_read_response_head -- read status line + headers; do NOT touch the
+ * body.  Any over-read bytes are stashed in r->tail for the body reader.
+ * Returns true on success.
+ */
+bool http_read_response_head(HttpConn *conn, HttpResponseHead *r);
+
+typedef struct {
+    HttpConn       *conn;            /* borrowed; not closed by reader */
+    HttpBodyFraming framing;
+    usize           length_remaining;
+    int             chunk_state;     /* 0=size_line 1=in_chunk 2=trail_crlf 3=done */
+    usize           chunk_remaining;
+    HttpBuf         recv;            /* internal buffer (seeded from head.tail) */
+    usize           recv_off;
+    bool            eof;
+} HttpBodyReader;
+
+void http_body_reader_init(HttpBodyReader *br,
+                           const HttpResponseHead *head, HttpConn *conn);
+void http_body_reader_free(HttpBodyReader *br);
+
+/*
+ * http_body_reader_read -- pull up to `cap` bytes into `out`.  Returns:
+ *   >0   bytes read
+ *    0   clean EOF (body fully consumed); br->eof is now true
+ *   -1   I/O or framing error
+ */
+int  http_body_reader_read(HttpBodyReader *br, void *out, usize cap);
+
+/* =========================================================================
  * Miscellaneous helpers
  * ===================================================================== */
 

--- a/source/lib/process.c
+++ b/source/lib/process.c
@@ -39,11 +39,14 @@
 #include <errno.h>
 #include <signal.h>
 
-#include <unistd.h>
-#include <sys/types.h>
 #if defined(_WIN32) || defined(_WIN64)
+#  include <windows.h>
+#  include <io.h>
+#  include <fcntl.h>
 #  include <process.h>
 #else
+#  include <unistd.h>
+#  include <sys/types.h>
 #  include <sys/wait.h>
 #  include <fcntl.h>
 extern char **environ;
@@ -68,6 +71,9 @@ typedef struct ProcSlot {
     int              stdin_stream_idx;
     int              stdout_stream_idx;
     int              stderr_stream_idx;
+    /* Windows: HANDLE for the child process so wait/kill can address it.
+     * Stored as void* to keep the struct identical across platforms. */
+    void            *win_proc_handle;
 } ProcSlot;
 
 static ProcSlot      g_proc_pool[PROC_MAX_INSTANCES];
@@ -184,7 +190,181 @@ static StdioMode parse_stdio(CdoObject *opts, const char *key, StdioMode def)
     return def;
 }
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if defined(_WIN32) || defined(_WIN64)
+/* =========================================================================
+ * Windows spawn: CreateProcess + anonymous pipes.
+ *
+ * The Windows command-line is one big string; we have to build it from
+ * argv with the standard CommandLineToArgv quoting rules so the child
+ * sees the same tokens.  Pipe ends are handed to the child via
+ * STARTF_USESTDHANDLES with bInheritHandles=TRUE; the parent's ends
+ * are explicitly marked non-inheritable so they don't leak into a
+ * subsequent CreateProcess call.
+ * ===================================================================== */
+
+/* Quote one argv element per CommandLineToArgvW's escaping rules. */
+static void win_append_quoted(char **buf, usize *len, usize *cap, const char *arg)
+{
+    bool need_quote = (*arg == '\0') ||
+                      strchr(arg, ' ')  || strchr(arg, '\t') ||
+                      strchr(arg, '"');
+    usize alen = strlen(arg);
+
+    /* Worst case: every char becomes \\ + " expansion = 4x.  Plus quotes. */
+    usize need = (need_quote ? 2 : 0) + alen * 4;
+    if (*len + need + 1 > *cap) {
+        while (*len + need + 1 > *cap) *cap *= 2;
+        *buf = (char *)cando_realloc(*buf, *cap);
+    }
+
+    if (!need_quote) {
+        memcpy(*buf + *len, arg, alen);
+        *len += alen;
+        return;
+    }
+
+    (*buf)[(*len)++] = '"';
+    int bs = 0;
+    for (const char *p = arg; *p; p++) {
+        if (*p == '\\') {
+            bs++;
+            (*buf)[(*len)++] = '\\';
+        } else if (*p == '"') {
+            for (int k = 0; k < bs; k++) (*buf)[(*len)++] = '\\';
+            (*buf)[(*len)++] = '\\';
+            (*buf)[(*len)++] = '"';
+            bs = 0;
+        } else {
+            bs = 0;
+            (*buf)[(*len)++] = *p;
+        }
+    }
+    for (int k = 0; k < bs; k++) (*buf)[(*len)++] = '\\';
+    (*buf)[(*len)++] = '"';
+}
+
+static char *win_build_cmdline(char *const argv[])
+{
+    usize cap = 256, len = 0;
+    char *out = (char *)cando_alloc(cap);
+    for (int i = 0; argv[i]; i++) {
+        if (i > 0) {
+            if (len + 1 >= cap) { cap *= 2; out = (char *)cando_realloc(out, cap); }
+            out[len++] = ' ';
+        }
+        win_append_quoted(&out, &len, &cap, argv[i]);
+    }
+    if (len + 1 > cap) { cap += 1; out = (char *)cando_realloc(out, cap); }
+    out[len] = '\0';
+    return out;
+}
+
+static int spawn_windows(char *const argv[],
+                         StdioMode in_mode, StdioMode out_mode, StdioMode err_mode,
+                         const char *cwd,
+                         char *err, usize errlen)
+{
+    HANDLE in_rd = NULL, in_wr = NULL;
+    HANDLE out_rd = NULL, out_wr = NULL;
+    HANDLE err_rd = NULL, err_wr = NULL;
+    HANDLE null_in = INVALID_HANDLE_VALUE, null_out = INVALID_HANDLE_VALUE;
+    int slot_idx = -1;
+
+    SECURITY_ATTRIBUTES sa = { sizeof(sa), NULL, TRUE };
+
+    if (in_mode == STDIO_PIPE) {
+        if (!CreatePipe(&in_rd, &in_wr, &sa, 0)) goto pipe_err;
+        SetHandleInformation(in_wr, HANDLE_FLAG_INHERIT, 0);
+    }
+    if (out_mode == STDIO_PIPE) {
+        if (!CreatePipe(&out_rd, &out_wr, &sa, 0)) goto pipe_err;
+        SetHandleInformation(out_rd, HANDLE_FLAG_INHERIT, 0);
+    }
+    if (err_mode == STDIO_PIPE) {
+        if (!CreatePipe(&err_rd, &err_wr, &sa, 0)) goto pipe_err;
+        SetHandleInformation(err_rd, HANDLE_FLAG_INHERIT, 0);
+    }
+    if (in_mode == STDIO_NULL) {
+        null_in = CreateFileA("NUL", GENERIC_READ,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
+                              OPEN_EXISTING, 0, NULL);
+    }
+    if (out_mode == STDIO_NULL || err_mode == STDIO_NULL) {
+        null_out = CreateFileA("NUL", GENERIC_WRITE,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE, &sa,
+                               OPEN_EXISTING, 0, NULL);
+    }
+
+    slot_idx = proc_pool_alloc();
+    if (slot_idx < 0) {
+        snprintf(err, errlen, "process.spawn: pool exhausted");
+        goto cleanup;
+    }
+
+    STARTUPINFOA si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    ZeroMemory(&pi, sizeof(pi));
+    si.cb        = sizeof(si);
+    si.dwFlags   = STARTF_USESTDHANDLES;
+    si.hStdInput  = (in_mode  == STDIO_PIPE) ? in_rd  :
+                    (in_mode  == STDIO_NULL) ? null_in :
+                    GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = (out_mode == STDIO_PIPE) ? out_wr :
+                    (out_mode == STDIO_NULL) ? null_out :
+                    GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError  = (err_mode == STDIO_PIPE) ? err_wr :
+                    (err_mode == STDIO_NULL) ? null_out :
+                    GetStdHandle(STD_ERROR_HANDLE);
+
+    char *cmdline = win_build_cmdline(argv);
+    BOOL ok = CreateProcessA(NULL, cmdline, NULL, NULL, TRUE,
+                             0, NULL, cwd, &si, &pi);
+    cando_free(cmdline);
+
+    if (!ok) {
+        snprintf(err, errlen, "process.spawn: CreateProcess failed: %lu",
+                 (unsigned long)GetLastError());
+        g_proc_pool[slot_idx].in_use = false;
+        slot_idx = -1;
+        goto cleanup;
+    }
+
+    /* Close the child ends in the parent so EOF propagates correctly when
+     * the child exits. */
+    if (in_rd)  { CloseHandle(in_rd);  in_rd  = NULL; }
+    if (out_wr) { CloseHandle(out_wr); out_wr = NULL; }
+    if (err_wr) { CloseHandle(err_wr); err_wr = NULL; }
+    if (null_in  != INVALID_HANDLE_VALUE) { CloseHandle(null_in);  null_in  = INVALID_HANDLE_VALUE; }
+    if (null_out != INVALID_HANDLE_VALUE) { CloseHandle(null_out); null_out = INVALID_HANDLE_VALUE; }
+
+    ProcSlot *p = &g_proc_pool[slot_idx];
+    p->pid = (int)pi.dwProcessId;
+    p->win_proc_handle = pi.hProcess;
+    if (in_mode == STDIO_PIPE)
+        p->stdin_fd  = _open_osfhandle((intptr_t)in_wr,  _O_WRONLY | _O_BINARY);
+    if (out_mode == STDIO_PIPE)
+        p->stdout_fd = _open_osfhandle((intptr_t)out_rd, _O_RDONLY | _O_BINARY);
+    if (err_mode == STDIO_PIPE)
+        p->stderr_fd = _open_osfhandle((intptr_t)err_rd, _O_RDONLY | _O_BINARY);
+    CloseHandle(pi.hThread);
+    return slot_idx;
+
+pipe_err:
+    snprintf(err, errlen, "process.spawn: CreatePipe failed: %lu",
+             (unsigned long)GetLastError());
+cleanup:
+    if (in_rd)  CloseHandle(in_rd);
+    if (in_wr)  CloseHandle(in_wr);
+    if (out_rd) CloseHandle(out_rd);
+    if (out_wr) CloseHandle(out_wr);
+    if (err_rd) CloseHandle(err_rd);
+    if (err_wr) CloseHandle(err_wr);
+    if (null_in  != INVALID_HANDLE_VALUE) CloseHandle(null_in);
+    if (null_out != INVALID_HANDLE_VALUE) CloseHandle(null_out);
+    return slot_idx < 0 ? -1 : -1;
+}
+#else
 /*
  * spawn_posix -- fork + exec on POSIX.  Returns the parent's slot index, or
  * -1 with `err` populated on failure.  argv must be NULL-terminated.
@@ -273,11 +453,6 @@ cleanup:
 /* process.spawn(argv [, opts]) -> proc */
 static int process_spawn_fn(CandoVM *vm, int argc, CandoValue *args)
 {
-#if defined(_WIN32) || defined(_WIN64)
-    (void)argc; (void)args;
-    cando_vm_error(vm, "process.spawn: not implemented on Windows yet");
-    return -1;
-#else
     if (argc < 1 || !cando_is_object(args[0])) {
         cando_vm_error(vm, "process.spawn: argv (array) required");
         return -1;
@@ -294,8 +469,7 @@ static int process_spawn_fn(CandoVM *vm, int argc, CandoValue *args)
     }
 
     /* Materialise argv into a NULL-terminated char* array.  We dup each
-     * string so the child has stable storage even if the script GC moves
-     * underlying CdoString memory between fork() and exec(). */
+     * string so the child has stable storage independent of script GC. */
     char **argv = (char **)cando_alloc(sizeof(char *) * (nargs + 1));
     for (u32 i = 0; i < nargs; i++) {
         CdoValue v = cdo_null();
@@ -330,9 +504,15 @@ static int process_spawn_fn(CandoVM *vm, int argc, CandoValue *args)
             cwd = vcwd.as.string->data;
     }
 
-    char errbuf[160] = {0};
-    int slot_idx = spawn_posix(argv, in_mode, out_mode, err_mode, cwd,
-                               errbuf, sizeof(errbuf));
+    char errbuf[256] = {0};
+    int slot_idx;
+#if defined(_WIN32) || defined(_WIN64)
+    slot_idx = spawn_windows(argv, in_mode, out_mode, err_mode, cwd,
+                             errbuf, sizeof(errbuf));
+#else
+    slot_idx = spawn_posix(argv, in_mode, out_mode, err_mode, cwd,
+                           errbuf, sizeof(errbuf));
+#endif
 
     for (u32 i = 0; i < nargs; i++) cando_free(argv[i]);
     cando_free(argv);
@@ -343,7 +523,6 @@ static int process_spawn_fn(CandoVM *vm, int argc, CandoValue *args)
     }
     cando_vm_push(vm, proc_create_instance(vm, slot_idx));
     return 1;
-#endif
 }
 
 /* =========================================================================
@@ -437,7 +616,22 @@ static int proc_stderr_fn(CandoVM *vm, int argc, CandoValue *args)
                            "rb", STREAM_CAP_READABLE, "proc:stderr");
 }
 
-/* proc:wait() -> exit code (POSIX waitpid) */
+/* Close fds the user never promoted to a stream.  Stream-owned fds are
+ * cleared from the slot at promotion time so this only frees orphans. */
+static void proc_close_orphan_fds(ProcSlot *p)
+{
+#if defined(_WIN32) || defined(_WIN64)
+    if (p->stdin_fd  >= 0) { _close(p->stdin_fd);  p->stdin_fd  = -1; }
+    if (p->stdout_fd >= 0) { _close(p->stdout_fd); p->stdout_fd = -1; }
+    if (p->stderr_fd >= 0) { _close(p->stderr_fd); p->stderr_fd = -1; }
+#else
+    if (p->stdin_fd  >= 0) { close(p->stdin_fd);  p->stdin_fd  = -1; }
+    if (p->stdout_fd >= 0) { close(p->stdout_fd); p->stdout_fd = -1; }
+    if (p->stderr_fd >= 0) { close(p->stderr_fd); p->stderr_fd = -1; }
+#endif
+}
+
+/* proc:wait() -> exit code */
 static int proc_wait_fn(CandoVM *vm, int argc, CandoValue *args)
 {
     ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
@@ -450,30 +644,45 @@ static int proc_wait_fn(CandoVM *vm, int argc, CandoValue *args)
         return 1;
     }
 #if defined(_WIN32) || defined(_WIN64)
-    cando_vm_error(vm, "proc:wait: not implemented on Windows");
-    return -1;
+    HANDLE h = (HANDLE)p->win_proc_handle;
+    if (h == NULL) {
+        cando_vm_error(vm, "proc:wait: process handle is invalid");
+        return -1;
+    }
+    DWORD wr = WaitForSingleObject(h, INFINITE);
+    if (wr != WAIT_OBJECT_0) {
+        cando_vm_error(vm, "proc:wait: WaitForSingleObject failed: %lu",
+                       (unsigned long)GetLastError());
+        return -1;
+    }
+    DWORD code = 0;
+    GetExitCodeProcess(h, &code);
+    CloseHandle(h);
+    p->win_proc_handle = NULL;
+    p->exit_code       = (int)code;
+    p->waited          = true;
+    proc_close_orphan_fds(p);
+    cando_vm_push(vm, cando_number((f64)code));
+    return 1;
 #else
     int status = 0;
     if (waitpid(p->pid, &status, 0) < 0) {
         cando_vm_error(vm, "proc:wait: waitpid failed: %s", strerror(errno));
         return -1;
     }
-    int code = WIFEXITED(status) ? WEXITSTATUS(status)
+    int code = WIFEXITED(status)  ? WEXITSTATUS(status)
             : WIFSIGNALED(status) ? -WTERMSIG(status)
             : -1;
     p->exit_code = code;
     p->waited    = true;
-    /* Close any fds the user never asked for via :stdin/:stdout/:stderr.
-     * Fds promoted into a stream are already owned by that stream. */
-    if (p->stdin_fd  >= 0) { close(p->stdin_fd);  p->stdin_fd  = -1; }
-    if (p->stdout_fd >= 0) { close(p->stdout_fd); p->stdout_fd = -1; }
-    if (p->stderr_fd >= 0) { close(p->stderr_fd); p->stderr_fd = -1; }
+    proc_close_orphan_fds(p);
     cando_vm_push(vm, cando_number((f64)code));
     return 1;
 #endif
 }
 
-/* proc:kill([sig]) */
+/* proc:kill([sig]) -- POSIX takes a signal; on Windows the signal arg is
+ * ignored and the child is unconditionally terminated. */
 static int proc_kill_fn(CandoVM *vm, int argc, CandoValue *args)
 {
     ProcSlot *p = proc_resolve_receiver(vm, argc > 0 ? args[0] : cando_null());
@@ -483,8 +692,18 @@ static int proc_kill_fn(CandoVM *vm, int argc, CandoValue *args)
     }
 #if defined(_WIN32) || defined(_WIN64)
     (void)argc;
-    cando_vm_error(vm, "proc:kill: not implemented on Windows");
-    return -1;
+    HANDLE h = (HANDLE)p->win_proc_handle;
+    if (h == NULL) {
+        cando_vm_error(vm, "proc:kill: process handle is invalid");
+        return -1;
+    }
+    if (!TerminateProcess(h, 1)) {
+        cando_vm_error(vm, "proc:kill: TerminateProcess failed: %lu",
+                       (unsigned long)GetLastError());
+        return -1;
+    }
+    cando_vm_push(vm, args[0]);
+    return 1;
 #else
     int sig = (int)libutil_arg_num_at(args, argc, 1, (f64)SIGTERM);
     if (kill(p->pid, sig) != 0) {

--- a/source/lib/stream.c
+++ b/source/lib/stream.c
@@ -796,6 +796,204 @@ static const StreamVTable g_chan_vt = {
     .self_locked = true,
 };
 
+/* =========================================================================
+ * Transform adapter (`stream.transform(fn)`)
+ *
+ * Duplex stream that pipes every chunk through a user-supplied CanDo
+ * function:  write(bytes) → fn(bytes) → output buffer ← read(bytes).
+ *
+ * The transform owns a child VM (cando_vm_init_child) so the function
+ * can be invoked from non-script threads (e.g. inside a pipe driver) the
+ * same way socket/http server callbacks already do.  The internal mutex
+ * serialises `fn` calls — only one write may be in flight at a time —
+ * which keeps the child VM single-consumer and matches the user's
+ * mental model that a transform is sequential.
+ *
+ * Contract for `fn`:
+ *   - takes one string argument (the input chunk; may be partial)
+ *   - returns a string (the transformed bytes; may be empty to drop the
+ *     chunk) — non-string returns are ignored
+ *
+ * Backpressure: writes block other writers via the mutex but never the
+ * reader.  Readers block when the output buffer is empty until either a
+ * new write fills it or `:end()` is called.
+ * ===================================================================== */
+
+typedef struct TransformCtx {
+    CandoVM         child_vm;
+    bool            vm_inited;
+    CandoValue      fn;
+    /* Output buffer: append-only growing byte buffer with a read cursor.
+     * Compacts when fully drained, mirroring MemCtx. */
+    u8             *out_buf;
+    usize           out_cap;
+    usize           out_len;        /* bytes available to read */
+    bool            write_ended;
+    cando_mutex_t   mu;
+    cando_cond_t    not_empty;
+    StreamSlot     *owner;
+} TransformCtx;
+
+static void transform_out_append(TransformCtx *t, const u8 *data, usize len)
+{
+    if (len == 0) return;
+    if (t->out_len + len > t->out_cap) {
+        usize ncap = t->out_cap ? t->out_cap : 4096;
+        while (t->out_len + len > ncap) ncap *= 2;
+        t->out_buf = (u8 *)cando_realloc(t->out_buf, ncap);
+        t->out_cap = ncap;
+    }
+    memcpy(t->out_buf + t->out_len, data, len);
+    t->out_len += len;
+}
+
+static StreamStatus transform_write(void *vctx, const u8 *buf, usize len,
+                                    usize *n_out)
+{
+    TransformCtx *t = (TransformCtx *)vctx;
+    if (len == 0) { *n_out = 0; return STREAM_OK; }
+
+    cando_os_mutex_lock(&t->mu);
+    if (t->write_ended) {
+        cando_os_mutex_unlock(&t->mu);
+        *n_out = 0;
+        stream_set_error(t->owner, "transform: write after end");
+        return STREAM_ERR;
+    }
+
+    /* Build the input string and call the user transform.  The mutex is
+     * held for the duration so the child VM is exclusively ours; the
+     * function body cannot race against another write on this stream. */
+    CandoString *in_s = cando_string_new((const char *)buf, (u32)len);
+    CandoValue   arg  = cando_string_value(in_s);
+
+    int n_ret = cando_vm_call_value(&t->child_vm, t->fn, &arg, 1);
+    cando_string_release(in_s);
+
+    /* Drain returned values; only the first string is appended to the
+     * output buffer.  Anything else is silently dropped — matches the
+     * "filter chunk" semantics where returning null/non-string skips. */
+    if (n_ret > 0) {
+        CandoValue r = cando_vm_pop(&t->child_vm);
+        if (cando_is_string(r) && r.as.string && r.as.string->length > 0) {
+            transform_out_append(t,
+                                 (const u8 *)r.as.string->data,
+                                 r.as.string->length);
+            cando_os_cond_broadcast(&t->not_empty);
+        }
+        cando_value_release(r);
+        for (int i = 1; i < n_ret; i++) {
+            CandoValue extra = cando_vm_pop(&t->child_vm);
+            cando_value_release(extra);
+        }
+    }
+
+    cando_os_mutex_unlock(&t->mu);
+    *n_out = len;
+    return STREAM_OK;
+}
+
+static StreamStatus transform_read(void *vctx, u8 *out, usize cap, usize *n_out)
+{
+    TransformCtx *t = (TransformCtx *)vctx;
+    cando_os_mutex_lock(&t->mu);
+    while (t->out_len == 0 && !t->write_ended) {
+        cando_os_cond_wait(&t->not_empty, &t->mu);
+    }
+    if (t->out_len == 0) {
+        cando_os_mutex_unlock(&t->mu);
+        *n_out = 0;
+        return STREAM_EOF;
+    }
+    usize n = cap < t->out_len ? cap : t->out_len;
+    memcpy(out, t->out_buf, n);
+    if (n < t->out_len) {
+        memmove(t->out_buf, t->out_buf + n, t->out_len - n);
+    }
+    t->out_len -= n;
+    cando_os_mutex_unlock(&t->mu);
+    *n_out = n;
+    return STREAM_OK;
+}
+
+static StreamStatus transform_end(void *vctx)
+{
+    TransformCtx *t = (TransformCtx *)vctx;
+    cando_os_mutex_lock(&t->mu);
+    t->write_ended = true;
+    cando_os_cond_broadcast(&t->not_empty);
+    cando_os_mutex_unlock(&t->mu);
+    return STREAM_OK;
+}
+
+static void transform_destroy(void *vctx)
+{
+    TransformCtx *t = (TransformCtx *)vctx;
+    if (!t) return;
+    cando_os_mutex_lock(&t->mu);
+    t->write_ended = true;
+    cando_os_cond_broadcast(&t->not_empty);
+    cando_os_mutex_unlock(&t->mu);
+
+    if (t->vm_inited) {
+        cando_vm_destroy(&t->child_vm);
+        t->vm_inited = false;
+    }
+    cando_value_release(t->fn);
+    cando_free(t->out_buf);
+    cando_os_cond_destroy(&t->not_empty);
+    cando_os_mutex_destroy(&t->mu);
+    cando_free(t);
+}
+
+static const StreamVTable g_transform_vt = {
+    .read        = transform_read,
+    .write       = transform_write,
+    .flush       = NULL,
+    .end         = transform_end,
+    .destroy     = transform_destroy,
+    .seek        = NULL,
+    .tell        = NULL,
+    .kind_name   = "transform",
+    .self_locked = true,
+};
+
+/* stream.transform(fn) -> stream
+ *
+ * fn(chunk) → chunk: returns the transformed bytes for each input chunk.
+ * Return null or a non-string to drop the chunk.  The transform is
+ * applied eagerly on each :write so reads only see already-transformed
+ * bytes.
+ */
+static int mod_transform_fn(CandoVM *vm, int argc, CandoValue *args)
+{
+    if (argc < 1 || !cando_is_object(args[0])) {
+        cando_vm_error(vm, "stream.transform: function required");
+        return -1;
+    }
+    TransformCtx *t = (TransformCtx *)cando_alloc(sizeof(TransformCtx));
+    memset(t, 0, sizeof(*t));
+    cando_vm_init_child(&t->child_vm, vm);
+    t->vm_inited = true;
+    t->fn = cando_value_copy(args[0]);
+    cando_os_mutex_init(&t->mu);
+    cando_os_cond_init(&t->not_empty);
+
+    int idx = stream_pool_alloc(&g_transform_vt, t, STREAM_CAP_DUPLEX);
+    if (idx < 0) {
+        cando_value_release(t->fn);
+        cando_vm_destroy(&t->child_vm);
+        cando_os_cond_destroy(&t->not_empty);
+        cando_os_mutex_destroy(&t->mu);
+        cando_free(t);
+        cando_vm_error(vm, "stream.transform: too many active streams");
+        return -1;
+    }
+    t->owner = stream_pool_get(idx);
+    cando_vm_push(vm, stream_create_instance(vm, idx));
+    return 1;
+}
+
 /* stream.channel(capacity?) -> stream */
 static int mod_channel_fn(CandoVM *vm, int argc, CandoValue *args)
 {
@@ -907,8 +1105,9 @@ void cando_lib_stream_register(CandoVM *vm)
     /* Module globals. */
     CandoValue mod_val = cando_bridge_new_object(vm);
     CdoObject *mod_obj = cando_bridge_resolve(vm, mod_val.as.handle);
-    libutil_set_method(vm, mod_obj, "memory",  mod_memory_fn);
-    libutil_set_method(vm, mod_obj, "channel", mod_channel_fn);
+    libutil_set_method(vm, mod_obj, "memory",    mod_memory_fn);
+    libutil_set_method(vm, mod_obj, "channel",   mod_channel_fn);
+    libutil_set_method(vm, mod_obj, "transform", mod_transform_fn);
     cando_vm_set_global(vm, "stream", mod_val, true);
 
     /* Meta table for every stream instance. */

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -149,7 +149,7 @@ run_test "lib_secure_socket" "$SCRIPTS/lib_secure_socket.cdo" \
     "$(printf 'after listen\ntls-echo:hello\ntrue\ntrue\ndone')"
 
 run_test "lib_stream" "$SCRIPTS/lib_stream.cdo" \
-    "$(printf 'memory\nhello, world\n'\'''\''\nfalse\n1600\n1600\n1600\nfinal\n'\'''\''\ntrue\nfile\nalpha-bravo\n'\'''\''\nthrew\n20\npiped through memory\n29\nCanDo streams compose nicely.\nfrom thread\nchannel\nhello-from-channel\ntcp\nECHO:hello\nfile-piped-as-response\npayload-from-http\n0\nspawned-output\n800\nok')"
+    "$(printf 'memory\nhello, world\n'\'''\''\nfalse\n1600\n1600\n1600\nfinal\n'\'''\''\ntrue\nfile\nalpha-bravo\n'\'''\''\nthrew\n20\npiped through memory\n29\nCanDo streams compose nicely.\nfrom thread\nchannel\nhello-from-channel\ntcp\nECHO:hello\nfile-piped-as-response\npayload-from-http\n0\nspawned-output\n800\nnull\nstreamed-from-server\nHELLO, WORLD\ntransform\nPIPED THROUGH TRANSFORM\nok')"
 
 run_test "lib_crypto" "$SCRIPTS/lib_crypto.cdo" \
     "$(printf 'md5_ok\nsha256_ok\naGVsbG8gd29ybGQA\nhello world')"

--- a/tests/scripts/lib_stream.cdo
+++ b/tests/scripts/lib_stream.cdo
@@ -208,4 +208,52 @@ small:pipeTo(collected);
 thread.join(p2);
 print(collected:readAll():length());   /* expected: 800 */
 
+/* ---- 13e. true streaming HTTP client: drain body straight into file ---
+ *         Same end-to-end shape as 13b but using `{ stream: true }` so the
+ *         response body is never buffered in memory.                    */
+VAR ssrv2 = http.createServer(FUNCTION(req, res) {
+    res:status(200);
+    res:send("streamed-from-server");
+});
+ssrv2:listen(18794);
+
+VAR resp_st = fetch("http://127.0.0.1:18794/", { stream: TRUE });
+print(resp_st.body);                /* expected: null */
+VAR sink_st = "/tmp/cando_stream_lazy.bin";
+file.delete(sink_st);
+VAR fout_st = file.open(sink_st, "wb");
+resp_st:stream():pipeTo(fout_st);
+fout_st:close();
+print(file.read(sink_st));          /* expected: streamed-from-server */
+file.delete(sink_st);
+ssrv2:close();
+
+/* ---- 14. transform: uppercase every chunk via a script function --- */
+VAR upper = stream.transform(FUNCTION(chunk) {
+    RETURN chunk:toUpper();
+});
+upper:writeAll("hello, ");
+upper:writeAll("world");
+upper:end();
+print(upper:readAll());             /* expected: HELLO, WORLD */
+print(upper:kind());                /* expected: transform */
+
+/* ---- 15. transform pipeline: file -> uppercase -> memory ---------- */
+VAR tr_path = "/tmp/cando_stream_transform.txt";
+file.delete(tr_path);
+VAR fw_t = file.open(tr_path, "wb");
+fw_t:writeAll("piped through transform");
+fw_t:close();
+
+VAR up2  = stream.transform(FUNCTION(c) { RETURN c:toUpper(); });
+VAR sink_t = stream.memory();
+VAR fr_t = file.open(tr_path, "rb");
+/* Two-phase: drain source into transform, end it, then drain transform. */
+fr_t:pipeTo(up2);
+up2:end();
+up2:pipeTo(sink_t);
+fr_t:close();
+print(sink_t:readAll());            /* expected: PIPED THROUGH TRANSFORM */
+file.delete(tr_path);
+
 print("ok");                        /* expected: ok */


### PR DESCRIPTION
## Summary

This PR adds true streaming support for HTTP client responses, implements Windows process spawning, and introduces a new `stream.transform()` API for lazy chunk transformation. These changes enable handling arbitrarily large downloads/uploads without buffering entire bodies in memory.

## Key Changes

### HTTP Client Streaming (`source/lib/http.c`)
- Added `HttpClientBodyCtx` adapter that wraps an open connection and body reader, allowing script code to drain response bodies lazily via `resp:stream()`
- Implemented `http_client_body_read()` and `http_client_body_destroy()` to manage the streaming lifecycle
- Extended `http_do_request_native()` to support `{ stream: true }` option; when enabled, returns response with `body: null` and a hidden `__stream_id` field for lazy draining
- Response object includes status, headers, and a `:stream()` method that surfaces the lazy body adapter

### HTTP Server Streaming (`source/lib/http.c`)
- Refactored `res:stream()` from buffering-then-sending to true chunked transfer encoding
- Implemented `res_stream_send_headers()`, `res_stream_send_chunk()`, and `res_stream_send_terminator()` to emit HTTP/1.1 chunked responses on-the-wire
- First `:write()` sends headers with `Transfer-Encoding: chunked`; subsequent writes emit individual chunks; `:end()` sends terminating zero-length chunk
- Enables servers to stream gigabyte responses without buffering

### Streaming Response Parser (`source/lib/httputil.c` and `.h`)
- Added `HttpResponseHead` struct and `http_read_response_head()` to parse status/headers without reading the body
- Implemented `HttpBodyReader` with `http_body_reader_init()` and `http_body_reader_read()` to support lazy body consumption
- Supports Content-Length, Transfer-Encoding: chunked, and connection-close framing with identical byte-for-byte behavior as buffered path
- Over-read bytes past headers are stashed in `tail` buffer for the body reader

### Transform Streams (`source/lib/stream.c`)
- Added `stream.transform(fn)` API: duplex stream that pipes every chunk through a user-supplied CanDo function
- `TransformCtx` owns a child VM (`cando_vm_init_child`) so the transform function can be invoked from any thread (e.g., pipe driver) without sharing call frames
- Internal mutex serializes function calls; only one write in flight at a time
- Output buffer with read cursor; readers block when empty until new write or `:end()`
- Returning `null` or non-string from `fn` drops the chunk (filter semantics)

### Windows Process Support (`source/lib/process.c`)
- Implemented `spawn_windows()` using `CreateProcess` + anonymous pipes
- Added `win_build_cmdline()` and `win_append_quoted()` to properly escape command-line arguments per Windows `CommandLineToArgvW` rules
- Pipe ends marked non-inheritable in parent to prevent leaks across multiple spawns
- Added `win_proc_handle` field to `ProcSlot` to track child process for `proc:wait()` and `proc:kill()`
- Implemented `proc:wait()` on Windows using `WaitForSingleObject()`
- Added `proc_close_orphan_fds()` to clean up file descriptors not promoted to streams

### Documentation (`docs/streaming.md`)
- Added `stream.transform()` to the stream types table
- Updated HTTP download example to use `{ stream: true }` with lazy body draining
- Added chunked HTTP response example showing server-side streaming
- Added transform pipeline example demonstrating uppercase transformation
- Clarified that transforms own child VMs and can run from any thread

## Notable Implementation Details

- **Lazy body draining**: HTTP client streaming reads only headers initially, then drains body on-demand via `HttpBodyReader` state machine supporting all three HTTP/1.1 framing modes
- **Chunked encoding**: Server-side streaming emits proper HTTP/1.1 chunked format with hex-length pref

https://claude.ai/code/session_01BrTYVbHrADbVj8fqHXFezk