### PR TITLE
Fix window close handling to prevent OS force-kill on Windows

### DIFF
--- a/modules/window/window_module.c
+++ b/modules/window/window_module.c
@@ -830,13 +830,20 @@ static void mgr_render_frame(void)
         WindowSlot *s = &g_slots[i];
         if (!s->alive || !s->handle) continue;
 
-        /* Note: we deliberately do NOT auto-tear-down on
-         * glfwWindowShouldClose yet.  The close-button -> w.quit ->
-         * w:close() chain is wired up alongside the GLFW input
-         * callbacks in the next chunk.  Keeping this off avoids xvfb
-         * spuriously reporting should-close at startup when there is
-         * no WM to handle WM_PROTOCOLS / WM_DELETE_WINDOW. */
-        glfwSetWindowShouldClose(s->handle, GLFW_FALSE);
+        /* Reap windows whose close button (X / WM_DELETE_WINDOW) was
+         * pressed.  Without this, WM_CLOSE is acknowledged by GLFW but
+         * never acted on, so the OS pump on Windows treats the window
+         * as non-responsive and eventually force-kills the app.  The
+         * spurious should-close that xvfb sets at construction is
+         * cleared once in CMD_CREATE; on a real WM nothing else sets
+         * the flag, so checking it per frame is safe. */
+        if (glfwWindowShouldClose(s->handle)) {
+            if (g_dispatch_vm_inited && s->inst_val_held) {
+                dispatch_call(s, "quit", NULL, 0);
+            }
+            slot_teardown(s);
+            continue;
+        }
 
         double dt = (s->last_frame_time > 0.0)
                     ? (now - s->last_frame_time)


### PR DESCRIPTION
## Summary
Changed window close button handling from unconditionally suppressing the close flag to actively reaping windows when the close button is pressed. This prevents the OS from treating the application as non-responsive on Windows when WM_CLOSE is acknowledged but not acted upon.

## Key Changes
- Replaced `glfwSetWindowShouldClose(s->handle, GLFW_FALSE)` with active window reaping logic
- When `glfwWindowShouldClose()` returns true, the window now:
  - Dispatches a "quit" call to the window's Lua instance (if initialized)
  - Tears down the window slot
  - Continues to the next window
- Updated comments to explain the new behavior and why it's necessary

## Implementation Details
- The spurious close flag set by xvfb at window construction is still cleared once during `CMD_CREATE`, so per-frame checking is safe on real window managers
- The change ensures proper handling of WM_DELETE_WINDOW protocol on all platforms while maintaining compatibility with headless environments like xvfb
- Lua-side cleanup via the "quit" dispatch is performed before teardown, allowing graceful shutdown logic to execute

https://claude.ai/code/session_01VZHRo9xEdJ2r6ap5961JZo