### PR TITLE
Add command-line argument passing to scripts via global `args`

### DIFF
--- a/include/cando.h
+++ b/include/cando.h
@@ -193,6 +193,26 @@ CANDO_API int cando_dofile(CandoVM *vm, const char *path);
 CANDO_API int cando_dostring(CandoVM *vm, const char *src, const char *name);
 
 /**
+ * cando_set_args — expose command-line arguments to the script.
+ *
+ * Registers a global named `args` containing an array of strings.  By
+ * convention `argv` is the list of arguments passed to the script (the
+ * caller decides whether to include the script path itself); the strings
+ * are copied, so the source buffer may be freed or reused after this call.
+ *
+ * The global is registered with const semantics — scripts cannot rebind
+ * `args` to a different value.  Calling cando_set_args() more than once
+ * on the same VM is a no-op after the first call.
+ *
+ * Typical usage from a host:
+ *   cando_set_args(vm, argc - 2, (const char *const *)&argv[2]);
+ *
+ * From inside a script:
+ *   IF args.length() > 0 { print(args[0]); }
+ */
+CANDO_API void cando_set_args(CandoVM *vm, int argc, const char *const *argv);
+
+/**
  * cando_loadstring — compile a source string without executing it.
  *
  * On success stores the compiled CandoChunk* in *chunk_out and returns

--- a/source/cando_lib.c
+++ b/source/cando_lib.c
@@ -29,10 +29,13 @@
 #include "core/common.h"
 #include "core/thread_platform.h"
 #include "vm/vm.h"
+#include "vm/bridge.h"
 #include "vm/chunk.h"
 #include "vm/debug.h"
 #include "parser/parser.h"
 #include "object/object.h"
+#include "object/array.h"
+#include "object/string.h"
 #include "natives.h"
 
 /* Library registration headers */
@@ -328,6 +331,27 @@ CANDO_API int cando_loadstring(CandoVM *vm, const char *src, const char *name,
                                 CandoChunk **chunk_out)
 {
     return compile_source(vm, src, strlen(src), name, chunk_out);
+}
+
+/* =========================================================================
+ * Command-line arguments
+ * ====================================================================== */
+
+CANDO_API void cando_set_args(CandoVM *vm, int argc, const char *const *argv)
+{
+    if (!vm) return;
+
+    CandoValue arr_val = cando_bridge_new_array(vm);
+    CdoObject *arr     = cando_bridge_resolve(vm, arr_val.as.handle);
+
+    for (int i = 0; i < argc; i++) {
+        const char *s = (argv && argv[i]) ? argv[i] : "";
+        CdoString *cs = cdo_string_new(s, (u32)strlen(s));
+        cdo_array_push(arr, cdo_string_value(cs));
+        cdo_string_release(cs);
+    }
+
+    cando_vm_set_global(vm, "args", arr_val, true);
 }
 
 /* =========================================================================

--- a/source/main.c
+++ b/source/main.c
@@ -6,8 +6,10 @@
  * main.c only handles command-line argument parsing and exit codes.
  *
  * Usage:
- *   cando <file.cdo>            Execute a script
- *   cando <file.cdo> --disasm   Disassemble then execute
+ *   cando <file.cdo> [--disasm] [args...]
+ *
+ * Anything after the script path that is not the `--disasm` switch is
+ * forwarded to the script via the global `args` array.
  *
  * Must compile with gcc -std=c11.
  */
@@ -22,20 +24,41 @@ int main(int argc, char *argv[])
 {
     if (argc < 2) {
         fprintf(stderr, "CanDo %s\n", CANDO_VERSION);
-        fprintf(stderr, "usage: %s <file.cdo> [--disasm]\n", argv[0]);
+        fprintf(stderr, "usage: %s <file.cdo> [--disasm] [args...]\n", argv[0]);
         return 1;
     }
 
     const char *path   = argv[1];
-    bool        disasm = (argc >= 3 && strcmp(argv[2], "--disasm") == 0);
+    bool        disasm = false;
+
+    /* Collect script args: everything after argv[1] except the --disasm
+     * switch (which is consumed by the interpreter, not the script). */
+    const char **script_argv = NULL;
+    int          script_argc = 0;
+    if (argc > 2) {
+        script_argv = (const char **)malloc(sizeof(char *) * (size_t)(argc - 2));
+        if (!script_argv) {
+            fprintf(stderr, "cando: out of memory\n");
+            return 1;
+        }
+        for (int i = 2; i < argc; i++) {
+            if (strcmp(argv[i], "--disasm") == 0) {
+                disasm = true;
+            } else {
+                script_argv[script_argc++] = argv[i];
+            }
+        }
+    }
 
     /* Create a new VM and load all standard libraries. */
     CandoVM *vm = cando_open();
     if (!vm) {
         fprintf(stderr, "cando: failed to create VM (out of memory?)\n");
+        free(script_argv);
         return 1;
     }
     cando_openlibs(vm);
+    cando_set_args(vm, script_argc, script_argv);
 
     int rc = 0;
 
@@ -46,6 +69,7 @@ int main(int argc, char *argv[])
         if (!f) {
             fprintf(stderr, "cando: cannot open '%s'\n", path);
             cando_close(vm);
+            free(script_argv);
             return 1;
         }
         fseek(f, 0, SEEK_END);
@@ -61,6 +85,7 @@ int main(int argc, char *argv[])
             if (lr != CANDO_OK || !chunk) {
                 fprintf(stderr, "cando: %s\n", cando_errmsg(vm));
                 cando_close(vm);
+                free(script_argv);
                 return 1;
             }
             cando_chunk_disasm(chunk, stderr);
@@ -83,5 +108,6 @@ int main(int argc, char *argv[])
     }
 
     cando_close(vm);
+    free(script_argv);
     return rc;
 }

--- a/tests/scripts/lib_args.cdo
+++ b/tests/scripts/lib_args.cdo
@@ -1,0 +1,6 @@
+/* Verify that command-line arguments are exposed via the `args` global. */
+
+print("args_type: " + type(args));
+print("args_count: " + toString(args:length()));
+
+FOR a OF args { print("arg: " + a); }


### PR DESCRIPTION
## Summary
This PR adds support for passing command-line arguments to CanDo scripts. Arguments are exposed to scripts via a global `args` array, allowing scripts to access parameters passed on the command line.

## Key Changes
- **Command-line parsing**: Modified `main.c` to collect all arguments after the script path (excluding the `--disasm` switch) and pass them to the VM
- **New API function**: Added `cando_set_args()` to the public API in `cando.h` to register command-line arguments as a global array
- **Implementation**: Added `cando_set_args()` implementation in `cando_lib.c` that creates a string array and registers it as a read-only global named `args`
- **Memory management**: Properly allocate and free the script arguments array in `main.c`, with cleanup on all error paths
- **Documentation**: Updated usage documentation in `main.c` and added comprehensive API documentation in `cando.h`
- **Test script**: Added `lib_args.cdo` test script to verify the feature works correctly

## Implementation Details
- Arguments are collected into a dynamically allocated array that excludes the `--disasm` flag (which is consumed by the interpreter)
- The `args` global is registered with const semantics, preventing scripts from rebinding it
- String arguments are copied into the VM's object system, so the source buffer can be freed after the call
- All error paths properly clean up allocated memory to prevent leaks

https://claude.ai/code/session_011WBDzyizm6YvTrYGMgYrxA