### PR TITLE
Fix form-event firing: closure capture + window onClose + dispatch diagnostics

### DIFF
--- a/source/parser/parser.c
+++ b/source/parser/parser.c
@@ -468,16 +468,52 @@ static void parse_unary(CandoParser *p, bool can_assign)
     p->last_expr_was_call = false;
 }
 
-/* Emit load for a name, using local slot if available, else global. */
+/* Look up `name` in the immediate enclosing function's local table; if
+ * found, register an upvalue capture (de-duplicating by slot) and return
+ * its index in upvalue_specs[].  Returns -1 if no outer local matches.
+ *
+ * Only the *immediate* enclosing function is consulted -- closures over
+ * locals more than one function deep are not supported yet, but
+ * single-level capture covers script-body locals that the user is most
+ * likely to close over (e.g. loop variables in the script's main scope).
+ */
+static int resolve_upvalue(CandoParser *p, const char *name, u32 len)
+{
+    if (!p->outer_locals || p->outer_count == 0) return -1;
+    for (int i = (int)p->outer_count - 1; i >= 0; i--) {
+        CandoLocal *loc = &p->outer_locals[i];
+        if (loc->len == len && memcmp(loc->name, name, len) == 0) {
+            /* Already captured? */
+            for (u16 j = 0; j < p->upvalue_count; j++) {
+                if (p->upvalue_specs[j] == (u16)i) return (int)j;
+            }
+            if (p->upvalue_count >= CANDO_LOCAL_MAX) {
+                error(p, "too many captured upvalues");
+                return -1;
+            }
+            p->upvalue_specs[p->upvalue_count] = (u16)i;
+            return (int)p->upvalue_count++;
+        }
+    }
+    return -1;
+}
+
+/* Emit load for a name, using local slot if available, then closure
+ * upvalue, else global. */
 static void emit_load(CandoParser *p, const char *name, u32 len)
 {
     int slot = resolve_local(p, name, len);
     if (slot >= 0) {
         emit_op_a(p, OP_LOAD_LOCAL, (u16)slot);
-    } else {
-        u16 idx = str_const(p, name, len);
-        emit_op_a(p, OP_LOAD_GLOBAL, idx);
+        return;
     }
+    int uv = resolve_upvalue(p, name, len);
+    if (uv >= 0) {
+        emit_op_a(p, OP_LOAD_UPVAL, (u16)uv);
+        return;
+    }
+    u16 idx = str_const(p, name, len);
+    emit_op_a(p, OP_LOAD_GLOBAL, idx);
 }
 
 /* Emit store for a name. */
@@ -486,9 +522,35 @@ static void emit_store(CandoParser *p, const char *name, u32 len)
     int slot = resolve_local(p, name, len);
     if (slot >= 0) {
         emit_op_a(p, OP_STORE_LOCAL, (u16)slot);
-    } else {
-        u16 idx = str_const(p, name, len);
-        emit_op_a(p, OP_STORE_GLOBAL, idx);
+        return;
+    }
+    int uv = resolve_upvalue(p, name, len);
+    if (uv >= 0) {
+        emit_op_a(p, OP_STORE_UPVAL, (u16)uv);
+        return;
+    }
+    u16 idx = str_const(p, name, len);
+    emit_op_a(p, OP_STORE_GLOBAL, idx);
+}
+
+/* Emit OP_CLOSURE plus the variable-length capture metadata that the VM
+ * uses to snapshot upvalue slots at runtime.  Format on the wire:
+ *
+ *     OP_CLOSURE   (1 byte opcode + 2-byte u16 const index)
+ *     u16          capture_count
+ *     u16 * count  outer-frame slot indices (one per upvalue)
+ */
+static void emit_closure(CandoParser *p, u16 pc_idx,
+                         const u16 *captures, u16 count)
+{
+    emit_op_a(p, OP_CLOSURE, pc_idx);
+    u32 line = p->previous.line;
+    cando_chunk_emit_byte(cur(p), (u8)(count & 0xFF), line);
+    cando_chunk_emit_byte(cur(p), (u8)(count >> 8),   line);
+    for (u16 i = 0; i < count; i++) {
+        u16 s = captures[i];
+        cando_chunk_emit_byte(cur(p), (u8)(s & 0xFF), line);
+        cando_chunk_emit_byte(cur(p), (u8)(s >> 8),   line);
     }
 }
 
