### PR TITLE
forms: route panel children's clicks to the form's wndproc

### DIFF
--- a/modules/forms/forms_module.c
+++ b/modules/forms/forms_module.c
@@ -634,6 +634,43 @@ static int do_create_form(FormsCommand *c)
     return 1;
 }
 
+/* Panel subclass.  STATIC's default wndproc swallows WM_COMMAND /
+ * WM_HSCROLL / WM_VSCROLL — meaning a button (or any notifying child)
+ * parented to a Panel never delivers BN_CLICKED to the top-level form,
+ * so user-supplied onClick handlers silently never fire.  We work
+ * around this by subclassing every panel: notification messages from
+ * children walk up the parent chain via SendMessageW until they reach
+ * a real form_wndproc that can translate them into FormsEvents.       */
+static LRESULT CALLBACK panel_wndproc(HWND h, UINT msg, WPARAM w, LPARAM l)
+{
+    int slot = slot_from_hwnd(h);
+    WNDPROC orig = (slot > 0 && slot < FORMS_MAX_SLOTS)
+                   ? g_slots[slot].orig_proc : NULL;
+    switch (msg) {
+    case WM_COMMAND:
+    case WM_HSCROLL:
+    case WM_VSCROLL:
+    case WM_NOTIFY: {
+        HWND parent = GetAncestor(h, GA_PARENT);
+        if (parent) return SendMessageW(parent, msg, w, l);
+        break;
+    }
+    case WM_CTLCOLORSTATIC:
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORBTN:
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORSCROLLBAR: {
+        /* Same forwarding for child colour overrides so panel children
+         * pick up custom fore/back colours stored on the form. */
+        HWND parent = GetAncestor(h, GA_PARENT);
+        if (parent) return SendMessageW(parent, msg, w, l);
+        break;
+    }
+    }
+    if (orig) return CallWindowProcW(orig, h, msg, w, l);
+    return DefWindowProcW(h, msg, w, l);
+}
+
 /* Create a child control parented to an existing form/panel slot. */
 static int do_create_control(FormsCommand *c)
 {
@@ -750,6 +787,15 @@ static int do_create_control(FormsCommand *c)
     s->hwnd = hwnd;
     s->x = x; s->y = y; s->w = w; s->h = h;
     s->visible = 1;
+
+    /* Subclass panels so notifications from their children (BN_CLICKED,
+     * EN_CHANGE, ...) reach the form's WndProc -- the default STATIC
+     * wndproc would otherwise swallow them. */
+    if (c->kind == KIND_PANEL) {
+        WNDPROC prev = (WNDPROC)SetWindowLongPtrW(
+            hwnd, GWLP_WNDPROC, (LONG_PTR)panel_wndproc);
+        s->orig_proc = prev;
+    }
     return 1;
 }
 


### PR DESCRIPTION
## Summary

Buttons (and any other notifying control) parented to a `Panel` never fired their `onClick` because Win32 sends `BN_CLICKED` via `WM_COMMAND` to the *immediate* parent — the Panel — and Panels use the `STATIC` window class whose default WndProc silently drops `WM_COMMAND`. The form's WndProc — the only place that translates notifications into FormsEvents — therefore never saw the click.

This is the third and final piece of the "form events do not fire" report from #56 / #57. The earlier PRs surfaced the silent error and made closures capture loop-locals, but a button inside `forms.Panel(window)` still couldn't deliver clicks at all.

## Changes

- New `panel_wndproc` is installed on every Panel at creation time. It forwards `WM_COMMAND` / `WM_HSCROLL` / `WM_VSCROLL` / `WM_NOTIFY` (and the `WM_CTLCOLOR*` family for fore/back colour inheritance) up the parent chain via `SendMessageW`, so notifications walk up until they reach a real `form_wndproc`.
- The original `STATIC` wndproc is preserved in `slot.orig_proc` and called for every other message, so default panel behaviour (painting, hit-testing, focus) is unchanged.

## Test plan

- [x] `make -C modules/forms` and `make -C modules/forms test` clean on Linux (stub backend untouched).
- [ ] On Windows: build a form with `forms.Button(forms.Panel(window))`, attach an `onClick`, click — handler now fires. The user reproducing pattern from #57 should now react to clicks end-to-end.

https://claude.ai/code/session_01NbSZrpTz9VreadtjgR1rhL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbSZrpTz9VreadtjgR1rhL)_