### PR TITLE
Add error logging to event dispatch and introduce onClose handler

### DIFF
--- a/modules/forms/forms_module.c
+++ b/modules/forms/forms_module.c
@@ -1145,20 +1145,28 @@ static void dispatch_one(FormsEvent ev)
     if (!name) return;
 
     CdoObject *inst = cando_bridge_resolve(&g_dispatch_vm, s->inst_val.as.handle);
-    if (!inst) return;
+    if (!inst) {
+        fprintf(stderr, "[forms] dispatch %s: no inst for slot %d\n",
+                name, ev.slot);
+        return;
+    }
 
     CdoString *key = cdo_string_intern(name, (u32)strlen(name));
     CdoValue   field;
     bool       have = cdo_object_get(inst, key, &field);
     cdo_string_release(key);
-    if (!have) return;
+    if (!have) return;          /* no handler installed -- silent */
 
     bool callable = (field.tag == CDO_FUNCTION) ||
                     (field.tag == CDO_NATIVE)   ||
                     (field.tag == CDO_OBJECT &&
                      field.as.object &&
                      field.as.object->kind == OBJ_FUNCTION);
-    if (!callable) return;
+    if (!callable) {
+        fprintf(stderr, "[forms] dispatch %s: handler is not callable "
+                "(tag=%d)\n", name, (int)field.tag);
+        return;
+    }
 
     CandoValue fn = cando_bridge_to_cando(&g_dispatch_vm, field);
 
@@ -1200,6 +1208,10 @@ static void dispatch_one(FormsEvent ev)
     }
 
     cando_vm_call_value(&g_dispatch_vm, fn, argv, argc);
+    if (g_dispatch_vm.has_error) {
+        fprintf(stderr, "[forms] %s handler error: %s\n",
+                name, g_dispatch_vm.error_msg);
+    }
     g_dispatch_vm.stack_top   = g_dispatch_vm.stack;
     g_dispatch_vm.frame_count = 0;
     g_dispatch_vm.has_error   = false;

--- a/modules/window/README.md
+++ b/modules/window/README.md
@@ -115,7 +115,13 @@ w.mousemoved    = FUNCTION(self, x, y) { ... };
 w.wheelmoved    = FUNCTION(self, dx, dy) { ... };
 w.resize       = FUNCTION(self, width, height) { ... };
 w.focus        = FUNCTION(self, focused) { ... };
+w.onClose      = FUNCTION(self) { ... };               // close button / X
 ```
+
+`onClose` fires once when the window's close button is pressed (or the
+underlying GLFW window is otherwise asked to close), just before the
+slot is torn down.  `quit` is kept as a back-compat alias and fires
+alongside `onClose`.
 
 Default handlers may be installed once on the prototype:
 

--- a/modules/window/window_module.c
+++ b/modules/window/window_module.c
@@ -839,7 +839,11 @@ static void mgr_render_frame(void)
          * the flag, so checking it per frame is safe. */
         if (glfwWindowShouldClose(s->handle)) {
             if (g_dispatch_vm_inited && s->inst_val_held) {
-                dispatch_call(s, "quit", NULL, 0);
+                /* `onClose` is the canonical name (matches modules/forms);
+                 * `quit` is kept as a back-compat alias.  Both fire so
+                 * existing scripts continue to work. */
+                dispatch_call(s, "onClose", NULL, 0);
+                dispatch_call(s, "quit",    NULL, 0);
             }
             slot_teardown(s);
             continue;


### PR DESCRIPTION
## Summary
This PR improves error visibility in the forms event dispatch system and adds a new `onClose` window handler as the canonical name for window close events, while maintaining backward compatibility with the existing `quit` handler.

## Key Changes

- **Enhanced error logging in `dispatch_one()`**: Added diagnostic messages for three failure cases:
  - When an instance cannot be resolved for a slot
  - When a handler field is not callable (with tag information)
  - When a handler execution results in a VM error (displays error message)

- **New `onClose` window handler**: Introduced `onClose` as the primary handler name for window close events, matching the naming convention used in the forms module

- **Backward compatibility**: Both `onClose` and `quit` handlers now fire when the window close button is pressed, ensuring existing scripts continue to work without modification

- **Documentation update**: Updated README.md to document the new `onClose` handler and explain its relationship to the deprecated `quit` alias

## Implementation Details

The error logging uses `fprintf(stderr, ...)` to output diagnostic information without disrupting normal program flow. The window close event now dispatches both handlers in sequence (`onClose` first, then `quit`), allowing for a graceful transition period where users can migrate to the new naming convention.

https://claude.ai/code/session_01NbSZrpTz9VreadtjgR1rhL