### PR TITLE
Add YAML standard library with parse and stringify support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tests/test_parser
 tests/test_thread
 tests/test_vm
 tests/test_sockutil
+tests/test_yaml
 
 # Library build artifacts (CMake and Makefile)
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(LIB_SRCS
     source/lib/include.c
     source/lib/json.c
     source/lib/csv.c
+    source/lib/yaml.c
     source/lib/thread.c
     source/lib/os.c
     source/lib/datetime.c
@@ -328,3 +329,12 @@ target_compile_options(test_sockutil PRIVATE
 target_link_libraries(test_sockutil PRIVATE
     Threads::Threads OpenSSL::SSL OpenSSL::Crypto ${PLATFORM_LIBS})
 add_test(NAME test_sockutil COMMAND $<TARGET_FILE:test_sockutil>)
+
+# test_yaml — links against libcando to drive the high-level VM/library API.
+add_executable(test_yaml tests/test_yaml.c)
+target_include_directories(test_yaml PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/source
+)
+target_link_libraries(test_yaml PRIVATE libcando)
+add_test(NAME test_yaml COMMAND $<TARGET_FILE:test_yaml>)

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ CANDO_LIB_SRCS = \
     source/lib/include.c          \
     source/lib/json.c             \
     source/lib/csv.c              \
+    source/lib/yaml.c             \
     source/lib/thread.c           \
     source/lib/os.c               \
     source/lib/app.c              \
@@ -153,6 +154,7 @@ TEST_PARSER_BIN   = tests/test_parser
 TEST_VM_BIN       = tests/test_vm
 TEST_THREAD_BIN   = tests/test_thread
 TEST_SOCKUTIL_BIN = tests/test_sockutil
+TEST_YAML_BIN     = tests/test_yaml
 
 TEST_CORE_SRCS     = $(CORE_SRCS)   tests/test_core.c
 TEST_OBJECT_SRCS   = $(CORE_SRCS) $(OBJECT_SRCS) tests/test_object.c
@@ -167,13 +169,13 @@ TEST_SOCKUTIL_SRCS = $(CORE_SRCS) source/lib/sockutil.c tests/test_sockutil.c
 
 .PHONY: all cando libcando.so libcando.a \
         test test_core test_object test_lexer test_parser test_vm test_thread \
-        test_sockutil test_integration clean \
+        test_sockutil test_yaml test_integration clean \
         modules modules-test modules-windows modules-clean
 
 all: libcando.so libcando.a $(CANDO_BIN) \
      $(TEST_CORE_BIN) $(TEST_OBJECT_BIN) $(TEST_LEXER_BIN) \
      $(TEST_PARSER_BIN) $(TEST_VM_BIN) $(TEST_THREAD_BIN) \
-     $(TEST_SOCKUTIL_BIN)
+     $(TEST_SOCKUTIL_BIN) $(TEST_YAML_BIN)
 
 # ---------------------------------------------------------------------------
 # Shared library: libcando.so
@@ -235,6 +237,12 @@ $(TEST_THREAD_BIN): $(TEST_THREAD_SRCS)
 $(TEST_SOCKUTIL_BIN): $(TEST_SOCKUTIL_SRCS)
 	$(CC) $(CFLAGS_CORE) -iquote source -iquote source/lib $^ -o $@ $(LDFLAGS)
 
+# test_yaml uses the high-level embedding API so it links against libcando.so.
+$(TEST_YAML_BIN): tests/test_yaml.c libcando.so
+	$(CC) $(CFLAGS_EXE) tests/test_yaml.c \
+	    -L. -lcando -Wl,-rpath,'$$ORIGIN/..' \
+	    -o $@ $(LDFLAGS)
+
 test: all
 	./$(TEST_CORE_BIN)
 	./$(TEST_OBJECT_BIN)
@@ -243,6 +251,7 @@ test: all
 	./$(TEST_PARSER_BIN)
 	./$(TEST_VM_BIN)
 	./$(TEST_SOCKUTIL_BIN)
+	./$(TEST_YAML_BIN)
 	bash tests/integration/run_tests.sh
 
 test_integration: $(CANDO_BIN)
@@ -268,6 +277,9 @@ test_thread: $(TEST_THREAD_BIN)
 
 test_sockutil: $(TEST_SOCKUTIL_BIN)
 	./$(TEST_SOCKUTIL_BIN)
+
+test_yaml: $(TEST_YAML_BIN)
+	./$(TEST_YAML_BIN)
 
 # ---------------------------------------------------------------------------
 # Windows cross-compilation (requires mingw-w64)
@@ -363,7 +375,7 @@ modules-clean:
 clean: modules-clean
 	rm -f $(TEST_CORE_BIN) $(TEST_OBJECT_BIN) $(TEST_LEXER_BIN) \
 	      $(TEST_PARSER_BIN) $(TEST_VM_BIN) $(TEST_THREAD_BIN) \
-	      $(TEST_SOCKUTIL_BIN) \
+	      $(TEST_SOCKUTIL_BIN) $(TEST_YAML_BIN) \
 	      $(CANDO_BIN) cando.exe \
 	      libcando.so libcando.a libcando.dll libcando.lib icon.res
 	rm -rf $(LIBOBJS_DIR)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ compiled to bytecode for a stack-based VM.
 | [socket.md](socket.md) | Long-form guide to the `socket` and `secure_socket` libraries |
 | [streaming.md](streaming.md) | Unified `stream` API: pipe between files, sockets, HTTP, processes, threads |
 | [threading.md](threading.md) | `thread` / `await`, the `thread` library, shared state |
+| [yaml.md](yaml.md) | YAML parse / stringify and `include()`-time loading |
 
 ## For C embedders
 

--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -59,6 +59,7 @@ void cando_open_arraylib(CandoVM *vm);            /* array prototype       */
 void cando_open_objectlib(CandoVM *vm);           /* object.*              */
 void cando_open_jsonlib(CandoVM *vm);             /* json.*                */
 void cando_open_csvlib(CandoVM *vm);              /* csv.*                 */
+void cando_open_yamllib(CandoVM *vm);             /* yaml.*                */
 void cando_open_threadlib(CandoVM *vm);           /* thread.*              */
 void cando_open_oslib(CandoVM *vm);               /* os.*                  */
 void cando_open_datetimelib(CandoVM *vm);         /* datetime.*            */

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -287,6 +287,57 @@ The parser accepts RFC 4180 quoting with doubled `""` escapes.
 
 ---
 
+## `yaml`
+
+| Function | Description |
+|---|---|
+| `yaml.parse(text)` | Decode a YAML 1.2 document into CanDo values.  Throws on malformed input. |
+| `yaml.stringify(value, indent?)` | Encode a CanDo value as block-style YAML text.  `indent` (default 2, range 1..16) controls the per-level indentation. |
+
+Supported features:
+
+- Block mappings (`key: value`), block sequences (`- item`), and nested
+  combinations of both — including the common `- key: value` form for
+  sequences of mappings.
+- Flow mappings (`{a: 1, b: 2}`) and flow sequences (`[1, 2, 3]`),
+  one-line only.
+- Plain, single-quoted (`'…'` with `''` escape), and double-quoted (`"…"`
+  with JSON-style escapes plus `\xNN`, `\uNNNN`, `\UNNNNNNNN`) scalars.
+- Literal (`|`) and folded (`>`) block scalars with the default
+  chomping behaviour (single trailing newline).
+- Core-schema scalar typing — unquoted scalars become `null`, `true`,
+  `false`, integers (decimal / `0x…` / `0o…`), or floats (`1.5`,
+  `.inf`, `.nan`) when they match the corresponding grammar; otherwise
+  they remain strings.  `yes`/`no`/`on`/`off` are also accepted as
+  booleans for compatibility.
+- Line comments (`# …`).  A `#` outside a quoted string and either at
+  start-of-line or preceded by whitespace begins a comment that runs to
+  end-of-line.
+- An optional leading `---` document marker.
+
+`yaml.stringify()` quotes scalars only when ambiguity rules require it
+(empty strings, reserved scalars like `null`/`true`/`yes`, leading
+indicator characters, embedded control characters, or strings that
+would otherwise round-trip back to a non-string type).  Functions and
+natives serialise as `null`.
+
+```cdo
+VAR cfg = yaml.parse("name: cando
+version: 1
+tags:
+  - alpha
+  - beta
+");
+print(cfg.name);          // cando
+print(cfg.tags[0]);       // alpha
+
+VAR doc = yaml.stringify({ host: "localhost", port: 8080 });
+// host: localhost
+// port: 8080
+```
+
+---
+
 ## `datetime`
 
 | Function | Description |
@@ -702,6 +753,7 @@ The file extension selects the loader:
 | `.so` / `.dylib` / `.dll`| Loaded with `dlopen`; the symbol `cando_module_init(CandoVM *) → CandoValue` is called once and its return value is the module value. See [writing-extensions.md](writing-extensions.md). |
 | `.json`                  | File contents are parsed as JSON and the resulting Cando value (object/array/string/number/bool/null) is returned.                                                |
 | `.csv`                   | File contents are parsed as CSV with the default `,` delimiter and no header row; the result is an array of arrays of strings.                                    |
+| `.yaml` / `.yml`         | File contents are parsed as YAML and the resulting Cando value is returned.  See `yaml.parse` for the supported feature set.                                       |
 
 If the path has **no extension at all**, `include` probes the
 filesystem in this order and uses the first match it finds:
@@ -716,8 +768,9 @@ file does not exist, `include` raises an error rather than probing
 alternatives.
 
 Identical canonical paths share one cached value across the whole VM —
-Node.js `require()` semantics.  This applies to JSON and CSV results
-too, so mutating the returned value mutates every other holder of it.
+Node.js `require()` semantics.  This applies to JSON, CSV and YAML
+results too, so mutating the returned value mutates every other holder
+of it.
 
 Example:
 
@@ -738,6 +791,9 @@ print(cfg.port);
 
 VAR rows = include("./data.csv");       // array of arrays of strings
 print(rows[0][0]);
+
+VAR yaml = include("./settings.yaml");  // parsed YAML mapping
+print(yaml.host);
 
 VAR bin  = include("./mylib");          // tries mylib.so, .dylib, .dll, .cdo
 ```

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -1,0 +1,146 @@
+# YAML Library
+
+The `yaml` library is part of the CanDo standard library — it is
+registered by `cando_openlibs()` (or `cando_open_yamllib()`) and
+exposes a single global `yaml` object.
+
+```cdo
+print(yaml.parse("a: 1\nb: 2"));
+```
+
+The implementation is self-contained C — no external `libyaml` runtime
+dependency.  It targets the YAML 1.2 *core schema*, with a small set of
+YAML 1.1 conveniences kept for compatibility (`yes`/`no`/`on`/`off`
+booleans).
+
+## API
+
+### `yaml.parse(text) → value`
+
+Decode a YAML document into native CanDo values.
+
+| YAML construct                      | CanDo value                                                |
+| ----------------------------------- | ---------------------------------------------------------- |
+| Block mapping / flow mapping        | object (insertion-ordered)                                 |
+| Block sequence / flow sequence      | array                                                      |
+| Plain scalar                        | core-schema typed: `null`/`true`/`false`/integer/float/string |
+| Single-quoted (`'…'`) scalar        | string (only `''` escape; preserves everything else)       |
+| Double-quoted (`"…"`) scalar        | string with JSON-style escapes plus `\xNN`, `\uNNNN`, `\UNNNNNNNN` |
+| Literal block scalar (`\|`)          | string (newlines preserved)                                |
+| Folded block scalar (`>`)           | string (line breaks become spaces; blank line → newline)   |
+
+Throws an error on malformed input — for example, unterminated quoted
+strings, unterminated flow containers, tab-indented block content, or
+trailing junk after the document.
+
+### `yaml.stringify(value, indent?) → string`
+
+Serialise a CanDo value as a block-style YAML document.
+
+- `indent` (default 2, range 1..16) controls the per-level indentation
+  in spaces.
+- Objects emit as block mappings, arrays as block sequences, with
+  empty containers rendered inline as `{}` / `[]`.
+- Scalars are quoted only when ambiguity rules would otherwise change
+  their type on round-trip — strings that look like numbers, booleans,
+  or `null`; strings starting with a YAML indicator character; strings
+  with control characters or trailing whitespace.
+- Functions and natives are not representable in YAML and serialise
+  as `null`.
+
+The output always ends with a single trailing newline.
+
+## Examples
+
+### Parsing a configuration file
+
+```cdo
+VAR cfg = yaml.parse('
+service: api
+port: 8080
+features:
+  - login
+  - billing
+db:
+  host: db.local
+  pool: 5
+');
+
+print(cfg.service);          // api
+print(cfg.port);             // 8080
+print(cfg.features[0]);      // login
+print(cfg.db.host);          // db.local
+```
+
+### Round-tripping
+
+```cdo
+VAR doc = { name: "cando", tags: ["alpha", "beta"], stable: true };
+VAR text = yaml.stringify(doc);
+VAR back = yaml.parse(text);
+
+print(back.name);            // cando
+print(back.tags[1]);         // beta
+print(back.stable);          // true
+```
+
+### Loading via `include()`
+
+`include()` recognises `.yaml` and `.yml` extensions and returns the
+parsed YAML document, with the same module caching rules as
+JSON / CSV / native modules:
+
+```cdo
+VAR settings = include("./settings.yaml");
+print(settings.host);
+```
+
+## Supported subset
+
+This is the supported feature set, in roughly the order you are likely
+to need it:
+
+- Block mappings: `key: value`, with the value either inline or on a
+  child indent.
+- Block sequences: `- item`, including the inline `- key: value` form
+  for sequences of mappings.
+- Flow containers: `[a, b]`, `{a: 1, b: 2}` — single-line only.
+- Plain, single-quoted, and double-quoted scalars.
+- Literal (`|`) and folded (`>`) block scalars with default chomping.
+- Line comments: `# …`.
+- An optional leading `---` document marker.
+- Core-schema scalar typing (`null`, `~`, `true`, `false`, integers,
+  floats, strings) plus YAML 1.1 booleans (`yes`/`no`/`on`/`off`).
+
+The following YAML features are intentionally not supported (they are
+rare in practice and add a lot of complexity to a single-file
+implementation):
+
+- Anchors (`&id`), aliases (`*id`), merge keys (`<<:`).
+- Explicit type tags (`!!str`, `!!float`, etc.).
+- Multi-document streams beyond a single optional leading `---`.
+- Complex / non-string mapping keys (`? key` syntax).
+- Tab characters in block-structural indentation (an explicit error).
+
+When the parser hits an unsupported or malformed construct it throws an
+error rather than silently producing the wrong shape, so scripts
+relying on `yaml.parse` can `try { … } catch (e) { … }` around the call
+and surface a useful diagnostic.
+
+## C API
+
+For embedders and other library code there is a single re-usable
+parsing entry point:
+
+```c
+#include <cando/lib/yaml.h>
+
+CANDO_API bool cando_lib_yaml_parse_buffer(CandoVM *vm,
+                                           const char *src, usize len,
+                                           const char *where,
+                                           CandoValue *out);
+```
+
+It is the same function used by the `include()` loader to parse
+`.yaml`/`.yml` files; on failure it sets a VM error prefixed with
+`where` and returns `false`.

--- a/include/cando.h
+++ b/include/cando.h
@@ -83,6 +83,7 @@
 #include "lib/include.h"
 #include "lib/json.h"
 #include "lib/csv.h"
+#include "lib/yaml.h"
 #include "lib/thread.h"
 #include "lib/os.h"
 #include "lib/datetime.h"
@@ -148,6 +149,7 @@ CANDO_API void cando_open_arraylib(CandoVM *vm);     /**< array prototype   */
 CANDO_API void cando_open_objectlib(CandoVM *vm);    /**< object.*          */
 CANDO_API void cando_open_jsonlib(CandoVM *vm);      /**< json.*            */
 CANDO_API void cando_open_csvlib(CandoVM *vm);       /**< csv.*             */
+CANDO_API void cando_open_yamllib(CandoVM *vm);      /**< yaml.*            */
 CANDO_API void cando_open_threadlib(CandoVM *vm);    /**< thread.*          */
 CANDO_API void cando_open_oslib(CandoVM *vm);        /**< os.*              */
 CANDO_API void cando_open_datetimelib(CandoVM *vm);  /**< datetime.*        */

--- a/source/cando_lib.c
+++ b/source/cando_lib.c
@@ -46,6 +46,7 @@
 #include "lib/include.h"
 #include "lib/json.h"
 #include "lib/csv.h"
+#include "lib/yaml.h"
 #include "lib/thread.h"
 #include "lib/os.h"
 #include "lib/app.h"
@@ -174,6 +175,7 @@ CANDO_API void cando_openlibs(CandoVM *vm)
     cando_lib_include_register(vm);
     cando_lib_json_register(vm);
     cando_lib_csv_register(vm);
+    cando_lib_yaml_register(vm);
     cando_lib_thread_register(vm);
     cando_lib_os_register(vm);
     cando_lib_app_register(vm);
@@ -205,6 +207,7 @@ CANDO_API void cando_open_arraylib(CandoVM *vm)    { cando_lib_array_register(vm
 CANDO_API void cando_open_objectlib(CandoVM *vm)   { cando_lib_object_register(vm);   }
 CANDO_API void cando_open_jsonlib(CandoVM *vm)     { cando_lib_json_register(vm);     }
 CANDO_API void cando_open_csvlib(CandoVM *vm)      { cando_lib_csv_register(vm);      }
+CANDO_API void cando_open_yamllib(CandoVM *vm)     { cando_lib_yaml_register(vm);     }
 CANDO_API void cando_open_threadlib(CandoVM *vm)   { cando_lib_thread_register(vm);   }
 CANDO_API void cando_open_oslib(CandoVM *vm)       { cando_lib_os_register(vm);       }
 CANDO_API void cando_open_datetimelib(CandoVM *vm) { cando_lib_datetime_register(vm); }

--- a/source/lib/include.c
+++ b/source/lib/include.c
@@ -4,10 +4,11 @@
  * include(path)
  *
  *   Loads a script (.cdo), binary extension (.so/.dylib/.dll), JSON
- *   document (.json) or CSV document (.csv) by path.  The first load
- *   executes/parses the module and caches the result; every subsequent
- *   call with the same canonical path returns the cached value without
- *   re-running the loader (Node.js require() semantics).
+ *   document (.json), CSV document (.csv) or YAML document (.yaml/.yml)
+ *   by path.  The first load executes/parses the module and caches the
+ *   result; every subsequent call with the same canonical path returns
+ *   the cached value without re-running the loader (Node.js require()
+ *   semantics).
  *
  * Path resolution
  *   - Absolute paths  ("/…")        → used as-is then canonicalised.
@@ -18,8 +19,8 @@
  *
  * Extension handling
  *   - If the path ends in a recognised extension (.cdo, .so, .dylib,
- *     .dll, .json, .csv) the file is loaded with the matching loader and
- *     a missing file is an error.
+ *     .dll, .json, .csv, .yaml, .yml) the file is loaded with the
+ *     matching loader and a missing file is an error.
  *   - If the path has no extension at all, include() probes the
  *     filesystem in order and uses the first existing match:
  *         <path>.so  →  <path>.dylib  →  <path>.dll  →  <path>.cdo
@@ -33,7 +34,9 @@
  *   .json files are parsed with cando_lib_json_parse_buffer() and the
  *   resulting Cando value is returned.  .csv files are parsed with
  *   cando_lib_csv_parse_buffer() (default comma delimiter, no header
- *   row) and the resulting array of arrays is returned.
+ *   row) and the resulting array of arrays is returned.  .yaml / .yml
+ *   files are parsed with cando_lib_yaml_parse_buffer() and the
+ *   resulting Cando value is returned.
  *
  * Must compile with gcc -std=c11.
  */
@@ -42,6 +45,7 @@
 #include "libutil.h"
 #include "json.h"
 #include "csv.h"
+#include "yaml.h"
 #include "../parser/parser.h"
 #include "../vm/chunk.h"
 
@@ -347,6 +351,7 @@ typedef enum {
     INC_KIND_BINARY,
     INC_KIND_JSON,
     INC_KIND_CSV,
+    INC_KIND_YAML,
 } IncludeKind;
 
 /* Case-sensitive suffix match. */
@@ -365,6 +370,8 @@ static IncludeKind path_kind(const char *p)
     if (ends_with(p, n, ".cdo"))   return INC_KIND_CDO;
     if (ends_with(p, n, ".json"))  return INC_KIND_JSON;
     if (ends_with(p, n, ".csv"))   return INC_KIND_CSV;
+    if (ends_with(p, n, ".yaml"))  return INC_KIND_YAML;
+    if (ends_with(p, n, ".yml"))   return INC_KIND_YAML;
     return INC_KIND_NONE;
 }
 
@@ -441,6 +448,17 @@ static bool load_csv(CandoVM *vm, const char *canonical_path,
     return ok;
 }
 
+static bool load_yaml(CandoVM *vm, const char *canonical_path,
+                      CandoValue *result_out)
+{
+    char  *src = NULL;
+    usize  len = 0;
+    if (!read_whole_file(vm, canonical_path, &src, &len)) return false;
+    bool ok = cando_lib_yaml_parse_buffer(vm, src, len, "include", result_out);
+    cando_free(src);
+    return ok;
+}
+
 static int native_include(CandoVM *vm, int argc, CandoValue *args)
 {
     if (argc < 1 || !cando_is_string(args[0])) {
@@ -503,6 +521,16 @@ static int native_include(CandoVM *vm, int argc, CandoValue *args)
             if (ok) {
                 results = (CandoValue *)cando_alloc(sizeof(CandoValue));
                 results[0]   = csv_res;
+                result_count = 1;
+            }
+            break;
+        }
+        case INC_KIND_YAML: {
+            CandoValue yaml_res = cando_null();
+            ok = load_yaml(vm, canonical, &yaml_res);
+            if (ok) {
+                results = (CandoValue *)cando_alloc(sizeof(CandoValue));
+                results[0]   = yaml_res;
                 result_count = 1;
             }
             break;

--- a/source/lib/libutil.c
+++ b/source/lib/libutil.c
@@ -34,10 +34,12 @@ void libutil_set_method(CandoVM *vm, CdoObject *obj,
                         const char *name, CandoNativeFn fn)
 {
     CandoValue sentinel = cando_vm_add_native(vm, fn);
-    /* If cando_vm_add_native returns null the native table is full: the
-     * sentinel number would be 0 which OP_CALL misinterprets as a script-
-     * function PC, causing silent infinite loops.  Catch this loudly. */
-    CANDO_ASSERT(cando_is_number(sentinel) && "native table full — increase CANDO_NATIVE_MAX");
+    /* cando_vm_add_native returns null only if the underlying realloc
+     * failed (the registry grows on demand and is otherwise unbounded).
+     * A null sentinel would be a 0 number which OP_CALL would misinterpret
+     * as a script-function PC, so abort loudly rather than corrupt state. */
+    CANDO_ASSERT(cando_is_number(sentinel) &&
+                 "native registry allocation failed");
     CdoString *key      = cdo_string_intern(name, (u32)strlen(name));
     cdo_object_rawset(obj, key, cdo_number(sentinel.as.number), FIELD_NONE);
     cdo_string_release(key);

--- a/source/lib/yaml.c
+++ b/source/lib/yaml.c
@@ -1,0 +1,1601 @@
+/*
+ * lib/yaml.c -- YAML encode/decode standard library for Cando.
+ *
+ * Self-contained YAML 1.2 subset implementation.  See yaml.h for the
+ * supported feature set; broadly:
+ *   - block mappings, block sequences, flow mappings, flow sequences
+ *   - plain / single-quoted / double-quoted scalars
+ *   - literal (|) and folded (>) block scalars with default chomping
+ *   - core-schema scalar typing (null/bool/int/float/string)
+ *   - line comments (`# ...`)
+ *   - optional leading document separator `---`
+ *
+ * Must compile with gcc -std=c11.
+ */
+
+#include "yaml.h"
+#include "libutil.h"
+#include "../vm/bridge.h"
+#include "../vm/vm.h"
+#include "../object/object.h"
+#include "../object/array.h"
+#include "../object/string.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <ctype.h>
+
+/* =========================================================================
+ * Dynamic byte buffer -- shared by the parser (scalar accumulation) and the
+ * writer (output accumulation).
+ * ======================================================================= */
+
+typedef struct {
+    char  *data;
+    usize  len;
+    usize  cap;
+    bool   oom;
+} YBuf;
+
+static void ybuf_grow(YBuf *b, usize need)
+{
+    if (b->oom) return;
+    if (b->len + need <= b->cap) return;
+    usize nc = b->cap ? b->cap * 2 : 256;
+    while (nc < b->len + need) nc *= 2;
+    char *p = (char *)realloc(b->data, nc);
+    if (!p) { b->oom = true; return; }
+    b->data = p;
+    b->cap  = nc;
+}
+
+static void ybuf_push(YBuf *b, const char *src, usize len)
+{
+    ybuf_grow(b, len);
+    if (b->oom) return;
+    memcpy(b->data + b->len, src, len);
+    b->len += len;
+}
+
+static void ybuf_push_char(YBuf *b, char c) { ybuf_push(b, &c, 1); }
+static void ybuf_push_cstr(YBuf *b, const char *s) { ybuf_push(b, s, strlen(s)); }
+
+static void ybuf_free(YBuf *b)
+{
+    free(b->data);
+    b->data = NULL;
+    b->len  = b->cap = 0;
+}
+
+/* =========================================================================
+ * Pre-tokenised line table.
+ *
+ * The parser is line-driven: every YAML construct's structure is determined
+ * by indentation, so we precompute (indent, content_offset, content_len) for
+ * every non-blank, non-comment line up front.  Blank/comment lines are kept
+ * in the array but flagged so structural parsers can skip them cheaply.
+ * ======================================================================= */
+
+typedef struct {
+    u32  start;      /* byte offset of first char of the line in src     */
+    u32  end;        /* byte offset just past the last char (excl. \n)   */
+    u32  indent;     /* count of leading spaces                          */
+    u32  content;    /* offset of first non-space, non-comment char      */
+    u32  content_end;/* offset just past last meaningful char            */
+    bool blank;      /* line is empty / whitespace-only / comment-only   */
+    bool has_tab_indent; /* tab found in indent — error for block ctx    */
+} YLine;
+
+typedef struct {
+    const char *src;
+    u32         len;
+    YLine      *lines;
+    u32         n_lines;
+    u32         pos;        /* current line index                        */
+    CandoVM    *vm;
+    bool        has_error;
+    char        error[256];
+} YParser;
+
+/* =========================================================================
+ * Forward declarations
+ * ======================================================================= */
+
+static CandoValue yp_parse_node(YParser *p, u32 min_indent);
+static CandoValue yp_parse_block_map(YParser *p, u32 indent);
+static CandoValue yp_parse_block_seq(YParser *p, u32 indent);
+static CandoValue yp_parse_flow_value(YParser *p, const char *s, u32 *i, u32 n);
+static CandoValue yp_decode_plain_scalar(YParser *p,
+                                          const char *s, u32 len);
+
+/* =========================================================================
+ * Error reporting
+ * ======================================================================= */
+
+static void yp_error_at(YParser *p, u32 line_idx, const char *msg)
+{
+    if (p->has_error) return;
+    /* Report a 1-based line number for human readability.  Callers may pass
+     * UINT32_MAX to indicate "unknown line"; we degrade gracefully. */
+    if (line_idx < p->n_lines) {
+        snprintf(p->error, sizeof(p->error), "%s (at line %u)",
+                 msg, (unsigned)(line_idx + 1));
+    } else {
+        snprintf(p->error, sizeof(p->error), "%s", msg);
+    }
+    p->has_error = true;
+}
+
+static void yp_error(YParser *p, const char *msg)
+{
+    yp_error_at(p, p->pos, msg);
+}
+
+/* =========================================================================
+ * Line pre-tokenisation
+ *
+ * Walks the raw source byte-by-byte.  For each line:
+ *   - records [start, end) offsets (end excludes the line terminator)
+ *   - counts leading spaces (tabs in indent set has_tab_indent)
+ *   - locates the first non-whitespace character; if it is '#' the line is
+ *     marked blank
+ *   - locates content_end by scanning forward and stripping a trailing
+ *     "  # comment" segment when found OUTSIDE any quoted string
+ *
+ * Trailing-comment stripping respects single-quoted (no escapes) and
+ * double-quoted (\"-aware) string literals; that's enough for typical
+ * YAML where the comment sentinel is "<space>#" not "#" alone.
+ * ======================================================================= */
+
+static u32 yl_find_comment_end(const char *src, u32 start, u32 end)
+{
+    /* Scan [start, end); return the offset of the comment sentinel
+     * (`<sp>#`) when one is found OUTSIDE quoted strings, else `end`. */
+    bool in_squote = false, in_dquote = false;
+    for (u32 i = start; i < end; i++) {
+        char c = src[i];
+        if (in_squote) {
+            if (c == '\'' && i + 1 < end && src[i + 1] == '\'') {
+                i++;             /* '' inside single-quoted string */
+            } else if (c == '\'') {
+                in_squote = false;
+            }
+            continue;
+        }
+        if (in_dquote) {
+            if (c == '\\' && i + 1 < end) { i++; continue; }
+            if (c == '"') in_dquote = false;
+            continue;
+        }
+        if (c == '\'') { in_squote = true; continue; }
+        if (c == '"')  { in_dquote = true; continue; }
+        if (c == '#' && (i == start || src[i - 1] == ' ' || src[i - 1] == '\t'))
+            return i;
+    }
+    return end;
+}
+
+static void yl_tokenise(YParser *p)
+{
+    u32 cap = 64, n = 0;
+    YLine *lines = (YLine *)malloc(cap * sizeof(YLine));
+    if (!lines) { yp_error(p, "out of memory"); return; }
+
+    u32 i = 0;
+    while (i <= p->len) {
+        u32 start = i;
+        while (i < p->len && p->src[i] != '\n') i++;
+        u32 end = i;                 /* exclusive of '\n' */
+        if (end > start && p->src[end - 1] == '\r') end--;
+
+        if (n == cap) {
+            cap *= 2;
+            YLine *np = (YLine *)realloc(lines, cap * sizeof(YLine));
+            if (!np) { free(lines); yp_error(p, "out of memory"); return; }
+            lines = np;
+        }
+
+        YLine *L = &lines[n++];
+        L->start          = start;
+        L->end            = end;
+        L->has_tab_indent = false;
+
+        /* Leading whitespace -> indent. */
+        u32 j = start;
+        u32 sp = 0;
+        while (j < end) {
+            char c = p->src[j];
+            if (c == ' ') { sp++; j++; }
+            else if (c == '\t') { L->has_tab_indent = true; j++; }
+            else break;
+        }
+        L->indent = sp;
+
+        if (j >= end || p->src[j] == '#') {
+            /* Blank or comment-only line. */
+            L->blank       = true;
+            L->content     = j;
+            L->content_end = j;
+        } else {
+            L->blank       = false;
+            L->content     = j;
+            u32 cend = yl_find_comment_end(p->src, j, end);
+            /* Trim trailing whitespace before the comment / line end. */
+            while (cend > j && (p->src[cend - 1] == ' ' ||
+                                p->src[cend - 1] == '\t'))
+                cend--;
+            L->content_end = cend;
+        }
+
+        if (i < p->len && p->src[i] == '\n') i++;
+        else if (i >= p->len) break;
+    }
+
+    p->lines   = lines;
+    p->n_lines = n;
+}
+
+/* =========================================================================
+ * cdo bridging
+ *
+ * Same trick the JSON parser uses: a CandoValue produced from the bridge
+ * needs to be converted back into a CdoValue when storing it in a parent
+ * container.  Strings get a fresh CdoString*; objects/arrays expose their
+ * underlying CdoObject* via the live handle.
+ * ======================================================================= */
+
+static CdoValue yp_to_cdo(YParser *p, CandoValue v)
+{
+    switch ((TypeTag)v.tag) {
+        case TYPE_NULL:   return cdo_null();
+        case TYPE_BOOL:   return cdo_bool(v.as.boolean);
+        case TYPE_NUMBER: return cdo_number(v.as.number);
+        case TYPE_STRING: {
+            CdoString *s = cdo_string_new(v.as.string->data,
+                                           v.as.string->length);
+            return cdo_string_value(s);
+        }
+        case TYPE_OBJECT: {
+            CdoObject *obj = cando_bridge_resolve(p->vm, v.as.handle);
+            return (obj->kind == OBJ_ARRAY)
+                   ? cdo_array_value(obj)
+                   : cdo_object_value(obj);
+        }
+    }
+    return cdo_null();
+}
+
+/* =========================================================================
+ * Scalar typing -- plain (unquoted) scalars in core schema
+ * ======================================================================= */
+
+static bool yp_str_eq_ci(const char *s, u32 n, const char *lit)
+{
+    u32 m = (u32)strlen(lit);
+    if (m != n) return false;
+    for (u32 i = 0; i < n; i++) {
+        char a = s[i];
+        char b = lit[i];
+        if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+        if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
+        if (a != b) return false;
+    }
+    return true;
+}
+
+/* Returns true iff [s, s+n) parses as a YAML 1.2 core-schema integer.
+ * Sets *out to the parsed value when true.  Accepts decimal, 0x… hex,
+ * and 0o… / 0… octal forms with an optional leading sign. */
+static bool yp_try_parse_int(const char *s, u32 n, f64 *out)
+{
+    if (n == 0) return false;
+    u32 i = 0;
+    int sign = 1;
+    if (s[i] == '+') i++;
+    else if (s[i] == '-') { sign = -1; i++; }
+    if (i >= n) return false;
+
+    /* Hexadecimal / octal */
+    if (s[i] == '0' && i + 1 < n &&
+        (s[i + 1] == 'x' || s[i + 1] == 'X')) {
+        i += 2;
+        if (i >= n) return false;
+        u64 acc = 0;
+        for (; i < n; i++) {
+            char c = s[i];
+            u32 d;
+            if      (c >= '0' && c <= '9') d = (u32)(c - '0');
+            else if (c >= 'a' && c <= 'f') d = (u32)(c - 'a' + 10);
+            else if (c >= 'A' && c <= 'F') d = (u32)(c - 'A' + 10);
+            else return false;
+            acc = acc * 16 + d;
+        }
+        *out = (f64)((i64)(sign) * (i64)acc);
+        return true;
+    }
+    if (s[i] == '0' && i + 1 < n &&
+        (s[i + 1] == 'o' || s[i + 1] == 'O')) {
+        i += 2;
+        if (i >= n) return false;
+        u64 acc = 0;
+        for (; i < n; i++) {
+            char c = s[i];
+            if (c < '0' || c > '7') return false;
+            acc = acc * 8 + (u32)(c - '0');
+        }
+        *out = (f64)((i64)(sign) * (i64)acc);
+        return true;
+    }
+
+    /* Plain decimal */
+    u32 start = i;
+    for (; i < n; i++) {
+        if (s[i] < '0' || s[i] > '9') return false;
+    }
+    if (i == start) return false;
+    u64 acc = 0;
+    for (u32 k = start; k < i; k++) acc = acc * 10 + (u32)(s[k] - '0');
+    *out = (f64)((i64)sign * (i64)acc);
+    return true;
+}
+
+/* Returns true iff [s, s+n) parses as a YAML 1.2 core-schema float. */
+static bool yp_try_parse_float(const char *s, u32 n, f64 *out)
+{
+    if (n == 0) return false;
+    /* .inf / -.inf / .nan */
+    if (yp_str_eq_ci(s, n, ".inf"))  { *out = INFINITY;  return true; }
+    if (yp_str_eq_ci(s, n, "+.inf")) { *out = INFINITY;  return true; }
+    if (yp_str_eq_ci(s, n, "-.inf")) { *out = -INFINITY; return true; }
+    if (yp_str_eq_ci(s, n, ".nan"))  { *out = NAN;       return true; }
+
+    /* Reject anything not consisting solely of digits / sign / dot / e / E. */
+    bool seen_digit = false, seen_dot = false, seen_exp = false;
+    for (u32 i = 0; i < n; i++) {
+        char c = s[i];
+        if (c >= '0' && c <= '9') { seen_digit = true; continue; }
+        if (c == '.') {
+            if (seen_dot || seen_exp) return false;
+            seen_dot = true; continue;
+        }
+        if (c == 'e' || c == 'E') {
+            if (seen_exp || !seen_digit) return false;
+            seen_exp = true; seen_digit = false; continue;
+        }
+        if (c == '+' || c == '-') {
+            if (i == 0) continue;
+            if (!seen_exp) return false;
+            char prev = s[i - 1];
+            if (prev != 'e' && prev != 'E') return false;
+            continue;
+        }
+        return false;
+    }
+    if (!seen_digit) return false;
+
+    char tmp[64];
+    if (n >= sizeof(tmp)) return false;
+    memcpy(tmp, s, n);
+    tmp[n] = '\0';
+    char *endp;
+    f64 v = strtod(tmp, &endp);
+    if (endp != tmp + n) return false;
+    *out = v;
+    return true;
+}
+
+/* yp_decode_plain_scalar: convert an unquoted YAML scalar string into a
+ * CandoValue using core-schema typing rules.  The caller has already
+ * stripped surrounding whitespace and escapes are not applicable. */
+static CandoValue yp_decode_plain_scalar(YParser *p,
+                                          const char *s, u32 len)
+{
+    (void)p;
+    if (len == 0) return cando_null();
+
+    /* null / ~ */
+    if (len == 1 && s[0] == '~') return cando_null();
+    if (yp_str_eq_ci(s, len, "null")) return cando_null();
+    if (yp_str_eq_ci(s, len, "Null")) return cando_null();
+    if (yp_str_eq_ci(s, len, "NULL")) return cando_null();
+
+    /* booleans (YAML 1.1 superset that's commonly expected) */
+    if (yp_str_eq_ci(s, len, "true")  || yp_str_eq_ci(s, len, "yes") ||
+        yp_str_eq_ci(s, len, "on"))   return cando_bool(true);
+    if (yp_str_eq_ci(s, len, "false") || yp_str_eq_ci(s, len, "no")  ||
+        yp_str_eq_ci(s, len, "off"))  return cando_bool(false);
+
+    /* numbers */
+    f64 num;
+    if (yp_try_parse_int(s, len, &num))   return cando_number(num);
+    if (yp_try_parse_float(s, len, &num)) return cando_number(num);
+
+    /* fallthrough: string */
+    CandoString *str = cando_string_new(s, len);
+    return cando_string_value(str);
+}
+
+/* =========================================================================
+ * Quoted scalar decoders
+ *
+ * Both helpers expect the cursor *i to point at the opening quote and on
+ * success advance past the closing quote.  Single-quoted strings have only
+ * one escape (`''` for a literal apostrophe).  Double-quoted strings honour
+ * a JSON-compatible escape set plus `\xNN`, `\uNNNN`, `\UNNNNNNNN`.
+ * Returns a freshly-allocated CandoString.  On error sets a parser error
+ * and returns cando_null().
+ * ======================================================================= */
+
+static CandoValue yp_decode_squoted(YParser *p, const char *s, u32 *i, u32 n)
+{
+    YBuf buf = {0};
+    u32 k = *i + 1;
+    bool closed = false;
+    while (k < n) {
+        char c = s[k];
+        if (c == '\'') {
+            if (k + 1 < n && s[k + 1] == '\'') {
+                ybuf_push_char(&buf, '\'');
+                k += 2;
+                continue;
+            }
+            k++;
+            closed = true;
+            break;
+        }
+        ybuf_push_char(&buf, c);
+        k++;
+    }
+    if (!closed) {
+        ybuf_free(&buf);
+        yp_error(p, "unterminated single-quoted string");
+        return cando_null();
+    }
+    if (buf.oom) {
+        ybuf_free(&buf);
+        yp_error(p, "out of memory in single-quoted string");
+        return cando_null();
+    }
+    *i = k;
+    CandoString *str = cando_string_new(buf.data ? buf.data : "", (u32)buf.len);
+    ybuf_free(&buf);
+    return cando_string_value(str);
+}
+
+/* Encode codepoint cp as UTF-8 into buf. */
+static void yp_emit_utf8(YBuf *buf, u32 cp)
+{
+    if (cp < 0x80u) {
+        ybuf_push_char(buf, (char)cp);
+    } else if (cp < 0x800u) {
+        ybuf_push_char(buf, (char)(0xC0u | (cp >> 6)));
+        ybuf_push_char(buf, (char)(0x80u | (cp & 0x3Fu)));
+    } else if (cp < 0x10000u) {
+        ybuf_push_char(buf, (char)(0xE0u | (cp >> 12)));
+        ybuf_push_char(buf, (char)(0x80u | ((cp >> 6) & 0x3Fu)));
+        ybuf_push_char(buf, (char)(0x80u | (cp & 0x3Fu)));
+    } else {
+        ybuf_push_char(buf, (char)(0xF0u | (cp >> 18)));
+        ybuf_push_char(buf, (char)(0x80u | ((cp >> 12) & 0x3Fu)));
+        ybuf_push_char(buf, (char)(0x80u | ((cp >> 6)  & 0x3Fu)));
+        ybuf_push_char(buf, (char)(0x80u | (cp          & 0x3Fu)));
+    }
+}
+
+static bool yp_read_hex(const char *s, u32 i, u32 count, u32 max, u32 *out)
+{
+    if (i + count > max) return false;
+    u32 acc = 0;
+    for (u32 k = 0; k < count; k++) {
+        char c = s[i + k];
+        u32 d;
+        if      (c >= '0' && c <= '9') d = (u32)(c - '0');
+        else if (c >= 'a' && c <= 'f') d = (u32)(c - 'a' + 10);
+        else if (c >= 'A' && c <= 'F') d = (u32)(c - 'A' + 10);
+        else return false;
+        acc = (acc << 4) | d;
+    }
+    *out = acc;
+    return true;
+}
+
+static CandoValue yp_decode_dquoted(YParser *p, const char *s, u32 *i, u32 n)
+{
+    YBuf buf = {0};
+    u32 k = *i + 1;
+    bool closed = false;
+    while (k < n) {
+        char c = s[k];
+        if (c == '"') { k++; closed = true; break; }
+        if (c == '\\') {
+            if (k + 1 >= n) { yp_error(p, "truncated escape"); break; }
+            char esc = s[k + 1];
+            switch (esc) {
+                case '"':  ybuf_push_char(&buf, '"');  k += 2; break;
+                case '\\': ybuf_push_char(&buf, '\\'); k += 2; break;
+                case '/':  ybuf_push_char(&buf, '/');  k += 2; break;
+                case 'n':  ybuf_push_char(&buf, '\n'); k += 2; break;
+                case 'r':  ybuf_push_char(&buf, '\r'); k += 2; break;
+                case 't':  ybuf_push_char(&buf, '\t'); k += 2; break;
+                case 'b':  ybuf_push_char(&buf, '\b'); k += 2; break;
+                case 'f':  ybuf_push_char(&buf, '\f'); k += 2; break;
+                case '0':  ybuf_push_char(&buf, '\0'); k += 2; break;
+                case 'a':  ybuf_push_char(&buf, '\a'); k += 2; break;
+                case 'v':  ybuf_push_char(&buf, '\v'); k += 2; break;
+                case 'e':  ybuf_push_char(&buf, 0x1B); k += 2; break;
+                case ' ':  ybuf_push_char(&buf, ' ');  k += 2; break;
+                case 'x': {
+                    u32 cp;
+                    if (!yp_read_hex(s, k + 2, 2, n, &cp)) {
+                        yp_error(p, "invalid \\x escape"); k = n; break;
+                    }
+                    yp_emit_utf8(&buf, cp);
+                    k += 4;
+                    break;
+                }
+                case 'u': {
+                    u32 cp;
+                    if (!yp_read_hex(s, k + 2, 4, n, &cp)) {
+                        yp_error(p, "invalid \\u escape"); k = n; break;
+                    }
+                    yp_emit_utf8(&buf, cp);
+                    k += 6;
+                    break;
+                }
+                case 'U': {
+                    u32 cp;
+                    if (!yp_read_hex(s, k + 2, 8, n, &cp)) {
+                        yp_error(p, "invalid \\U escape"); k = n; break;
+                    }
+                    yp_emit_utf8(&buf, cp);
+                    k += 10;
+                    break;
+                }
+                default:
+                    yp_error(p, "unknown escape sequence");
+                    k = n; break;
+            }
+            if (p->has_error) break;
+            continue;
+        }
+        ybuf_push_char(&buf, c);
+        k++;
+    }
+    if (p->has_error) { ybuf_free(&buf); return cando_null(); }
+    if (!closed) {
+        ybuf_free(&buf);
+        yp_error(p, "unterminated double-quoted string");
+        return cando_null();
+    }
+    if (buf.oom) {
+        ybuf_free(&buf);
+        yp_error(p, "out of memory in double-quoted string");
+        return cando_null();
+    }
+    *i = k;
+    CandoString *str = cando_string_new(buf.data ? buf.data : "", (u32)buf.len);
+    ybuf_free(&buf);
+    return cando_string_value(str);
+}
+
+/* =========================================================================
+ * Flow context parsing
+ *
+ * yp_parse_flow_value reads a single value starting at s[*i] and advances
+ * *i past it.  It dispatches to:
+ *    - yp_decode_squoted / yp_decode_dquoted   (quoted strings)
+ *    - yp_parse_flow_seq / yp_parse_flow_map   (nested flow containers)
+ *    - yp_decode_plain_scalar                  (plain scalar)
+ *
+ * The flow parser is line-local: nested flow containers are required to
+ * fit on the same logical line.  This matches what JSON-style YAML usage
+ * needs and keeps line-driven block parsing cleanly separated.
+ * ======================================================================= */
+
+static void yp_skip_flow_ws(const char *s, u32 *i, u32 n)
+{
+    while (*i < n && (s[*i] == ' ' || s[*i] == '\t')) (*i)++;
+}
+
+static CandoValue yp_parse_flow_seq(YParser *p, const char *s, u32 *i, u32 n)
+{
+    (*i)++;                              /* consume '[' */
+    CandoValue arr_val = cando_bridge_new_array(p->vm);
+    CdoObject *arr     = cando_bridge_resolve(p->vm, arr_val.as.handle);
+
+    yp_skip_flow_ws(s, i, n);
+    if (*i < n && s[*i] == ']') { (*i)++; return arr_val; }
+
+    while (!p->has_error) {
+        yp_skip_flow_ws(s, i, n);
+        CandoValue elem = yp_parse_flow_value(p, s, i, n);
+        if (p->has_error) { cando_value_release(elem); break; }
+        CdoValue cv = yp_to_cdo(p, elem);
+        cando_value_release(elem);
+        cdo_array_push(arr, cv);
+        cdo_value_release(cv);
+        yp_skip_flow_ws(s, i, n);
+        if (*i >= n) { yp_error(p, "unterminated flow sequence"); break; }
+        if (s[*i] == ']') { (*i)++; break; }
+        if (s[*i] != ',') { yp_error(p, "expected ',' or ']' in flow sequence"); break; }
+        (*i)++;
+    }
+    return arr_val;
+}
+
+static CandoValue yp_parse_flow_map(YParser *p, const char *s, u32 *i, u32 n)
+{
+    (*i)++;                              /* consume '{' */
+    CandoValue obj_val = cando_bridge_new_object(p->vm);
+    CdoObject *obj     = cando_bridge_resolve(p->vm, obj_val.as.handle);
+
+    yp_skip_flow_ws(s, i, n);
+    if (*i < n && s[*i] == '}') { (*i)++; return obj_val; }
+
+    while (!p->has_error) {
+        yp_skip_flow_ws(s, i, n);
+
+        /* Key: quoted string or plain scalar (scan until ':' or ',' or '}'). */
+        CandoValue key_val = cando_null();
+        if (*i < n && s[*i] == '"') {
+            key_val = yp_decode_dquoted(p, s, i, n);
+        } else if (*i < n && s[*i] == '\'') {
+            key_val = yp_decode_squoted(p, s, i, n);
+        } else {
+            u32 ks = *i;
+            while (*i < n && s[*i] != ':' && s[*i] != ',' && s[*i] != '}'
+                   && s[*i] != '\n')
+                (*i)++;
+            u32 kend = *i;
+            while (kend > ks && (s[kend - 1] == ' ' || s[kend - 1] == '\t')) kend--;
+            key_val = yp_decode_plain_scalar(p, s + ks, kend - ks);
+        }
+        if (p->has_error) { cando_value_release(key_val); break; }
+
+        /* Coerce the key to a string. */
+        CandoString *kstr = NULL;
+        if (cando_is_string(key_val)) {
+            kstr = key_val.as.string;
+        } else {
+            char *tmp = cando_value_tostring(key_val);
+            u32 tn = (u32)strlen(tmp);
+            kstr = cando_string_new(tmp, tn);
+            free(tmp);
+            cando_value_release(key_val);
+            key_val = cando_string_value(kstr);
+        }
+
+        yp_skip_flow_ws(s, i, n);
+        CandoValue val_val = cando_null();
+        if (*i < n && s[*i] == ':') {
+            (*i)++;
+            yp_skip_flow_ws(s, i, n);
+            if (*i < n && s[*i] != ',' && s[*i] != '}') {
+                val_val = yp_parse_flow_value(p, s, i, n);
+                if (p->has_error) {
+                    cando_value_release(key_val);
+                    cando_value_release(val_val);
+                    break;
+                }
+            }
+        }
+
+        CdoString *kintern = cdo_string_intern(kstr->data, kstr->length);
+        cando_value_release(key_val);
+        CdoValue cv = yp_to_cdo(p, val_val);
+        cando_value_release(val_val);
+        cdo_object_rawset(obj, kintern, cv, FIELD_NONE);
+        cdo_value_release(cv);
+        cdo_string_release(kintern);
+
+        yp_skip_flow_ws(s, i, n);
+        if (*i >= n) { yp_error(p, "unterminated flow mapping"); break; }
+        if (s[*i] == '}') { (*i)++; break; }
+        if (s[*i] != ',') { yp_error(p, "expected ',' or '}' in flow mapping"); break; }
+        (*i)++;
+    }
+    return obj_val;
+}
+
+static CandoValue yp_parse_flow_value(YParser *p, const char *s, u32 *i, u32 n)
+{
+    yp_skip_flow_ws(s, i, n);
+    if (*i >= n) { yp_error(p, "expected flow value"); return cando_null(); }
+    char c = s[*i];
+    if (c == '[') return yp_parse_flow_seq(p, s, i, n);
+    if (c == '{') return yp_parse_flow_map(p, s, i, n);
+    if (c == '"') return yp_decode_dquoted(p, s, i, n);
+    if (c == '\'') return yp_decode_squoted(p, s, i, n);
+
+    /* Plain scalar: read until ',' / ']' / '}' / EOL. */
+    u32 start = *i;
+    while (*i < n && s[*i] != ',' && s[*i] != ']' && s[*i] != '}'
+           && s[*i] != '\n')
+        (*i)++;
+    u32 end = *i;
+    while (end > start && (s[end - 1] == ' ' || s[end - 1] == '\t')) end--;
+    return yp_decode_plain_scalar(p, s + start, end - start);
+}
+
+/* =========================================================================
+ * yp_parse_inline_value
+ *
+ * Decodes a single value rendered on one logical line: a flow container,
+ * a quoted scalar, or a plain scalar.  Used for "key: value" right-hand
+ * sides and "- value" sequence items where the value sits on the same
+ * line as its container marker.
+ *
+ *  s, len : the line-local content slice (already comment-stripped)
+ * Returns a CandoValue.  On error sets a parser error and returns null.
+ * ======================================================================= */
+static CandoValue yp_parse_inline_value(YParser *p, const char *s, u32 len)
+{
+    if (len == 0) return cando_null();
+    u32 i = 0;
+    yp_skip_flow_ws(s, &i, len);
+    if (i >= len) return cando_null();
+
+    char c = s[i];
+    CandoValue v;
+    if (c == '[' || c == '{') {
+        v = yp_parse_flow_value(p, s, &i, len);
+    } else if (c == '"') {
+        v = yp_decode_dquoted(p, s, &i, len);
+    } else if (c == '\'') {
+        v = yp_decode_squoted(p, s, &i, len);
+    } else {
+        /* Plain scalar to end of slice. */
+        u32 end = len;
+        while (end > i && (s[end - 1] == ' ' || s[end - 1] == '\t')) end--;
+        return yp_decode_plain_scalar(p, s + i, end - i);
+    }
+
+    /* Reject trailing junk after a structured/quoted value. */
+    yp_skip_flow_ws(s, &i, len);
+    if (!p->has_error && i < len) {
+        cando_value_release(v);
+        yp_error(p, "unexpected text after inline value");
+        return cando_null();
+    }
+    return v;
+}
+
+/* =========================================================================
+ * Block scalars  (`|` literal, `>` folded)
+ *
+ * The first line carries only the indicator (and an optional chomping char
+ * `-` strip / `+` keep — we accept them for compatibility but always emit
+ * trailing-newline-clipped output, which matches the YAML 1.2 default).
+ *
+ * Subsequent indented lines (indent strictly greater than `parent_indent`)
+ * are concatenated:
+ *   - literal `|` keeps each newline
+ *   - folded `>` joins lines with a single space; a blank line introduces
+ *     one literal newline
+ *
+ * The block ends at the first non-blank line whose indent <= parent_indent.
+ * On exit, p->pos points at that terminating line (or n_lines).
+ * ======================================================================= */
+
+static CandoValue yp_parse_block_scalar(YParser *p, char indicator,
+                                         u32 parent_indent)
+{
+    p->pos++;                            /* consume the `|`/`>` line */
+
+    /* Determine the block's indent from the first non-blank line. */
+    u32 block_indent = 0;
+    bool indent_known = false;
+
+    YBuf buf = {0};
+    bool prev_blank = false;
+    bool first_line = true;
+
+    while (p->pos < p->n_lines) {
+        YLine *L = &p->lines[p->pos];
+
+        if (L->blank) {
+            /* Blank line inside the block: emit a newline (folded) or pass
+             * through (literal handles it via the next non-blank emission). */
+            if (!first_line) {
+                if (indicator == '>') {
+                    /* In folded style a blank line yields a real newline. */
+                    ybuf_push_char(&buf, '\n');
+                } else {
+                    ybuf_push_char(&buf, '\n');
+                }
+            }
+            prev_blank = true;
+            p->pos++;
+            continue;
+        }
+
+        if (!indent_known) {
+            block_indent = L->indent;
+            if (block_indent <= parent_indent) {
+                /* Block contains nothing -- stop right away. */
+                break;
+            }
+            indent_known = true;
+        }
+
+        if (L->indent < block_indent) break;     /* end of block scalar */
+
+        /* Compute the meaningful slice: indent past block_indent + content
+         * that we recorded earlier (already trimmed for trailing comment). */
+        u32 line_start = L->start + block_indent;
+        if (line_start > L->end) line_start = L->end;
+        u32 line_end   = L->end;                 /* keep raw line contents */
+
+        if (!first_line && !prev_blank) {
+            ybuf_push_char(&buf, indicator == '>' ? ' ' : '\n');
+        } else if (first_line) {
+            /* leading content -- nothing to add */
+        }
+
+        ybuf_push(&buf, p->src + line_start,
+                  (usize)(line_end - line_start));
+        first_line = false;
+        prev_blank = false;
+        p->pos++;
+    }
+
+    /* Default chomping: ensure exactly one trailing '\n' (or zero if the
+     * block produced an empty string). */
+    while (buf.len > 0 && (buf.data[buf.len - 1] == '\n' ||
+                           buf.data[buf.len - 1] == ' '))
+        buf.len--;
+    if (buf.len > 0) ybuf_push_char(&buf, '\n');
+
+    if (buf.oom) {
+        ybuf_free(&buf);
+        yp_error(p, "out of memory in block scalar");
+        return cando_null();
+    }
+    CandoString *str = cando_string_new(buf.data ? buf.data : "", (u32)buf.len);
+    ybuf_free(&buf);
+    return cando_string_value(str);
+}
+
+/* =========================================================================
+ * yp_skip_blanks -- advance p->pos past blank/comment-only lines.
+ * ======================================================================= */
+static void yp_skip_blanks(YParser *p)
+{
+    while (p->pos < p->n_lines && p->lines[p->pos].blank) p->pos++;
+}
+
+/* =========================================================================
+ * yp_line_has_block_map_key
+ *
+ * Heuristic: returns true iff the given content slice starts with a key
+ * (plain or quoted) followed by `:` and either end-of-content or one or
+ * more spaces.  Used to decide whether a line begins a block mapping.
+ * ======================================================================= */
+static bool yp_line_has_block_map_key(const char *s, u32 len)
+{
+    if (len == 0) return false;
+    u32 i = 0;
+    char first = s[0];
+    if (first == '"' || first == '\'') {
+        /* Skip past the matching quote. */
+        char q = first;
+        i = 1;
+        while (i < len && s[i] != q) {
+            if (q == '"' && s[i] == '\\' && i + 1 < len) { i += 2; continue; }
+            if (q == '\'' && s[i] == '\'' && i + 1 < len && s[i + 1] == '\'') {
+                i += 2; continue;
+            }
+            i++;
+        }
+        if (i >= len) return false;
+        i++;                              /* consume closing quote */
+    } else if (first == '[' || first == '{' || first == '|' || first == '>'
+               || first == '-') {
+        return false;
+    } else {
+        /* Plain key: scan until ':' that is followed by a space or EOL.
+         * Stop at flow indicators since they cannot appear in plain keys. */
+        while (i < len && s[i] != ':' && s[i] != '\n'
+               && s[i] != '[' && s[i] != ']'
+               && s[i] != '{' && s[i] != '}'
+               && s[i] != ',') {
+            i++;
+        }
+    }
+    /* Skip trailing space before ':'. */
+    while (i < len && (s[i] == ' ' || s[i] == '\t')) i++;
+    if (i >= len || s[i] != ':') return false;
+    /* `:` must be followed by space, EOL or be the very last character. */
+    if (i + 1 >= len) return true;
+    char after = s[i + 1];
+    return after == ' ' || after == '\t';
+}
+
+/* =========================================================================
+ * yp_split_map_key  --  find the position of the ':' separator in a block
+ * mapping line, returning the byte offset of ':' (which is also the end of
+ * the key, possibly with trailing whitespace to be trimmed by the caller).
+ * Assumes yp_line_has_block_map_key has already returned true.
+ * ======================================================================= */
+static u32 yp_split_map_key(const char *s, u32 len)
+{
+    u32 i = 0;
+    char first = s[0];
+    if (first == '"' || first == '\'') {
+        char q = first;
+        i = 1;
+        while (i < len && s[i] != q) {
+            if (q == '"' && s[i] == '\\' && i + 1 < len) { i += 2; continue; }
+            if (q == '\'' && s[i] == '\'' && i + 1 < len && s[i + 1] == '\'') {
+                i += 2; continue;
+            }
+            i++;
+        }
+        if (i < len) i++;        /* consume closing quote */
+        while (i < len && (s[i] == ' ' || s[i] == '\t')) i++;
+        return i;                /* points at ':' */
+    }
+    while (i < len && s[i] != ':') i++;
+    return i;
+}
+
+/* =========================================================================
+ * Block sequence
+ *
+ * Each item begins with `- ` at column == indent.  After consuming the
+ * `- ` marker the rest of the line is interpreted as either:
+ *   1) empty -> nested node on subsequent lines at indent > current
+ *   2) inline scalar / flow value -> single-line value
+ *   3) inline `key: value` mapping -> nested block map starting at the
+ *      column of the key, with subsequent keys aligned to that column
+ * ======================================================================= */
+
+static CandoValue yp_parse_block_seq(YParser *p, u32 indent)
+{
+    CandoValue arr_val = cando_bridge_new_array(p->vm);
+    CdoObject *arr     = cando_bridge_resolve(p->vm, arr_val.as.handle);
+
+    while (!p->has_error) {
+        yp_skip_blanks(p);
+        if (p->pos >= p->n_lines) break;
+        YLine *L = &p->lines[p->pos];
+        if (L->indent != indent) break;
+
+        u32 cs = L->content;
+        u32 ce = L->content_end;
+        if (cs >= ce || p->src[cs] != '-') break;
+        if (cs + 1 < ce && p->src[cs + 1] != ' ' && p->src[cs + 1] != '\t')
+            break;                       /* `-...` plain scalar, not seq */
+
+        /* Position past "- " (or "-\n"). */
+        u32 after = cs + 1;
+        while (after < ce && (p->src[after] == ' ' || p->src[after] == '\t'))
+            after++;
+
+        CandoValue item;
+        if (after >= ce) {
+            /* Marker only: child node on following lines, indent > indent. */
+            p->pos++;
+            item = yp_parse_node(p, indent + 1);
+        } else {
+            /* The column where item content begins, relative to line start. */
+            u32 item_col = after - L->start;
+
+            /* Could be inline mapping: `- key: value` or `- key:`. */
+            const char *line_slice = p->src + after;
+            u32 slice_len = ce - after;
+            if (yp_line_has_block_map_key(line_slice, slice_len)) {
+                /* Treat the item line as the first entry of a virtual
+                 * mapping at indent = item_col.  We need to roll back the
+                 * tokenised line so the map parser sees the slice without
+                 * the `- ` prefix.  We do so by editing this line's view
+                 * to start at `after`. */
+                YLine saved = *L;
+                L->content = after;
+                L->indent  = item_col;
+                item = yp_parse_block_map(p, item_col);
+                /* Restore (the next iteration won't look at L anyway, but
+                 * keep the state consistent for diagnostics). */
+                p->lines[p->pos > 0 ? p->pos - 1 : 0] = p->lines[
+                    p->pos > 0 ? p->pos - 1 : 0];
+                (void)saved;
+            } else if (line_slice[0] == '-' &&
+                       (slice_len == 1 ||
+                        line_slice[1] == ' ' || line_slice[1] == '\t')) {
+                /* Nested sequence on the same line: rewrite indent. */
+                YLine saved = *L;
+                L->content = after;
+                L->indent  = item_col;
+                item = yp_parse_block_seq(p, item_col);
+                (void)saved;
+            } else {
+                /* Plain inline value. */
+                item = yp_parse_inline_value(p, line_slice, slice_len);
+                p->pos++;
+            }
+        }
+
+        if (p->has_error) { cando_value_release(item); break; }
+        CdoValue cv = yp_to_cdo(p, item);
+        cando_value_release(item);
+        cdo_array_push(arr, cv);
+        cdo_value_release(cv);
+    }
+
+    return arr_val;
+}
+
+/* =========================================================================
+ * Block mapping
+ *
+ * Each key/value entry occupies one or more lines starting at indent.  The
+ * value may be:
+ *   - inline on the same line after `: ` (scalar / flow / quoted)
+ *   - omitted (key followed by `:` with nothing after) -> nested node on
+ *     following lines at indent > current, or null if none
+ *   - a block scalar begun on this line with `|` / `>`
+ * ======================================================================= */
+
+static CandoValue yp_parse_block_map(YParser *p, u32 indent)
+{
+    CandoValue obj_val = cando_bridge_new_object(p->vm);
+    CdoObject *obj     = cando_bridge_resolve(p->vm, obj_val.as.handle);
+
+    while (!p->has_error) {
+        yp_skip_blanks(p);
+        if (p->pos >= p->n_lines) break;
+        YLine *L = &p->lines[p->pos];
+        if (L->indent != indent) break;
+
+        const char *cs = p->src + L->content;
+        u32 clen = L->content_end - L->content;
+
+        if (!yp_line_has_block_map_key(cs, clen)) break;
+
+        /* Decode the key. */
+        u32 colon_off = yp_split_map_key(cs, clen);
+        u32 key_end = colon_off;
+        while (key_end > 0 && (cs[key_end - 1] == ' ' ||
+                               cs[key_end - 1] == '\t'))
+            key_end--;
+
+        CandoValue key_val;
+        if (cs[0] == '"') {
+            u32 i = 0;
+            key_val = yp_decode_dquoted(p, cs, &i, key_end);
+        } else if (cs[0] == '\'') {
+            u32 i = 0;
+            key_val = yp_decode_squoted(p, cs, &i, key_end);
+        } else {
+            key_val = yp_decode_plain_scalar(p, cs, key_end);
+        }
+        if (p->has_error) { cando_value_release(key_val); break; }
+
+        /* Coerce key to a string if it parsed to bool/number/null. */
+        CandoString *kstr;
+        if (cando_is_string(key_val)) {
+            kstr = key_val.as.string;
+        } else {
+            char *tmp = cando_value_tostring(key_val);
+            u32 tn = (u32)strlen(tmp);
+            kstr = cando_string_new(tmp, tn);
+            free(tmp);
+            cando_value_release(key_val);
+            key_val = cando_string_value(kstr);
+        }
+        CdoString *kintern = cdo_string_intern(kstr->data, kstr->length);
+
+        /* Locate value text after ':'. */
+        u32 vs = colon_off + 1;
+        while (vs < clen && (cs[vs] == ' ' || cs[vs] == '\t')) vs++;
+
+        CandoValue val_val = cando_null();
+        if (vs >= clen) {
+            /* Empty right-hand side: child node on following line(s). */
+            p->pos++;
+            val_val = yp_parse_node(p, indent + 1);
+        } else if (cs[vs] == '|' || cs[vs] == '>') {
+            char ind = cs[vs];
+            /* Block scalar: parse_block_scalar consumes p->pos at this line. */
+            val_val = yp_parse_block_scalar(p, ind, indent);
+        } else {
+            val_val = yp_parse_inline_value(p, cs + vs, clen - vs);
+            p->pos++;
+        }
+        if (p->has_error) {
+            cando_value_release(key_val);
+            cando_value_release(val_val);
+            cdo_string_release(kintern);
+            break;
+        }
+
+        CdoValue cv = yp_to_cdo(p, val_val);
+        cando_value_release(val_val);
+        cando_value_release(key_val);
+        cdo_object_rawset(obj, kintern, cv, FIELD_NONE);
+        cdo_value_release(cv);
+        cdo_string_release(kintern);
+    }
+
+    return obj_val;
+}
+
+/* =========================================================================
+ * yp_parse_node -- consume a node whose first line has indent >= min_indent.
+ *
+ * Returns null if no such line exists (the caller's container is empty).
+ * Dispatches to the block sequence / mapping / scalar parser based on the
+ * first non-blank line's content.
+ * ======================================================================= */
+
+static CandoValue yp_parse_node(YParser *p, u32 min_indent)
+{
+    yp_skip_blanks(p);
+    if (p->pos >= p->n_lines) return cando_null();
+    YLine *L = &p->lines[p->pos];
+    if (L->indent < min_indent) return cando_null();
+
+    const char *cs = p->src + L->content;
+    u32 clen = L->content_end - L->content;
+    u32 indent = L->indent;
+
+    if (clen == 0) {                    /* defensive: blank-but-not-flagged */
+        p->pos++;
+        return cando_null();
+    }
+
+    char first = cs[0];
+
+    /* Block sequence:  - ...   or just `-` */
+    if (first == '-' && (clen == 1 || cs[1] == ' ' || cs[1] == '\t')) {
+        return yp_parse_block_seq(p, indent);
+    }
+
+    /* Flow container on its own line. */
+    if (first == '[' || first == '{') {
+        u32 i = 0;
+        CandoValue v = yp_parse_flow_value(p, cs, &i, clen);
+        p->pos++;
+        return v;
+    }
+
+    /* Block scalar:  | / > */
+    if (first == '|' || first == '>') {
+        return yp_parse_block_scalar(p, first, indent == 0 ? 0 : indent - 1);
+    }
+
+    /* Block mapping detection. */
+    if (yp_line_has_block_map_key(cs, clen)) {
+        return yp_parse_block_map(p, indent);
+    }
+
+    /* Otherwise: a single-line scalar that lives on this line only. */
+    CandoValue v = yp_parse_inline_value(p, cs, clen);
+    p->pos++;
+    return v;
+}
+
+/* =========================================================================
+ * Public parse entry point
+ * ======================================================================= */
+
+bool cando_lib_yaml_parse_buffer(CandoVM *vm,
+                                  const char *src, usize len,
+                                  const char *where,
+                                  CandoValue *out)
+{
+    YParser p;
+    p.src       = src;
+    p.len       = (u32)len;
+    p.lines     = NULL;
+    p.n_lines   = 0;
+    p.pos       = 0;
+    p.vm        = vm;
+    p.has_error = false;
+    p.error[0]  = '\0';
+
+    yl_tokenise(&p);
+
+    /* Optional leading "---" document separator. */
+    yp_skip_blanks(&p);
+    if (!p.has_error && p.pos < p.n_lines) {
+        YLine *L = &p.lines[p.pos];
+        u32 cl = L->content_end - L->content;
+        if (cl >= 3 && memcmp(p.src + L->content, "---", 3) == 0
+                    && (cl == 3 || p.src[L->content + 3] == ' '
+                                || p.src[L->content + 3] == '\t')) {
+            p.pos++;
+        }
+    }
+
+    /* Tab-indented block scalars are reasonable but block-structure tabs
+     * are not.  Scan once for the latter. */
+    for (u32 i = 0; !p.has_error && i < p.n_lines; i++) {
+        if (p.lines[i].has_tab_indent && !p.lines[i].blank) {
+            yp_error_at(&p, i, "tab character used for indentation");
+            break;
+        }
+    }
+
+    CandoValue result = cando_null();
+    if (!p.has_error) result = yp_parse_node(&p, 0);
+
+    /* Anything left over (other than blanks / a "..." terminator) is junk. */
+    if (!p.has_error) {
+        yp_skip_blanks(&p);
+        if (p.pos < p.n_lines) {
+            YLine *L = &p.lines[p.pos];
+            u32 cl = L->content_end - L->content;
+            bool is_terminator = (cl == 3 &&
+                memcmp(p.src + L->content, "...", 3) == 0);
+            if (!is_terminator) {
+                yp_error_at(&p, p.pos, "unexpected trailing content");
+            }
+        }
+    }
+
+    free(p.lines);
+
+    if (p.has_error) {
+        cando_value_release(result);
+        if (out) *out = cando_null();
+        cando_vm_error(vm, "%s: %s", where ? where : "yaml.parse", p.error);
+        return false;
+    }
+
+    if (out) *out = result;
+    else     cando_value_release(result);
+    return true;
+}
+
+static int yaml_parse(CandoVM *vm, int argc, CandoValue *args)
+{
+    if (argc < 1 || !cando_is_string(args[0])) {
+        cando_vm_error(vm, "yaml.parse: expected a string argument");
+        return -1;
+    }
+    CandoValue result = cando_null();
+    if (!cando_lib_yaml_parse_buffer(vm,
+                                     args[0].as.string->data,
+                                     (usize)args[0].as.string->length,
+                                     "yaml.parse",
+                                     &result)) {
+        return -1;
+    }
+    cando_vm_push(vm, result);
+    return 1;
+}
+
+/* =========================================================================
+ * YAML writer
+ *
+ * Produces block-style YAML for objects and arrays; scalars print as a
+ * single line with double-quoting only when content would otherwise be
+ * misinterpreted (would round-trip back to a different type, contains
+ * special leading characters, or contains control chars).
+ * ======================================================================= */
+
+typedef struct {
+    YBuf      buf;
+    int       indent;        /* spaces per nesting level (>= 1)             */
+    CandoVM  *vm;
+} YWriter;
+
+static void yw_write_cdo_value(YWriter *w, CdoValue val, int depth, bool inline_first);
+static void yw_write_string_scalar(YWriter *w, const char *s, u32 len);
+
+static void yw_write_indent(YWriter *w, int depth)
+{
+    int n = depth * w->indent;
+    for (int i = 0; i < n; i++) ybuf_push_char(&w->buf, ' ');
+}
+
+static bool yw_string_needs_quotes(const char *s, u32 len)
+{
+    if (len == 0) return true;            /* empty string -> "" */
+    /* Reserved scalars that would parse back to non-string types. */
+    static const char *reserved[] = {
+        "null", "Null", "NULL", "~",
+        "true", "True", "TRUE", "false", "False", "FALSE",
+        "yes",  "Yes",  "YES",  "no",   "No",  "NO",
+        "on",   "On",   "ON",   "off",  "Off", "OFF",
+        ".inf", ".Inf", ".INF", ".nan", ".NaN", ".NAN",
+        NULL,
+    };
+    for (u32 i = 0; reserved[i]; i++) {
+        if (yp_str_eq_ci(s, len, reserved[i])) return true;
+    }
+    /* Numeric look-alikes. */
+    f64 n;
+    if (yp_try_parse_int(s, len, &n)) return true;
+    if (yp_try_parse_float(s, len, &n)) return true;
+
+    /* Special leading characters or control chars / structural indicators. */
+    char first = s[0];
+    if (first == ' ' || first == '\t' || first == '#' ||
+        first == '&' || first == '*' || first == '!' ||
+        first == '|' || first == '>' || first == '\'' ||
+        first == '"' || first == '%' || first == '@' ||
+        first == '`' || first == '?' || first == ':' ||
+        first == '-' || first == '[' || first == ']' ||
+        first == '{' || first == '}' || first == ',')
+        return true;
+    if (s[len - 1] == ' ' || s[len - 1] == '\t') return true;
+
+    for (u32 i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c < 0x20 || c == 0x7F) return true;
+        /* `: ` or ` #` cannot appear in a plain scalar; they would terminate it. */
+        if (c == ':' && (i + 1 == len ||
+                         s[i + 1] == ' ' || s[i + 1] == '\t')) return true;
+        if (c == '#' && i > 0 && (s[i - 1] == ' ' || s[i - 1] == '\t'))
+            return true;
+    }
+    return false;
+}
+
+static void yw_write_string_scalar(YWriter *w, const char *s, u32 len)
+{
+    if (!yw_string_needs_quotes(s, len)) {
+        ybuf_push(&w->buf, s, len);
+        return;
+    }
+    /* Emit double-quoted with JSON-compatible escapes. */
+    ybuf_push_char(&w->buf, '"');
+    for (u32 i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)s[i];
+        switch (c) {
+            case '"':  ybuf_push(&w->buf, "\\\"", 2); break;
+            case '\\': ybuf_push(&w->buf, "\\\\", 2); break;
+            case '\n': ybuf_push(&w->buf, "\\n",  2); break;
+            case '\r': ybuf_push(&w->buf, "\\r",  2); break;
+            case '\t': ybuf_push(&w->buf, "\\t",  2); break;
+            case '\b': ybuf_push(&w->buf, "\\b",  2); break;
+            case '\f': ybuf_push(&w->buf, "\\f",  2); break;
+            default:
+                if (c < 0x20 || c == 0x7F) {
+                    char esc[7];
+                    snprintf(esc, sizeof(esc), "\\x%02x", c);
+                    ybuf_push(&w->buf, esc, 4);
+                } else {
+                    ybuf_push_char(&w->buf, (char)c);
+                }
+                break;
+        }
+    }
+    ybuf_push_char(&w->buf, '"');
+}
+
+static void yw_write_number(YWriter *w, f64 n)
+{
+    if (isnan(n)) { ybuf_push(&w->buf, ".nan", 4); return; }
+    if (isinf(n)) {
+        ybuf_push_cstr(&w->buf, n < 0 ? "-.inf" : ".inf");
+        return;
+    }
+    char tmp[64];
+    if (n == floor(n) && fabs(n) < 1e15) {
+        snprintf(tmp, sizeof(tmp), "%.0f", n);
+    } else {
+        snprintf(tmp, sizeof(tmp), "%.17g", n);
+    }
+    ybuf_push_cstr(&w->buf, tmp);
+}
+
+static bool yw_first_field_cb(CdoString *k, CdoValue *v, u8 f, void *ud)
+{
+    (void)k; (void)v; (void)f;
+    *(bool *)ud = false;
+    return false;                            /* stop after first field */
+}
+
+static bool yw_obj_is_empty(CdoObject *obj)
+{
+    bool empty = true;
+    cdo_object_foreach(obj, yw_first_field_cb, &empty);
+    return empty;
+}
+
+/* =========================================================================
+ * Recursive writers for arrays and objects
+ *
+ * `inline_first`:
+ *   - true  -> the first character of this value is rendered immediately
+ *              after whatever the caller already wrote (e.g. after `key:` or
+ *              after `- ` in a sequence parent).  For containers we still
+ *              break to a new line because YAML cannot start a block-style
+ *              container immediately after the parent indicator.
+ *   - false -> caller wants this value preceded by indentation.
+ * ======================================================================= */
+
+typedef struct { YWriter *w; int depth; bool first; } YObjCtx;
+
+static bool yw_field_cb(CdoString *key, CdoValue *val, u8 flags, void *ud)
+{
+    (void)flags;
+    YObjCtx *ctx = (YObjCtx *)ud;
+    if (ctx->w->buf.oom) return false;
+
+    if (!ctx->first) ybuf_push_char(&ctx->w->buf, '\n');
+    ctx->first = false;
+
+    yw_write_indent(ctx->w, ctx->depth);
+    yw_write_string_scalar(ctx->w, key->data, key->length);
+    ybuf_push_char(&ctx->w->buf, ':');
+
+    /* For non-empty containers, emit on the next line; for scalars, inline. */
+    bool needs_newline =
+        (val->tag == CDO_ARRAY) ||
+        (val->tag == CDO_OBJECT && val->as.object->kind != OBJ_ARRAY &&
+         !yw_obj_is_empty(val->as.object));
+    if (val->tag == CDO_ARRAY && cdo_array_len(val->as.object) == 0)
+        needs_newline = false;        /* empty array -> ` []` inline */
+    if (val->tag == CDO_OBJECT && val->as.object->kind == OBJ_ARRAY &&
+        cdo_array_len(val->as.object) == 0)
+        needs_newline = false;
+
+    if (needs_newline) {
+        ybuf_push_char(&ctx->w->buf, '\n');
+        yw_write_cdo_value(ctx->w, *val, ctx->depth + 1, false);
+    } else {
+        ybuf_push_char(&ctx->w->buf, ' ');
+        yw_write_cdo_value(ctx->w, *val, ctx->depth + 1, true);
+    }
+    return !ctx->w->buf.oom;
+}
+
+static void yw_write_object(YWriter *w, CdoObject *obj, int depth)
+{
+    if (yw_obj_is_empty(obj)) {
+        ybuf_push(&w->buf, "{}", 2);
+        return;
+    }
+    YObjCtx ctx = { .w = w, .depth = depth, .first = true };
+    cdo_object_foreach(obj, yw_field_cb, &ctx);
+}
+
+static void yw_write_array(YWriter *w, CdoObject *arr, int depth)
+{
+    u32 len = cdo_array_len(arr);
+    if (len == 0) {
+        ybuf_push(&w->buf, "[]", 2);
+        return;
+    }
+    for (u32 i = 0; i < len; i++) {
+        if (i > 0) ybuf_push_char(&w->buf, '\n');
+        yw_write_indent(w, depth);
+        ybuf_push_char(&w->buf, '-');
+
+        CdoValue elem = cdo_null();
+        cdo_array_rawget_idx(arr, i, &elem);
+
+        bool nested_container = (elem.tag == CDO_ARRAY) ||
+            (elem.tag == CDO_OBJECT && elem.as.object->kind != OBJ_ARRAY &&
+             !yw_obj_is_empty(elem.as.object));
+        if (elem.tag == CDO_ARRAY && cdo_array_len(elem.as.object) == 0)
+            nested_container = false;
+        if (elem.tag == CDO_OBJECT && elem.as.object->kind == OBJ_ARRAY &&
+            cdo_array_len(elem.as.object) == 0)
+            nested_container = false;
+
+        if (nested_container) {
+            ybuf_push_char(&w->buf, '\n');
+            yw_write_cdo_value(w, elem, depth + 1, false);
+        } else {
+            ybuf_push_char(&w->buf, ' ');
+            yw_write_cdo_value(w, elem, depth + 1, true);
+        }
+        if (w->buf.oom) break;
+    }
+}
+
+static void yw_write_cdo_value(YWriter *w, CdoValue val, int depth,
+                                bool inline_first)
+{
+    if (w->buf.oom) return;
+    switch ((CdoTypeTag)val.tag) {
+        case CDO_NULL:
+            if (!inline_first) yw_write_indent(w, depth);
+            ybuf_push(&w->buf, "null", 4);
+            break;
+        case CDO_BOOL:
+            if (!inline_first) yw_write_indent(w, depth);
+            ybuf_push_cstr(&w->buf, val.as.boolean ? "true" : "false");
+            break;
+        case CDO_NUMBER:
+            if (!inline_first) yw_write_indent(w, depth);
+            yw_write_number(w, val.as.number);
+            break;
+        case CDO_STRING:
+            if (!inline_first) yw_write_indent(w, depth);
+            yw_write_string_scalar(w, val.as.string->data,
+                                   val.as.string->length);
+            break;
+        case CDO_ARRAY:
+            yw_write_array(w, val.as.object, depth);
+            break;
+        case CDO_OBJECT:
+            if (val.as.object->kind == OBJ_ARRAY)
+                yw_write_array(w, val.as.object, depth);
+            else
+                yw_write_object(w, val.as.object, depth);
+            break;
+        case CDO_FUNCTION:
+        case CDO_NATIVE:
+            /* Not representable in YAML; emit `null` to keep doc valid. */
+            if (!inline_first) yw_write_indent(w, depth);
+            ybuf_push(&w->buf, "null", 4);
+            break;
+    }
+}
+
+/* =========================================================================
+ * yaml.stringify(val, indent?) -> string
+ * ======================================================================= */
+
+static int yaml_stringify(CandoVM *vm, int argc, CandoValue *args)
+{
+    if (argc < 1) {
+        libutil_push_cstr(vm, "null\n");
+        return 1;
+    }
+
+    int indent = 2;
+    if (argc >= 2 && cando_is_number(args[1])) {
+        indent = (int)args[1].as.number;
+        if (indent < 1)  indent = 1;
+        if (indent > 16) indent = 16;
+    }
+
+    YWriter w;
+    w.buf.data = NULL; w.buf.len = 0; w.buf.cap = 0; w.buf.oom = false;
+    w.indent   = indent;
+    w.vm       = vm;
+
+    CandoValue val = args[0];
+    switch ((TypeTag)val.tag) {
+        case TYPE_NULL:
+            ybuf_push(&w.buf, "null", 4); break;
+        case TYPE_BOOL:
+            ybuf_push_cstr(&w.buf, val.as.boolean ? "true" : "false"); break;
+        case TYPE_NUMBER:
+            yw_write_number(&w, val.as.number); break;
+        case TYPE_STRING:
+            yw_write_string_scalar(&w, val.as.string->data,
+                                   val.as.string->length);
+            break;
+        case TYPE_OBJECT: {
+            CdoObject *obj = cando_bridge_resolve(vm, val.as.handle);
+            if (obj->kind == OBJ_ARRAY)
+                yw_write_array(&w, obj, 0);
+            else
+                yw_write_object(&w, obj, 0);
+            break;
+        }
+    }
+
+    /* Always end with exactly one newline. */
+    if (w.buf.len == 0 || w.buf.data[w.buf.len - 1] != '\n')
+        ybuf_push_char(&w.buf, '\n');
+
+    libutil_push_str(vm, w.buf.data ? w.buf.data : "", (u32)w.buf.len);
+    ybuf_free(&w.buf);
+    return 1;
+}
+
+/* =========================================================================
+ * Registration
+ * ======================================================================= */
+
+void cando_lib_yaml_register(CandoVM *vm)
+{
+    CandoValue yaml_val = cando_bridge_new_object(vm);
+    CdoObject *yaml_obj = cando_bridge_resolve(vm, yaml_val.as.handle);
+
+    libutil_set_method(vm, yaml_obj, "parse",     yaml_parse);
+    libutil_set_method(vm, yaml_obj, "stringify", yaml_stringify);
+
+    cando_vm_set_global(vm, "yaml", yaml_val, true);
+}

--- a/source/lib/yaml.h
+++ b/source/lib/yaml.h
@@ -1,0 +1,59 @@
+/*
+ * lib/yaml.h -- YAML encode/decode standard library for Cando.
+ *
+ * Registers a global `yaml` object with the following methods:
+ *
+ *   yaml.parse(str)              → value | null
+ *   yaml.stringify(val, indent?) → string
+ *
+ * yaml.parse() maps YAML constructs to native Cando values:
+ *   block mapping / flow mapping        → object
+ *   block sequence / flow sequence      → array
+ *   plain / single-quoted / double-     → string  (heuristic typing rules
+ *     quoted scalars                       turn unquoted scalars matching
+ *                                          the integer/float grammar into
+ *                                          numbers; "true"/"false"/"yes"/
+ *                                          "no" become bool; "null"/"~"/""
+ *                                          become null)
+ *   literal (|) / folded (>) blocks     → string
+ *
+ * yaml.stringify() serialises a Cando value to a YAML 1.2 compatible
+ * document.  Objects render as block mappings, arrays as block sequences,
+ * scalars are quoted only when ambiguity rules require it.  The optional
+ * `indent` argument controls the per-level indentation (default: 2,
+ * clamped to 1..16).
+ *
+ * Both interfaces support nesting to arbitrary depth and are independent
+ * of any external YAML library; the implementation is self-contained.
+ *
+ * Must compile with gcc -std=c11.
+ */
+
+#ifndef CANDO_LIB_YAML_H
+#define CANDO_LIB_YAML_H
+
+#include "../vm/vm.h"
+
+/*
+ * cando_lib_yaml_register -- create the `yaml` global object and register
+ * all methods on it.  Must be called after cdo_object_init() and after the
+ * VM has been initialised with cando_vm_init().
+ */
+CANDO_API void cando_lib_yaml_register(CandoVM *vm);
+
+/*
+ * cando_lib_yaml_parse_buffer -- parse a YAML document from a raw byte
+ * buffer and store the resulting Cando value in *out.  Returns true on
+ * success.  On failure sets a VM error (with the supplied `where` string
+ * used as the prefix, e.g. "yaml.parse" or "include") and returns false;
+ * *out is left as cando_null() in that case.
+ *
+ * Provided so other library code (notably include()) can reuse the YAML
+ * parser without going through the VM-level yaml.parse native.
+ */
+CANDO_API bool cando_lib_yaml_parse_buffer(CandoVM *vm,
+                                           const char *src, usize len,
+                                           const char *where,
+                                           CandoValue *out);
+
+#endif /* CANDO_LIB_YAML_H */

--- a/source/natives.h
+++ b/source/natives.h
@@ -32,12 +32,15 @@ int cando_native_tostring(CandoVM *vm, int argc, CandoValue *args);
  * nested arrays/objects beyond that level.  Returns 1. */
 int cando_native_inspect(CandoVM *vm, int argc, CandoValue *args);
 
-/* Dispatch table indexed by NATIVE_INDEX.
- * Sized to CANDO_NATIVE_MAX; unused trailing slots are NULL.
- * Iterate until a NULL entry to discover the count. */
+/* Static dispatch table for the small set of *core* natives that ship
+ * inside libcando itself (print, type, toString, inspect, ...).  Sized to
+ * CANDO_NATIVE_MAX with unused trailing slots left NULL; iterate until a
+ * NULL entry to discover the count.  Standard-library natives registered
+ * via cando_vm_register_native() / cando_vm_add_native() do NOT live here
+ * — they live in the per-VM dynamic registry, which has no fixed cap. */
 extern CandoNativeFn cando_native_table[CANDO_NATIVE_MAX];
 
-/* Parallel name table (NULL-terminated) for registration in main(). */
+/* Parallel name table (NULL-terminated) for the core dispatch table. */
 extern const char *cando_native_names[CANDO_NATIVE_MAX];
 
 #endif /* CANDO_NATIVES_H */

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -135,7 +135,10 @@ void cando_vm_init(CandoVM *vm, CandoMemCtrl *mem) {
     vm->try_depth      = 0;
     vm->loop_depth     = 0;
     vm->open_upvalues  = NULL;
+    /* Native registry: lazily grown on first cando_vm_register_native(). */
+    vm->native_fns     = NULL;
     vm->native_count   = 0;
+    vm->native_cap     = 0;
     vm->mem            = mem;
     vm->has_error       = false;
     vm->error_val_count = 0;
@@ -234,10 +237,19 @@ void cando_vm_init_child(CandoVM *child, const CandoVM *parent) {
     child->globals_owned = NULL;
     child->globals       = parent->globals;   /* shared, locked on access */
 
-    /* Copy native function registry (read-only after init; safe to share). */
+    /* Copy native function registry (read-only after init; child gets its
+     * own buffer so subsequent registrations on either VM cannot disturb
+     * the other). */
     child->native_count = parent->native_count;
-    for (u32 i = 0; i < parent->native_count; i++)
-        child->native_fns[i] = parent->native_fns[i];
+    child->native_cap   = parent->native_count;
+    if (parent->native_count > 0) {
+        child->native_fns = (CandoNativeFn *)cando_alloc(
+            parent->native_count * sizeof(CandoNativeFn));
+        for (u32 i = 0; i < parent->native_count; i++)
+            child->native_fns[i] = parent->native_fns[i];
+    } else {
+        child->native_fns = NULL;
+    }
 
     /* NOTE: cdo_object_init() is intentionally NOT called here.
      * The parent VM's cando_vm_init() already initialized the global
@@ -285,6 +297,13 @@ void cando_vm_destroy(CandoVM *vm) {
     }
 
     for (u32 i = 0; i < CANDO_MAX_THROW_ARGS; i++) cando_value_release(vm->error_vals[i]);
+
+    /* Release the native registry.  Each VM owns its own buffer (see the
+     * fork path in cando_vm_init_child) so freeing here is unconditional. */
+    cando_free(vm->native_fns);
+    vm->native_fns   = NULL;
+    vm->native_count = 0;
+    vm->native_cap   = 0;
 
     /* Release eval results. */
     for (u32 i = 0; i < vm->eval_result_count; i++) {
@@ -483,9 +502,20 @@ static bool vm_set_global_str(CandoVM *vm, CandoString *key,
  * Native function registration
  * ===================================================================== */
 
+/* Ensure vm->native_fns has room for at least one more entry.  Doubles the
+ * capacity (starting at 16) so amortised registration is O(1).  Aborts on
+ * allocation failure via cando_realloc, matching the rest of the codebase. */
+static void vm_native_reserve_one(CandoVM *vm) {
+    if (vm->native_count < vm->native_cap) return;
+    u32 new_cap = vm->native_cap ? vm->native_cap * 2 : 16;
+    vm->native_fns = (CandoNativeFn *)cando_realloc(
+        vm->native_fns, new_cap * sizeof(CandoNativeFn));
+    vm->native_cap = new_cap;
+}
+
 bool cando_vm_register_native(CandoVM *vm, const char *name,
                                CandoNativeFn fn) {
-    if (vm->native_count >= CANDO_NATIVE_MAX) return false;
+    vm_native_reserve_one(vm);
     u32 idx = vm->native_count++;
     vm->native_fns[idx] = fn;
     /* Sentinel value: native #idx → -(idx+1) */
@@ -495,7 +525,7 @@ bool cando_vm_register_native(CandoVM *vm, const char *name,
 }
 
 CandoValue cando_vm_add_native(CandoVM *vm, CandoNativeFn fn) {
-    if (vm->native_count >= CANDO_NATIVE_MAX) return cando_null();
+    vm_native_reserve_one(vm);
     u32 idx = vm->native_count++;
     vm->native_fns[idx] = fn;
     return cando_number(-(f64)(idx + 1));

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -51,7 +51,9 @@
 #define CANDO_FRAMES_MAX       256    /* maximum call depth                 */
 #define CANDO_TRY_MAX          64     /* maximum nested try blocks          */
 #define CANDO_LOOP_MAX         64     /* maximum nested loop depth          */
-#define CANDO_NATIVE_MAX      512     /* maximum registered native functions */
+#define CANDO_NATIVE_MAX      512     /* size of the static core-native dispatch table
+                                        * in source/natives.c.  Per-VM native registries
+                                        * grow dynamically and are NOT bounded by this. */
 #define CANDO_MAX_THROW_ARGS   32     /* maximum values in one THROW        */
 
 /* Forward declaration — CandoClosure is defined below. */
@@ -239,8 +241,12 @@ struct CandoVM {
     CandoGlobalEnv  *globals_owned; /* heap-allocated env; NULL for child VMs */
 
     /* Native functions ------------------------------------------------- */
-    CandoNativeFn  native_fns[CANDO_NATIVE_MAX];
+    /* The native registry grows on demand: cando_vm_register_native /
+     * cando_vm_add_native double native_cap when full.  Child thread VMs
+     * receive a fresh allocation copied from the parent at fork time. */
+    CandoNativeFn *native_fns;
     u32            native_count;
+    u32            native_cap;
 
     /* Memory controller (may be NULL for unit tests) ------------------- */
     CandoMemCtrl  *mem;
@@ -425,17 +431,18 @@ CANDO_API u32 cando_vm_stack_depth(const CandoVM *vm);
  *
  * Assigns the next available sentinel value (-(count+1)) to the function,
  * stores it in vm->native_fns[], and defines a global variable `name` with
- * that sentinel so scripts can call it by name.
+ * that sentinel so scripts can call it by name.  The native table grows on
+ * demand, so registration only fails on allocation pressure.
  *
- * Returns true on success, false if CANDO_NATIVE_MAX is exceeded.
+ * Returns true on success, false if the underlying allocation failed.
  */
 CANDO_API bool cando_vm_register_native(CandoVM *vm, const char *name,
                                CandoNativeFn fn);
 
 /*
  * cando_vm_add_native -- register a native without exposing it as a global.
- * Returns the sentinel CandoValue that represents this function.
- * Returns cando_null() if CANDO_NATIVE_MAX is exceeded.
+ * Returns the sentinel CandoValue that represents this function, or
+ * cando_null() if the underlying allocation failed.
  */
 CANDO_API CandoValue cando_vm_add_native(CandoVM *vm, CandoNativeFn fn);
 

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -51,7 +51,7 @@
 #define CANDO_FRAMES_MAX       256    /* maximum call depth                 */
 #define CANDO_TRY_MAX          64     /* maximum nested try blocks          */
 #define CANDO_LOOP_MAX         64     /* maximum nested loop depth          */
-#define CANDO_NATIVE_MAX      256     /* maximum registered native functions */
+#define CANDO_NATIVE_MAX      512     /* maximum registered native functions */
 #define CANDO_MAX_THROW_ARGS   32     /* maximum values in one THROW        */
 
 /* Forward declaration — CandoClosure is defined below. */

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -116,7 +116,10 @@ run_test "include_16" "$SCRIPTS/include_16.cdo" \
     "$(printf '1\n8\n16\ntrue\ntrue\ntrue')"
 
 run_test "include_ext" "$SCRIPTS/include_ext.cdo" \
-    "$(printf 'Cando\n1\ntrue\nalpha\nbeta\nalice\nbob\neve\nLA\nHello, Ext!\nMutated')"
+    "$(printf 'Cando\n1\ntrue\nalpha\nbeta\nalice\nbob\neve\nLA\nHello, Ext!\nMutated\nCando\n1\nalpha\ntrue')"
+
+run_test "lib_yaml" "$SCRIPTS/lib_yaml.cdo" \
+    "$(printf '42\n3.5\ntrue\nfalse\nnull\nnull\ntrue\nfalse\nhello\n42\nAlice\n30\ntrue\none\n2\ntrue\nnull\nlocalhost\n8080\ndebug\nverbose\nalice\n30\nbob\n25\n1\n3\n1\nhello\ntrue\n12\n14\nvalue\na\nb\ntrue\n3\n5\n5\n7\n6\nCando\n1\na\nb\ntrue\n3\n3\nflow_error_caught')"
 
 run_test "threads" "$SCRIPTS/threads.cdo" \
     "$(printf '42\n10\n20\ntrue\nsleep_ok\nid_ok\n99\ntrue\nnull\n7\n1\n2\n3\ndone\nerror\nbad\ntrue\ntrue\n77\n88\ncaught_err\nalready\nfalse')"

--- a/tests/scripts/include_ext.cdo
+++ b/tests/scripts/include_ext.cdo
@@ -23,3 +23,10 @@ print(greet("Ext"));                /* Hello, Ext!      */
 VAR data2 = include("modules/data.json");
 data2.name = "Mutated";
 print(data.name);                   /* Mutated (shared) */
+
+/* --- .yaml: parsed object via include() --- */
+VAR yml = include("modules/data.yaml");
+print(yml.name);                    /* Cando            */
+print(yml.version);                 /* 1                */
+print(yml.tags[0]);                 /* alpha            */
+print(yml.active);                  /* true             */

--- a/tests/scripts/lib_yaml.cdo
+++ b/tests/scripts/lib_yaml.cdo
@@ -1,0 +1,135 @@
+/* lib_yaml.cdo -- Integration tests for the yaml standard library.
+ *
+ * Each test prints a labelled result to stdout.  Expected output is
+ * registered in tests/integration/run_tests.sh.
+ *
+ * Note: cdo string literals do not process backslash escapes, so YAML
+ * source strings use real (multi-line) text in single- and double-quoted
+ * cdo strings.
+ */
+
+/* ----- yaml.parse: scalar typing ----------------------------------------- */
+print(yaml.parse("42"));            /* 42         */
+print(yaml.parse("3.5"));           /* 3.5        */
+print(yaml.parse("true"));          /* true       */
+print(yaml.parse("false"));         /* false      */
+print(yaml.parse("null"));          /* null       */
+print(yaml.parse("~"));             /* null       */
+print(yaml.parse("yes"));           /* true       */
+print(yaml.parse("NO"));            /* false      */
+print(yaml.parse("hello"));         /* hello      */
+print(yaml.parse("'42'"));          /* 42 (string, but printed without quotes) */
+
+/* ----- yaml.parse: block mapping ----------------------------------------- */
+var m = yaml.parse("name: Alice
+age: 30
+admin: true
+");
+print(m.name);                      /* Alice      */
+print(m.age);                       /* 30         */
+print(m.admin);                     /* true       */
+
+/* ----- yaml.parse: block sequence ---------------------------------------- */
+var s = yaml.parse("- one
+- 2
+- true
+- null
+");
+print(s[0]);                        /* one        */
+print(s[1]);                        /* 2          */
+print(s[2]);                        /* true       */
+print(s[3]);                        /* null       */
+
+/* ----- yaml.parse: nested ------------------------------------------------ */
+var nested = yaml.parse("config:
+  host: localhost
+  port: 8080
+  flags:
+    - debug
+    - verbose
+");
+print(nested.config.host);          /* localhost  */
+print(nested.config.port);          /* 8080       */
+print(nested.config.flags[0]);      /* debug      */
+print(nested.config.flags[1]);      /* verbose    */
+
+/* ----- yaml.parse: sequence of mappings ---------------------------------- */
+var people = yaml.parse("- name: alice
+  age: 30
+- name: bob
+  age: 25
+");
+print(people[0].name);              /* alice      */
+print(people[0].age);               /* 30         */
+print(people[1].name);              /* bob        */
+print(people[1].age);               /* 25         */
+
+/* ----- yaml.parse: flow style -------------------------------------------- */
+var flow = yaml.parse("nums: [1, 2, 3]
+obj: {a: 1, b: hello, c: true}
+");
+print(flow.nums[0]);                /* 1          */
+print(flow.nums[2]);                /* 3          */
+print(flow.obj.a);                  /* 1          */
+print(flow.obj.b);                  /* hello      */
+print(flow.obj.c);                  /* true       */
+
+/* ----- yaml.parse: literal block scalar (multi-line string preserved) ---- */
+var lit = yaml.parse("text: |
+  hello
+  world
+");
+print(lit.text:length());           /* 12 (hello\nworld\n) */
+
+/* ----- yaml.parse: folded block scalar ----------------------------------- */
+var fold = yaml.parse("text: >
+  one two
+  three
+");
+print(fold.text:length());          /* 14 (one two three\n) */
+
+/* ----- yaml.parse: comments stripped ------------------------------------- */
+var c = yaml.parse("# header
+key: value  # inline
+list:
+  - a   # first
+  - b   # second
+");
+print(c.key);                       /* value      */
+print(c.list[0]);                   /* a          */
+print(c.list[1]);                   /* b          */
+
+/* ----- yaml.parse: leading --- separator --------------------------------- */
+var d = yaml.parse("---
+ok: true
+");
+print(d.ok);                        /* true       */
+
+/* ----- yaml.stringify: scalars ------------------------------------------- */
+print(yaml.stringify(42):length());        /* "42\n"    -> 3 */
+print(yaml.stringify(true):length());      /* "true\n"  -> 5 */
+print(yaml.stringify(null):length());      /* "null\n"  -> 5 */
+print(yaml.stringify("true"):length());    /* '"true"\n' -> 7  (quoted) */
+print(yaml.stringify("hello"):length());   /* "hello\n" -> 6 */
+
+/* ----- yaml.stringify round-trip ----------------------------------------- */
+var orig = { name: "Cando", version: 1, tags: ["a", "b"], on: true };
+var text = yaml.stringify(orig);
+var back = yaml.parse(text);
+print(back.name);                   /* Cando      */
+print(back.version);                /* 1          */
+print(back.tags[0]);                /* a          */
+print(back.tags[1]);                /* b          */
+print(back.on);                     /* true       */
+
+/* ----- yaml.stringify: empty containers ---------------------------------- */
+print(yaml.stringify([]):length());        /* "[]\n" -> 3 */
+print(yaml.stringify({}):length());        /* "{}\n" -> 3 */
+
+/* ----- yaml.parse: error path ------------------------------------------- */
+try {
+    yaml.parse("[1, 2");                  /* unterminated flow seq */
+    print("no_error");
+} catch (e) {
+    print("flow_error_caught");
+}

--- a/tests/scripts/modules/data.yaml
+++ b/tests/scripts/modules/data.yaml
@@ -1,0 +1,8 @@
+# tests/scripts/modules/data.yaml
+# Mirror of data.json so the include() suite can exercise YAML loading.
+name: Cando
+version: 1
+active: true
+tags:
+  - alpha
+  - beta

--- a/tests/test_yaml.c
+++ b/tests/test_yaml.c
@@ -1,0 +1,215 @@
+/*
+ * tests/test_yaml.c -- Unit tests for the yaml standard library.
+ *
+ * Exercises both the C-level entry point (cando_lib_yaml_parse_buffer) and
+ * the script-visible interface (yaml.parse / yaml.stringify) by spinning up
+ * a real CandoVM, opening libraries, and running short scripts.
+ *
+ * Compile via Makefile:
+ *   make test_yaml
+ *
+ * Exit 0 on success, non-zero on failure.
+ */
+
+#include "cando.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* -----------------------------------------------------------------------
+ * Minimal harness mirroring test_sockutil / test_vm
+ * --------------------------------------------------------------------- */
+static int g_run    = 0;
+static int g_passed = 0;
+static int g_failed = 0;
+
+#define EXPECT(cond) \
+    do { \
+        g_run++; \
+        if (cond) { g_passed++; } \
+        else { g_failed++; \
+               fprintf(stderr, "FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); } \
+    } while (0)
+
+#define EXPECT_TRUE(x)   EXPECT(!!(x))
+#define EXPECT_FALSE(x)  EXPECT(!(x))
+#define EXPECT_EQ(a, b)  EXPECT((a) == (b))
+
+#define TEST(name) static void name(CandoVM *vm)
+
+static void run_test(const char *name, void (*fn)(CandoVM *), CandoVM *vm)
+{
+    printf("  %-52s ", name);
+    fflush(stdout);
+    int before = g_failed;
+    /* Reset error state between tests by recreating the VM if needed. */
+    fn(vm);
+    printf("%s\n", g_failed == before ? "OK" : "FAIL");
+}
+
+/* Helper: run a short script that *should* succeed.  Asserts return code
+ * and clears any leftover error. */
+static bool run_ok(CandoVM *vm, const char *src)
+{
+    int rc = cando_dostring(vm, src, "test");
+    if (rc != CANDO_OK) {
+        fprintf(stderr, "  [unexpected error] %s\n", cando_errmsg(vm));
+        return false;
+    }
+    return true;
+}
+
+/* =========================================================================
+ * Tests: parse_buffer C API
+ * ===================================================================== */
+
+TEST(test_parse_null_via_buffer)
+{
+    /* Empty document parses to null. */
+    CandoValue out = cando_null();
+    bool ok = cando_lib_yaml_parse_buffer(vm, "", 0, "test", &out);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ((int)out.tag, (int)TYPE_NULL);
+    cando_value_release(out);
+}
+
+TEST(test_parse_scalar_int)
+{
+    CandoValue out = cando_null();
+    bool ok = cando_lib_yaml_parse_buffer(vm, "42", 2, "test", &out);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ((int)out.tag, (int)TYPE_NUMBER);
+    EXPECT_EQ((int)out.as.number, 42);
+    cando_value_release(out);
+}
+
+TEST(test_parse_scalar_bool)
+{
+    CandoValue out = cando_null();
+    bool ok = cando_lib_yaml_parse_buffer(vm, "yes", 3, "test", &out);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ((int)out.tag, (int)TYPE_BOOL);
+    EXPECT_TRUE(out.as.boolean);
+    cando_value_release(out);
+}
+
+TEST(test_parse_block_map)
+{
+    const char *src = "name: alice\nage: 30\n";
+    CandoValue out = cando_null();
+    bool ok = cando_lib_yaml_parse_buffer(vm, src, strlen(src), "test", &out);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ((int)out.tag, (int)TYPE_OBJECT);
+    cando_value_release(out);
+}
+
+TEST(test_parse_error_message)
+{
+    /* Unterminated flow sequence; parse_buffer should set a VM error. */
+    CandoValue out;
+    bool ok = cando_lib_yaml_parse_buffer(vm, "[1, 2", 5, "test", &out);
+    EXPECT_FALSE(ok);
+    EXPECT_EQ((int)out.tag, (int)TYPE_NULL);
+    EXPECT_TRUE(strstr(cando_errmsg(vm), "test") != NULL);
+    /* Clear VM error so subsequent tests start clean. */
+    vm->has_error = false;
+    vm->error_msg[0] = '\0';
+}
+
+TEST(test_parse_tab_indent_rejected)
+{
+    /* Tab-indented block content is an error. */
+    const char *src = "a:\n\tb: 1\n";
+    CandoValue out;
+    bool ok = cando_lib_yaml_parse_buffer(vm, src, strlen(src), "test", &out);
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(strstr(cando_errmsg(vm), "tab") != NULL);
+    vm->has_error = false;
+    vm->error_msg[0] = '\0';
+}
+
+/* =========================================================================
+ * Tests: yaml.parse / yaml.stringify via scripts
+ * ===================================================================== */
+
+TEST(test_script_parse_basic)
+{
+    EXPECT_TRUE(run_ok(vm,
+        "VAR v = yaml.parse(\"a: 1\nb: hello\n\");\n"
+        "IF v.a != 1         { THROW \"a wrong\"; }\n"
+        "IF v.b != \"hello\"   { THROW \"b wrong\"; }\n"
+    ));
+}
+
+TEST(test_script_parse_sequence)
+{
+    EXPECT_TRUE(run_ok(vm,
+        "VAR v = yaml.parse(\"- one\n- 2\n- true\n\");\n"
+        "IF v[0] != \"one\"  { THROW \"v[0]\"; }\n"
+        "IF v[1] != 2       { THROW \"v[1]\"; }\n"
+        "IF v[2] != true    { THROW \"v[2]\"; }\n"
+    ));
+}
+
+TEST(test_script_round_trip)
+{
+    EXPECT_TRUE(run_ok(vm,
+        "VAR orig = { name: \"Cando\", n: 3, ok: true, items: [1, 2] };\n"
+        "VAR s    = yaml.stringify(orig);\n"
+        "VAR back = yaml.parse(s);\n"
+        "IF back.name != \"Cando\" { THROW \"name\"; }\n"
+        "IF back.n    != 3         { THROW \"n\"; }\n"
+        "IF back.ok   != true      { THROW \"ok\"; }\n"
+        "IF back.items[0] != 1     { THROW \"items[0]\"; }\n"
+        "IF back.items[1] != 2     { THROW \"items[1]\"; }\n"
+    ));
+}
+
+TEST(test_script_quoted_scalar)
+{
+    /* Quoted scalar should remain a string even if it looks like a number. */
+    EXPECT_TRUE(run_ok(vm,
+        "VAR v = yaml.parse(\"'42'\");\n"
+        "IF type(v) != \"string\" { THROW type(v); }\n"
+        "IF v != \"42\"            { THROW v; }\n"
+    ));
+}
+
+TEST(test_script_stringify_quotes_ambiguous)
+{
+    /* Strings that would round-trip to non-string types must be quoted. */
+    EXPECT_TRUE(run_ok(vm,
+        "VAR s = yaml.stringify(\"true\");\n"
+        "IF s:find(`\"`) == null { THROW \"missing quotes: \" + s; }\n"
+    ));
+}
+
+/* =========================================================================
+ * Main
+ * ===================================================================== */
+
+int main(void)
+{
+    printf("Running yaml unit tests...\n");
+
+    CandoVM *vm = cando_open();
+    cando_openlibs(vm);
+
+    run_test("test_parse_null_via_buffer",       test_parse_null_via_buffer,       vm);
+    run_test("test_parse_scalar_int",            test_parse_scalar_int,            vm);
+    run_test("test_parse_scalar_bool",           test_parse_scalar_bool,           vm);
+    run_test("test_parse_block_map",             test_parse_block_map,             vm);
+    run_test("test_parse_error_message",         test_parse_error_message,         vm);
+    run_test("test_parse_tab_indent_rejected",   test_parse_tab_indent_rejected,   vm);
+    run_test("test_script_parse_basic",          test_script_parse_basic,          vm);
+    run_test("test_script_parse_sequence",       test_script_parse_sequence,       vm);
+    run_test("test_script_round_trip",           test_script_round_trip,           vm);
+    run_test("test_script_quoted_scalar",        test_script_quoted_scalar,        vm);
+    run_test("test_script_stringify_quotes_ambiguous",
+             test_script_stringify_quotes_ambiguous, vm);
+
+    cando_close(vm);
+
+    printf("\n  %d run, %d passed, %d failed\n", g_run, g_passed, g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Adds a complete, self-contained YAML 1.2 parser and serializer to the CanDo standard library, with no external dependencies. The implementation provides `yaml.parse()` and `yaml.stringify()` functions for encoding/decoding YAML documents to/from native CanDo values.

## Key Changes

- **New YAML library** (`source/lib/yaml.c`, `source/lib/yaml.h`):
  - Self-contained C implementation (~1600 lines) targeting YAML 1.2 core schema
  - Line-driven parser with pre-tokenization for efficient block-context parsing
  - Support for block mappings/sequences, flow containers, and all scalar types
  - Quoted string handling: single-quoted (with `''` escape), double-quoted (JSON-style escapes + `\xNN`, `\uNNNN`, `\UNNNNNNNN`)
  - Block scalars: literal (`|`) and folded (`>`) with default chomping
  - Core-schema scalar typing: automatic conversion of plain scalars to null/bool/int/float/string
  - YAML 1.1 compatibility: `yes`/`no`/`on`/`off` recognized as booleans
  - Comprehensive error reporting with line numbers

- **Serialization** (`yaml.stringify()`):
  - Converts CanDo values to block-style YAML documents
  - Configurable indentation (1-16 spaces, default 2)
  - Smart quoting: only quotes scalars when necessary to preserve type on round-trip
  - Handles objects as mappings, arrays as sequences, empty containers as inline `{}`/`[]`

- **Integration**:
  - Registered via `cando_openlibs()` and `cando_open_yamllib()`
  - Exposed as global `yaml` object with `parse()` and `stringify()` methods
  - Integrated with `include()` for `.yaml`/`.yml` file loading
  - Full C API: `cando_lib_yaml_parse_buffer()` for programmatic use

- **Testing**:
  - Comprehensive unit tests (`tests/test_yaml.c`) covering C API and script interface
  - Integration tests (`tests/scripts/lib_yaml.cdo`) exercising parsing and serialization
  - Test data file (`tests/scripts/modules/data.yaml`) for include() testing

- **Documentation**:
  - Full API documentation in `docs/yaml.md` with examples
  - Updated standard library reference in `docs/standard-library.md`
  - Updated C API documentation in `docs/c-api.md`

## Notable Implementation Details

- **Line-driven architecture**: Pre-tokenizes input into a line table with indent/content tracking, enabling efficient block-context parsing without backtracking
- **Dynamic buffers**: Shared `YBuf` structure for scalar accumulation and output generation with automatic growth and OOM handling
- **Flow context isolation**: Flow containers (arrays/objects) are line-local, matching JSON-style YAML usage patterns
- **Escape handling**: Comprehensive support for YAML/JSON escape sequences with proper UTF-8 encoding
- **Tab detection**: Explicitly rejects tab indentation in block contexts per YAML spec
- **Comment stripping**: Respects quoted strings when removing trailing comments

https://claude.ai/code/session_01Jj8xntBaF7Yi2sjXJSmZKe