@@ -1355,9 +1417,12 @@ static void parse_thread_expr(CandoParser *p, bool can_assign)
 
     patch_jump(p, skip_body);
 
-    /* Build the closure object and immediately spawn it as a thread. */
+    /* Build the closure object and immediately spawn it as a thread.
+     * Threads don't reset/restore the parser's local table the way
+     * function bodies do, so they never accumulate upvalue captures --
+     * emit zero captures to keep the OP_CLOSURE wire format uniform. */
     u16 pc_idx = cando_chunk_add_const(cur(p), cando_number((f64)fn_start));
-    emit_op_a(p, OP_CLOSURE, pc_idx);
+    emit_closure(p, pc_idx, NULL, 0);
     emit_op(p, OP_THREAD);
 
     p->last_expr_was_call = true;  /* await + multi-return spreading works */
@@ -1919,8 +1984,23 @@ static void parse_function_expr(CandoParser *p, bool can_assign)
     int        saved_depth = p->scope_depth;
     memcpy(saved_locals, p->locals, sizeof(CandoLocal) * saved_count);
 
-    p->local_count = 0;
-    p->scope_depth = 1;
+    /* Stash any in-flight upvalue tracking from a still-compiling outer
+     * function, then expose this function's outer scope so resolve_upvalue
+     * can capture loop-locals / block-locals declared in the enclosing
+     * frame. */
+    CandoLocal *saved_outer_locals = p->outer_locals;
+    u32         saved_outer_count  = p->outer_count;
+    u16         saved_uv_specs[CANDO_LOCAL_MAX];
+    u16         saved_uv_count     = p->upvalue_count;
+    if (saved_uv_count > 0)
+        memcpy(saved_uv_specs, p->upvalue_specs,
+               sizeof(u16) * saved_uv_count);
+
+    p->local_count    = 0;
+    p->scope_depth    = 1;
+    p->outer_locals   = saved_locals;
+    p->outer_count    = saved_count;
+    p->upvalue_count  = 0;
 
     /* Slot 0 is the function value in the call frame. */
     declare_local(p, "", 0, false);
@@ -1932,15 +2012,28 @@ static void parse_function_expr(CandoParser *p, bool can_assign)
     emit_op(p, OP_NULL);
     emit_op_a(p, OP_RETURN, 1);
 
-    /* Restore outer scope state. */
+    /* Snapshot the captures registered while parsing the body, then
+     * restore the outer compile state before emitting OP_CLOSURE. */
+    u16 body_uv_count = p->upvalue_count;
+    u16 body_uv_specs[CANDO_LOCAL_MAX];
+    if (body_uv_count > 0)
+        memcpy(body_uv_specs, p->upvalue_specs,
+               sizeof(u16) * body_uv_count);
+
     p->local_count = saved_count;
     p->scope_depth = saved_depth;
     memcpy(p->locals, saved_locals, sizeof(CandoLocal) * saved_count);
+    p->outer_locals  = saved_outer_locals;
+    p->outer_count   = saved_outer_count;
+    p->upvalue_count = saved_uv_count;
+    if (saved_uv_count > 0)
+        memcpy(p->upvalue_specs, saved_uv_specs,
+               sizeof(u16) * saved_uv_count);
 
     patch_jump(p, skip_body);
 
     u16 pc_idx = cando_chunk_add_const(cur(p), cando_number((f64)fn_start));
-    emit_op_a(p, OP_CLOSURE, pc_idx);
+    emit_closure(p, pc_idx, body_uv_specs, body_uv_count);
 
     /* The function *expression* evaluates to a closure value — it is not a
      * call.  Clear last_expr_was_call / last_expr_was_unpack so callers such
@@ -1991,8 +2084,19 @@ static void parse_function(CandoParser *p)
     int        saved_depth = p->scope_depth;
     memcpy(saved_locals, p->locals, sizeof(CandoLocal) * saved_count);
 
-    p->local_count = 0;
-    p->scope_depth = 1;
+    CandoLocal *saved_outer_locals = p->outer_locals;
+    u32         saved_outer_count  = p->outer_count;
+    u16         saved_uv_specs[CANDO_LOCAL_MAX];
+    u16         saved_uv_count     = p->upvalue_count;
+    if (saved_uv_count > 0)
+        memcpy(saved_uv_specs, p->upvalue_specs,
+               sizeof(u16) * saved_uv_count);
+
+    p->local_count    = 0;
+    p->scope_depth    = 1;
+    p->outer_locals   = saved_locals;
+    p->outer_count    = saved_count;
+    p->upvalue_count  = 0;
 
     declare_local(p, "", 0, false); /* slot 0 */
     for (u16 i = 0; i < arity; i++)
