### PR TITLE
Add module shutdown hooks and bundle VS Code extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release:
     name: Publish release zips
-    needs: [linux, windows]
+    needs: [linux, windows, vscode-extension]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -286,12 +286,29 @@ jobs:
           name: cando-windows-x86_64
           path: cando-windows-x86_64
 
+      - name: Download VS Code extension artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vscode-cando-extension
+          path: vscode-cando-extension
+
+      - name: Bundle VS Code extension into platform artifacts
+        # Ship the .vsix alongside each platform binary so a single
+        # download gives users both the interpreter and the editor
+        # integration.  Also publish it standalone on its own channel.
+        run: |
+          set -e
+          mkdir -p cando-linux-x86_64/editors cando-windows-x86_64/editors
+          cp vscode-cando-extension/vscode-cando.vsix cando-linux-x86_64/editors/
+          cp vscode-cando-extension/vscode-cando.vsix cando-windows-x86_64/editors/
+
       - name: Zip platform artifacts
         run: |
           set -e
-          (cd cando-linux-x86_64   && zip -r ../cando-linux-x86_64.zip   .)
-          (cd cando-windows-x86_64 && zip -r ../cando-windows-x86_64.zip .)
-          ls -l cando-linux-x86_64.zip cando-windows-x86_64.zip
+          (cd cando-linux-x86_64       && zip -r ../cando-linux-x86_64.zip       .)
+          (cd cando-windows-x86_64     && zip -r ../cando-windows-x86_64.zip     .)
+          cp vscode-cando-extension/vscode-cando.vsix vscode-cando.vsix
+          ls -l cando-linux-x86_64.zip cando-windows-x86_64.zip vscode-cando.vsix
 
       - name: Publish Linux release channel
         uses: softprops/action-gh-release@v2
@@ -314,5 +331,17 @@ jobs:
             Rolling release of the latest green Windows build.
             Built from commit ${{ github.sha }} on `${{ github.ref_name }}`.
           files: cando-windows-x86_64.zip
+          prerelease: true
+          make_latest: false
+
+      - name: Publish VS Code extension release channel
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: vscode-latest
+          name: CanDo (VS Code extension, latest)
+          body: |
+            Rolling release of the latest green VS Code extension build.
+            Built from commit ${{ github.sha }} on `${{ github.ref_name }}`.
+          files: vscode-cando.vsix
           prerelease: true
           make_latest: false

--- a/modules/forms/forms_module.c
+++ b/modules/forms/forms_module.c
@@ -1043,6 +1043,14 @@ static void mgr_shutdown(void)
 #endif
 }
 
+/* Exported module shutdown hook.  cando_vm_destroy looks this symbol up
+ * via dlsym and calls it before unloading the module so the manager
+ * thread is stopped while the .so is still mapped.  Idempotent. */
+void cando_module_shutdown(void)
+{
+    mgr_shutdown();
+}
+
 static int ensure_manager(void)
 {
     sync_init_once();

--- a/modules/window/window_module.c
+++ b/modules/window/window_module.c
@@ -1032,6 +1032,16 @@ static void mgr_shutdown(void)
 #endif
 }
 
+/* Exported module shutdown hook.  cando_vm_destroy looks this symbol up
+ * via dlsym and calls it before dlclose, so we can stop the manager
+ * thread while the .so is still mapped.  Without this, dlclose unmaps
+ * the manager thread's instructions and the process hangs in dl-close.
+ * Idempotent: mgr_shutdown bails out if the manager isn't running. */
+void cando_module_shutdown(void)
+{
+    mgr_shutdown();
+}
+
 /* Lazy start.  Returns true if the manager thread is in MGR_RUNNING.
  * Safe to call from any thread; idempotent. */
 static int ensure_manager(void)

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -311,7 +311,15 @@ void cando_vm_destroy(CandoVM *vm) {
     }
     cando_free(vm->eval_results);
 
-    /* Release module cache. */
+    /* Release module cache.
+     *
+     * Binary modules may export an optional `cando_module_shutdown` symbol
+     * that lets them stop manager threads, release OS handles, etc. before
+     * the shared library is unloaded.  Unloading the .so while a thread it
+     * spawned is still running unmaps the thread's instruction pointer and
+     * deadlocks the dlclose call -- so we always invoke shutdown first
+     * when the symbol is exported. */
+    typedef void (*CandoModuleShutdownFn)(void);
     for (u32 i = 0; i < vm->module_cache_count; i++) {
         CandoModuleEntry *e = &vm->module_cache[i];
         cando_free(e->path);
@@ -323,8 +331,14 @@ void cando_vm_destroy(CandoVM *vm) {
         cando_chunk_free(e->chunk);     /* NULL-safe; chunk owned by module entry  */
         if (e->dl_handle) {
 #if defined(_WIN32) || defined(_WIN64)
+            CandoModuleShutdownFn shutdown_fn = (CandoModuleShutdownFn)(void *)
+                GetProcAddress((HMODULE)e->dl_handle, "cando_module_shutdown");
+            if (shutdown_fn) shutdown_fn();
             FreeLibrary((HMODULE)e->dl_handle);
 #else
+            CandoModuleShutdownFn shutdown_fn = (CandoModuleShutdownFn)(uintptr_t)
+                dlsym(e->dl_handle, "cando_module_shutdown");
+            if (shutdown_fn) shutdown_fn();
             dlclose(e->dl_handle);
 #endif
         }


### PR DESCRIPTION
## Summary
This PR adds a module shutdown mechanism to prevent deadlocks when unloading binary modules, and updates the CI/CD pipeline to bundle the VS Code extension with platform releases.

## Key Changes

### Module Shutdown Hooks
- Added `cando_module_shutdown` symbol lookup in `cando_vm_destroy` that executes before unloading shared libraries
- Implemented on both Windows (via `GetProcAddress`) and Unix (via `dlsym`)
- Prevents deadlocks caused by unloading .so files while spawned manager threads are still running
- Added shutdown hook implementations in `window_module.c` and `forms_module.c` that call their respective `mgr_shutdown()` functions

### CI/CD Pipeline Updates
- Updated release job to depend on `vscode-extension` build job
- Added download step for VS Code extension artifact
- Bundle `.vsix` file into platform-specific release directories (`editors/` subdirectory)
- Publish VS Code extension as standalone release on `vscode-latest` tag
- Users now get both the interpreter and editor integration in a single download

## Implementation Details
- The shutdown hook is optional and idempotent—modules without the symbol are unloaded normally
- Manager threads are stopped while the shared library is still mapped, avoiding instruction pointer unmapping issues during `dlclose`
- VS Code extension is published to both platform-specific archives and as a standalone rolling release

https://claude.ai/code/session_01JVCMmhFbjM7pLxpvgYSCTa