@@ -2003,16 +2107,28 @@ static void parse_function(CandoParser *p)
     emit_op(p, OP_NULL);          /* implicit return null */
     emit_op_a(p, OP_RETURN, 1);
 
+    u16 body_uv_count = p->upvalue_count;
+    u16 body_uv_specs[CANDO_LOCAL_MAX];
+    if (body_uv_count > 0)
+        memcpy(body_uv_specs, p->upvalue_specs,
+               sizeof(u16) * body_uv_count);
+
     /* Restore outer scope state. */
     p->local_count = saved_count;
     p->scope_depth = saved_depth;
     memcpy(p->locals, saved_locals, sizeof(CandoLocal) * saved_count);
+    p->outer_locals  = saved_outer_locals;
+    p->outer_count   = saved_outer_count;
+    p->upvalue_count = saved_uv_count;
+    if (saved_uv_count > 0)
+        memcpy(p->upvalue_specs, saved_uv_specs,
+               sizeof(u16) * saved_uv_count);
 
     patch_jump(p, skip_body);
 
     /* Build a closure object from the function's start PC and define it. */
     u16 pc_idx   = cando_chunk_add_const(cur(p), cando_number((f64)fn_start));
-    emit_op_a(p, OP_CLOSURE, pc_idx);
+    emit_closure(p, pc_idx, body_uv_specs, body_uv_count);
     u16 name_idx = str_const(p, fn_name, fn_len);
     emit_op_a(p, OP_DEF_GLOBAL, name_idx);
 #undef MAX_PARAMS
@@ -2086,8 +2202,19 @@ static void emit_class_body(CandoParser *p, bool has_extends)
     int        saved_depth = p->scope_depth;
     memcpy(saved_locals, p->locals, sizeof(CandoLocal) * saved_count);
 
-    p->local_count = 0;
-    p->scope_depth = 1;
+    CandoLocal *saved_outer_locals = p->outer_locals;
+    u32         saved_outer_count  = p->outer_count;
+    u16         saved_uv_specs[CANDO_LOCAL_MAX];
+    u16         saved_uv_count     = p->upvalue_count;
+    if (saved_uv_count > 0)
+        memcpy(saved_uv_specs, p->upvalue_specs,
+               sizeof(u16) * saved_uv_count);
+
+    p->local_count    = 0;
+    p->scope_depth    = 1;
+    p->outer_locals   = saved_locals;
+    p->outer_count    = saved_count;
+    p->upvalue_count  = 0;
 
     declare_local(p, "", 0, false); /* slot 0: call frame sentinel */
     for (u16 i = 0; i < arity; i++)
@@ -2098,9 +2225,21 @@ static void emit_class_body(CandoParser *p, bool has_extends)
     emit_op(p, OP_NULL);
     emit_op_a(p, OP_RETURN, 1);
 
+    u16 body_uv_count = p->upvalue_count;
+    u16 body_uv_specs[CANDO_LOCAL_MAX];
+    if (body_uv_count > 0)
+        memcpy(body_uv_specs, p->upvalue_specs,
+               sizeof(u16) * body_uv_count);
+
     p->local_count = saved_count;
     p->scope_depth = saved_depth;
     memcpy(p->locals, saved_locals, sizeof(CandoLocal) * saved_count);
+    p->outer_locals  = saved_outer_locals;
+    p->outer_count   = saved_outer_count;
+    p->upvalue_count = saved_uv_count;
+    if (saved_uv_count > 0)
+        memcpy(p->upvalue_specs, saved_uv_specs,
+               sizeof(u16) * saved_uv_count);
 
     patch_jump(p, skip_body);
 
@@ -2109,7 +2248,7 @@ static void emit_class_body(CandoParser *p, bool has_extends)
      * inline-PC trick lets cando_vm_call_value() invoke it from C.       */
     u16 ctor_pc_idx   = cando_chunk_add_const(cur(p),
                                               cando_number((f64)fn_start));
-    emit_op_a(p, OP_CLOSURE, ctor_pc_idx);
+    emit_closure(p, ctor_pc_idx, body_uv_specs, body_uv_count);
     static const char kCtorName[] = "__constructor";
     u16 ctor_name_idx = str_const(p, kCtorName,
                                   (u32)(sizeof(kCtorName) - 1));
@@ -2376,6 +2515,9 @@ void cando_parser_init(CandoParser *p, const char *source, usize len,
     p->in_safe_chain      = false;
     p->safe_chain_count   = 0;
     p->ternary_then_depth = 0;
+    p->outer_locals       = NULL;
+    p->outer_count        = 0;
+    p->upvalue_count      = 0;
     p->error_msg[0] = '\0';
 
     p->current.type = TOK_EOF;

--- a/source/parser/parser.h
+++ b/source/parser/parser.h
@@ -85,6 +85,19 @@ typedef struct {
      * than as the method-call infix operator.                            */
     u32          ternary_then_depth;
 
+    /* Closure capture tracking ----------------------------------------- */
+    /* When parsing the body of a nested function, `outer_locals` /
+     * `outer_count` point at the enclosing function's local table.  An
+     * identifier that doesn't resolve inside the current body but does
+     * resolve in the outer table is captured: its outer-frame slot is
+     * appended to upvalue_specs[] and referenced via OP_LOAD_UPVAL.  At
+     * the matching OP_CLOSURE the recorded slots are written out as
+     * capture metadata so the VM can snapshot them at runtime.         */
+    CandoLocal  *outer_locals;
+    u32          outer_count;
+    u16          upvalue_specs[CANDO_LOCAL_MAX];
+    u16          upvalue_count;
+
     /* Safe-access chain tracking (?., ?[) ------------------------------ */
     /* When true, every member-access infix in the current expression also
      * emits an OP_JUMP_IF_NULL guard so a null result mid-chain skips the

--- a/source/vm/debug.c
+++ b/source/vm/debug.c
@@ -150,7 +150,20 @@ u32 cando_instr_disasm(const CandoChunk *chunk, u32 offset, FILE *out) {
         case OP_DEF_CONST_GLOBAL: return disasm_const(chunk, "OP_DEF_CONST_GLOBAL", offset, out);
         case OP_GET_FIELD:        return disasm_const(chunk, "OP_GET_FIELD",        offset, out);
         case OP_SET_FIELD:        return disasm_const(chunk, "OP_SET_FIELD",        offset, out);
-        case OP_CLOSURE:          return disasm_const(chunk, "OP_CLOSURE",          offset, out);
+        case OP_CLOSURE: {
+            u16 idx = cando_read_u16(&chunk->code[offset + 1]);
+            u16 cap = cando_read_u16(&chunk->code[offset + 3]);
+            fprintf(out, "%-22s %5u    ", "OP_CLOSURE", idx);
+            if (idx < chunk->const_count)
+                print_const(&chunk->constants[idx], out);
+            fprintf(out, " (captures=%u", cap);
+            for (u16 ci = 0; ci < cap; ci++) {
+                u16 slot = cando_read_u16(&chunk->code[offset + 5 + ci * 2]);
+                fprintf(out, "%s%u", ci == 0 ? ": " : ",", slot);
+            }
+            fprintf(out, ")\n");
+            return offset + 5 + (u32)cap * 2;
+        }
         case OP_NEW_CLASS:        return disasm_const(chunk, "OP_NEW_CLASS",        offset, out);
         case OP_BIND_METHOD:      return disasm_const(chunk, "OP_BIND_METHOD",      offset, out);
 

--- a/source/vm/opcodes.c
+++ b/source/vm/opcodes.c
@@ -309,3 +309,13 @@ CandoOpFmt cando_opcode_fmt(CandoOpcode op) {
     if ((u32)op >= OP_COUNT) return OPFMT_NONE;
     return s_opcode_fmts[(u32)op];
 }
+
+u32 cando_instr_size_at(const u8 *code, u32 offset) {
+    CandoOpcode op = (CandoOpcode)code[offset];
+    if (op == OP_CLOSURE) {
+        /* OP_CLOSURE = 1B opcode + 2B const idx + 2B capture_count + 2B*N */
+        u16 cap = (u16)code[offset + 3] | ((u16)code[offset + 4] << 8);
+        return 5u + (u32)cap * 2u;
+    }
+    return cando_opcode_size(op);
+}

--- a/source/vm/opcodes.h
+++ b/source/vm/opcodes.h
@@ -241,6 +241,10 @@ CandoOpFmt cando_opcode_fmt(CandoOpcode op);
 
 /* -------------------------------------------------------------------------
  * Convenience: byte-size of the full instruction (opcode + operands).
+ *
+ * NOTE: variable-width opcodes (currently OP_CLOSURE, whose tail carries
+ * an inline capture-spec table) cannot be sized from the opcode alone --
+ * use cando_instr_size_at() with the chunk byte buffer for those.
  * ---------------------------------------------------------------------- */
 CANDO_INLINE u32 cando_opcode_size(CandoOpcode op) {
     switch (cando_opcode_fmt(op)) {
@@ -250,6 +254,14 @@ CANDO_INLINE u32 cando_opcode_size(CandoOpcode op) {
         default:         return 1;
     }
 }
+
+/* -------------------------------------------------------------------------
+ * cando_instr_size_at -- byte-size of the instruction at `code[offset]`,
+ * including any variable-length tail (currently the capture metadata that
+ * follows OP_CLOSURE).  Use this when walking a chunk's bytecode rather
+ * than cando_opcode_size().
+ * ---------------------------------------------------------------------- */
+u32 cando_instr_size_at(const u8 *code, u32 offset);
 
 /* -------------------------------------------------------------------------
  * Operand read/write helpers — little-endian u16 stored in bytecode.

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -2501,15 +2501,43 @@ static CandoVMResult vm_run(CandoVM *vm) {
         OP_CASE(OP_CLOSURE): {
             /* The constant at index ci is a cando_number(fn_pc) — the byte
              * offset of the function body within the current chunk.
-             * We wrap (current closure, fn_pc) in a CdoObject of kind
-             * OBJ_FUNCTION so the function value carries its home chunk
-             * and can be called correctly even after crossing module
-             * boundaries via include().                                  */
+             * Following the operand the parser writes:
+             *
+             *     u16 capture_count
+             *     u16 outer_slot[capture_count]
+             *
+             * For each captured slot we snapshot the current frame's value
+             * into a fresh CandoUpvalue and attach the array to a fresh
+             * CandoClosure -- so each invocation of OP_CLOSURE produces a
+             * function whose OP_LOAD_UPVAL/OP_STORE_UPVAL access *its*
+             * captures, not whatever the parent frame happened to share. */
             u16 ci    = READ_U16();
             u32 fn_pc = (u32)frame->closure->chunk->constants[ci].as.number;
 
+            u16 cap_count = READ_U16();
+
+            CandoClosure *new_closure = (CandoClosure *)cando_alloc(
+                sizeof(CandoClosure));
+            new_closure->chunk         = frame->closure->chunk;
+            new_closure->upvalue_count = cap_count;
+            new_closure->upvalues      = NULL;
+            if (cap_count > 0) {
+                new_closure->upvalues = (CandoUpvalue **)cando_alloc(
+                    cap_count * sizeof(CandoUpvalue *));
+                for (u16 ui = 0; ui < cap_count; ui++) {
+                    u16 slot = READ_U16();
+                    CandoUpvalue *uv = (CandoUpvalue *)cando_alloc(
+                        sizeof(CandoUpvalue));
+                    cando_lock_init(&uv->lock);
+                    uv->closed   = cando_value_copy(frame->slots[slot]);
+                    uv->location = &uv->closed;
+                    uv->next     = NULL;
+                    new_closure->upvalues[ui] = uv;
+                }
+            }
+
             CdoObject  *fn_obj = cdo_function_new(fn_pc,
-                                                  (void *)frame->closure,
+                                                  (void *)new_closure,
                                                   NULL, 0);
             HandleIndex h = cando_handle_alloc(vm->handles, fn_obj);
             PUSH(cando_object_value(h));

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -89,7 +89,7 @@ static int find_op(const CandoChunk *c, CandoOpcode op)
     while (i < c->code_len) {
         CandoOpcode cur = (CandoOpcode)c->code[i];
         if (cur == op) return (int)i;
-        u32 sz = cando_opcode_size(cur);
+        u32 sz = cando_instr_size_at(c->code, i);
         i += (sz > 0) ? sz : 1;
     }
     return -1;
@@ -103,7 +103,7 @@ static int count_op(const CandoChunk *c, CandoOpcode op)
     while (i < c->code_len) {
         CandoOpcode cur = (CandoOpcode)c->code[i];
         if (cur == op) n++;
-        u32 sz = cando_opcode_size(cur);
+        u32 sz = cando_instr_size_at(c->code, i);
         i += (sz > 0) ? sz : 1;
     }
     return n;
@@ -805,7 +805,7 @@ TEST(test_safe_dot_chain)
     for (u32 i = 0; i < c->code_len; ) {
         u8 op = c->code[i];
         if (op == OP_JUMP_IF_NULL) n_guards++;
-        i += cando_opcode_size((CandoOpcode)op);
+        i += cando_instr_size_at(c->code, i);
     }
     EXPECT_TRUE(n_guards >= 3);   /* one per access in the chain */
     cando_chunk_free(c);
@@ -1021,7 +1021,7 @@ TEST(test_inline_function_no_spread_from_body)
     while (i < c->code_len) {
         CandoOpcode cur = (CandoOpcode)c->code[i];
         if (cur == OP_CALL) call_pos = (int)i;
-        u32 sz = cando_opcode_size(cur);
+        u32 sz = cando_instr_size_at(c->code, i);
         i += (sz > 0) ? sz : 1;
     }
     EXPECT_TRUE(call_pos >= 0);
@@ -1039,7 +1039,7 @@ TEST(test_inline_function_body_with_method_call)
     while (i < c->code_len) {
         CandoOpcode cur = (CandoOpcode)c->code[i];
         if (cur == OP_CALL) call_pos = (int)i;
-        u32 sz = cando_opcode_size(cur);
+        u32 sz = cando_instr_size_at(c->code, i);
         i += (sz > 0) ? sz : 1;
     }
     EXPECT_TRUE(call_pos >= 0);


### PR DESCRIPTION
## Summary

Fixes the reported "form events do not fire" bug. The root cause turned out to be a parser limitation, not a forms-module problem: callbacks that referenced any local variable from an enclosing scope (e.g. a loop-local `name`/`pnl`) compiled to `OP_LOAD_GLOBAL`, raised `"undefined variable …"` at runtime, and the error was silently swallowed by the forms manager thread.

`test_forms.cdo` worked only because its captures (`clicks`, `bar`) were declared at script top level (and therefore globals).

## Changes

**`parser/vm`: capture outer-scope locals into closures** (commit 2)
- Parser exposes the about-to-be-reset local table to nested function bodies via new `outer_locals`/`outer_count` fields; `resolve_upvalue()` registers captures, `emit_load`/`emit_store` emit `OP_LOAD_UPVAL`/`OP_STORE_UPVAL`.
- New `emit_closure()` helper writes a `u16 capture_count` plus one `u16` outer-frame slot per upvalue immediately after `OP_CLOSURE`. All four emit sites (function expression, FUNCTION declaration, class constructor, thread spawn) go through it so the wire format stays uniform.
- VM `OP_CLOSURE` allocates a per-invocation `CandoClosure` with its own upvalue array, snapshotting captured slots from the parent's frame. Each iteration of a loop produces a closure with its own upvalues — clicking each tab now prints the right name.
- Mutating an upvalue from inside the callback works end-to-end via the existing `OP_LOAD_UPVAL`/`OP_STORE_UPVAL` lock-protected path (counter-style closures behave correctly).
- Added `cando_instr_size_at()` for byte-walking variable-length opcodes; disassembler and parser tests updated.

**`forms/window`: surface dispatch errors; add `onClose` for windows** (commit 1)
- `forms`: log to stderr when a handler is missing, of the wrong type, or raises during dispatch. Previously every failure path returned silently.
- `window`: dispatch a new `onClose` callback when the close button is pressed (matching the forms naming convention). Existing `quit` callback kept as a back-compat alias and still fires alongside `onClose`.
- `modules/window/README.md`: documents `w.onClose` and the alias.

## Test plan

- [x] All 7 unit-test suites pass (`make test`)
- [x] All `tests/scripts/*.cdo` integration scripts still pass
- [x] User's tab-builder pattern works locally: per-iteration `name`/`pnl` captured per closure, script-level `active` propagates across closures
- [x] Counter closure (`var n=0; return function(){ n=n+1; return n; }`) returns 1, 2, 3 across calls — confirms upvalue mutation
- [ ] Forms integration test on Windows (test_forms.cdo) — was passing before, should still pass; user to verify the more complex closure-using script also runs

https://claude.ai/code/session_01NbSZrpTz9VreadtjgR1rhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbSZrpTz9VreadtjgR1rhL)_