### PR TITLE
Add comprehensive documentation: patterns, CLI guide, and reference updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,16 +7,44 @@ compiled to bytecode for a stack-based VM.
 
 ## For script authors
 
+**Start here:**
+
 | Document | What's in it |
 |---|---|
 | [getting-started.md](getting-started.md) | Build the interpreter and run your first script |
 | [user-guide.md](user-guide.md) | Hands-on tutorial: learn CanDo by example |
 | [language-reference.md](language-reference.md) | Complete syntax: types, expressions, statements, functions, classes |
 | [standard-library.md](standard-library.md) | Every built-in library module, function-by-function |
-| [socket.md](socket.md) | Long-form guide to the `socket` and `secure_socket` libraries |
-| [streaming.md](streaming.md) | Unified `stream` API: pipe between files, sockets, HTTP, processes, threads |
+| [patterns.md](patterns.md) | Common idioms — error handling, FP style, classes, modules, threads |
+| [cli.md](cli.md) | The `cando` executable: flags, `args[]`, exit codes, environment |
+
+**Concurrency:**
+
+| Document | What's in it |
+|---|---|
 | [threading.md](threading.md) | `thread` / `await`, the `thread` library, shared state |
+| [streaming.md](streaming.md) | Unified `stream` API: pipe between files, sockets, HTTP, processes, threads |
+
+**Networking:**
+
+| Document | What's in it |
+|---|---|
+| [socket.md](socket.md) | Long-form guide to the `socket` and `secure_socket` libraries |
+
+**Data formats:**
+
+| Document | What's in it |
+|---|---|
 | [yaml.md](yaml.md) | YAML parse / stringify and `include()`-time loading |
+| [sql.md](sql.md) | SQLite-backed `sql` module: queries, parameter binding, transactions |
+
+**Graphics & UI** (require platform binary modules):
+
+| Document | What's in it |
+|---|---|
+| [window.md](window.md) | Window creation and event loop |
+| [draw.md](draw.md) | 2D drawing primitives, sprites, text |
+| [forms.md](forms.md) | Declarative widget tree for in-window UI |
 
 ## For C embedders
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,138 @@
+# The `cando` Command-Line Interpreter
+
+The `cando` executable is a thin wrapper around the embedding API.  It
+opens a VM, loads every standard library, runs your script, and exits.
+
+```
+cando <file.cdo> [--disasm] [args...]
+```
+
+| Element       | Meaning                                                                                          |
+|---            |---                                                                                               |
+| `<file.cdo>`  | Path to the script to execute.  Required.  May be relative or absolute.                          |
+| `--disasm`    | Disassemble the compiled bytecode to **stderr** before running it.  See *Bytecode disassembly* below. |
+| `[args...]`   | Everything else after the script path is forwarded to the script as a global `args` array of strings. |
+
+If invoked with no arguments, `cando` prints the version and a usage
+line to stderr and exits with code `1`.
+
+## Exit codes
+
+| Code | Meaning                                                                |
+|---   |---                                                                     |
+| `0`  | Script ran to completion without a runtime error.                      |
+| `1`  | Failure: bad CLI args, file not found, parse error, runtime error, OOM, or VM-creation failure. |
+
+A script may exit early with `os.exit(code)`; the code provided becomes
+the process exit status.  An uncaught `THROW` inside the script also
+exits with code `1` after the runtime error message is printed to stderr.
+
+## The global `args` array
+
+Every script can read `args` directly — it is set up before the script
+runs.  `args[0]` is the **first argument after the script path**, *not*
+the script path itself.
+
+```cando
+// echo.cdo
+FOR (VAR i = 0; i < #args; i = i + 1) {
+    print(args[i]);
+}
+```
+
+```bash
+$ cando echo.cdo hello world
+hello
+world
+
+$ cando echo.cdo
+$            # args is empty, loop body does not run
+```
+
+If the only thing after the script path is `--disasm`, that switch is
+consumed by the interpreter and is **not** passed to the script.  `args`
+will therefore be empty in `cando script.cdo --disasm`.
+
+`args` is always an array of strings, even when the underlying CLI
+argument looks numeric.  Convert with the `+` numeric coercion or
+`number(args[0])`:
+
+```cando
+VAR n = +args[0];          // unary plus coerces "42" -> 42
+```
+
+## Standard streams
+
+| Stream | Used for                                                                |
+|---     |---                                                                      |
+| stdout | `print(...)`, anything written by `file.write("/dev/stdout", ...)`     |
+| stderr | Runtime errors prefixed with `cando: `, the `--disasm` listing         |
+| stdin  | `file.readLine("/dev/stdin")` and similar (Linux/macOS); see `os.stdin` for portable handles |
+
+A runtime error message has the form
+
+```
+cando: <message> [<file.cdo> line <N>]
+```
+
+and is printed to stderr just before `cando` exits with code `1`.
+
+## Bytecode disassembly
+
+`--disasm` prints the compiled chunk for the entire script (including
+the contents of inline `FUNCTION` and `CLASS` literals) to **stderr**
+before execution begins.  The script then runs normally — disassembly
+is purely diagnostic.
+
+```bash
+$ cando hello.cdo --disasm 2> hello.dis
+hello, world!
+$ head hello.dis
+== chunk: hello.cdo ==
+0000 OP_CONST              0 ; "hello, world!"
+0003 OP_LOAD_GLOBAL        1 ; "print"
+0006 OP_CALL               1
+...
+```
+
+This is useful for:
+
+- Verifying that an optimisation hypothesis matches what the parser
+  emits.
+- Investigating performance: counting opcodes, looking for redundant
+  loads, spotting unintended re-evaluations.
+- Learning the VM by example.
+
+The mnemonic catalogue lives in [vm-internals.md](vm-internals.md).
+
+## Environment variables
+
+`cando` itself reads no environment variables directly; the VM and
+standard libraries do.
+
+| Variable           | Read by                                                              |
+|---                 |---                                                                   |
+| `PATH`             | `process.exec` to find executables when no explicit path is given.   |
+| `HOME`, `TMPDIR`   | `os.tmpDir()`, `os.homeDir()`.                                       |
+| `CANDO_PATH`       | `include(...)` search path for relative imports (colon-separated).   |
+| `SSL_CERT_FILE`, `SSL_CERT_DIR` | Read by the OpenSSL backend used by `https` and `secure_socket`. |
+
+Scripts can read any environment variable with `os.getEnv("NAME")` and
+set them in the **child process only** with `process.exec({env:...})`.
+
+## Embedding equivalent
+
+Everything `cando` does is exposed in the embedding API:
+
+```c
+CandoVM *vm = cando_open();
+cando_openlibs(vm);
+cando_set_args(vm, argc - 2, (const char *const *)(argv + 2));
+int rc = cando_dofile(vm, "main.cdo");
+if (rc != CANDO_OK)
+    fprintf(stderr, "cando: %s\n", cando_errmsg(vm));
+cando_close(vm);
+return rc == CANDO_OK ? 0 : 1;
+```
+
+See [embedding.md](embedding.md) for a complete walk-through.

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -28,11 +28,14 @@ and cannot be used as identifiers.
 
 ### Keywords
 
-Keywords are case-sensitive and — with one exception — upper-case.
+Keywords are case-insensitive but **reject mixed-case** spellings.  `VAR`,
+`var`, `IF`, `if` all work; `Var` and `iF` are ordinary identifiers.  The
+canonical CanDo style is **all-uppercase** for keywords; the all-lowercase
+form is supported for users coming from other languages.
 
 ```
 IF   ELSE   WHILE   FOR   IN   OF   OVER
-FUNCTION   RETURN   CLASS
+FUNCTION   RETURN   CLASS   EXTENDS
 TRY   CATCH   FINALY   THROW
 VAR   CONST   GLOBAL   STATIC   PRIVATE
 THREAD   ASYNC   AWAIT
@@ -42,7 +45,9 @@ pipe
 ```
 
 The lower-case `pipe` is the implicit iteration variable in `~>` and
-`~!>` expressions (see *Pipe and filter* below).
+`~!>` expressions (see *Pipe and filter* below); like other keywords its
+spelling can be either all-lower or all-upper, but the convention is
+lowercase to make it visually distinct from statement keywords.
 
 > `FINALY` is spelled with one `L`.  `FINALLY` is **not** accepted.
 
@@ -534,13 +539,6 @@ VAR rex = Dog("Rex", "labrador");
 print(rex:bark());     // Rex says hello (woof, labrador)
 ```
 
-### Keyword case
-
-CanDo keywords are case-insensitive but reject mixed-case spellings.
-`class`, `CLASS`, `var`, `VAR`, `extends`, `EXTENDS` etc. all work; a
-mixed-case form like `Class` or `eXtEnDs` is treated as an ordinary
-identifier.
-
 See [metamethods.md](metamethods.md) for the full prototype system,
 the desugaring of `class`, and all available meta-keys.
 
@@ -574,15 +572,111 @@ same way; see [writing-extensions.md](writing-extensions.md).
 
 ## Errors raised by the runtime
 
-The following operations raise catchable errors:
+Runtime errors are catchable with `TRY` / `CATCH`.  The first `CATCH`
+parameter receives the message string.  If uncaught, the host embedder
+sees `CANDO_ERR_RUNTIME` and `cando_errmsg(vm)` returns the formatted
+message; the `cando` CLI prints it to stderr and exits with code 1.
 
-- Division or modulo by zero on numbers
-- Calling a non-callable value (`v()`)
-- Indexing `NULL` with a field or `[idx]`
-- Assigning to a `CONST` variable
-- `RETURN` or `BREAK` outside a valid target (parse error)
-- Stack overflow (call depth > 256, value stack > 2048)
+### Arithmetic and operator errors
 
-The error message is the value passed to the `CATCH` parameter.  If
-uncaught, the host embedder sees `CANDO_ERR_RUNTIME` and
-`cando_errmsg(vm)` returns the formatted message.
+| Message                                                    | Cause                                                |
+|---                                                         |---                                                   |
+| `division by zero`                                         | `a / 0` or `a % 0`.                                  |
+| `operands must be numbers (got <T> and <T>)`               | `a + b` where neither side has a `__add` metamethod and at least one side isn't a number / string. |
+| `operands must be numbers`                                 | A binary operator (`-`, `*`, `/`, etc.) received a non-numeric operand. |
+| `comparison requires numbers`                              | `<`, `<=`, `>`, `>=` between non-numeric values without a `__lt` / `__le` metamethod. |
+| `range requires numbers`                                   | `a -> b` or `a <- b` outside a `FOR` (the range-list form). |
+| `range check requires numbers`                             | A `FOR i IN a -> b { … }` where `a` or `b` isn't a number. |
+| `unary '+' requires a number`                              | `+x` on a non-string non-number.                     |
+| `unary '-' requires a number`                              | `-x` on a non-numeric value without `__unm`.         |
+| `'++' requires a number`, `'--' requires a number`         | Increment/decrement on a non-number.                 |
+| `# operator requires a string or object`                   | `#x` on `null`, `bool`, or `number` without `__len`. |
+
+### Type errors on access
+
+| Message                                          | Cause                                              |
+|---                                               |---                                                 |
+| `field access on non-object (got <T>)`           | `v.name` when `v` is not an object or string.      |
+| `field assignment on non-object`                 | `v.name = …` when `v` is not an object.            |
+| `index access on non-object`                     | `v[k]` on a non-object (and non-string).           |
+| `index assignment on non-object`                 | `v[k] = …` on a non-object.                        |
+| `index must be a number or string`               | `arr[obj]` and similar.                            |
+| `IN operator requires an object`                 | `FOR k IN v` where `v` isn't an iterable object.   |
+| `OF operator requires an object`                 | `FOR x OF v` where `v` isn't an array.             |
+| `pipe/filter (~>/~!>) requires an array source`  | `arr ~> body` where `arr` isn't an array.          |
+
+### Calls and methods
+
+| Message                                          | Cause                                              |
+|---                                               |---                                                 |
+| `can only call functions (got <T>)`              | Called a non-callable value.  An object with `__call` would have been dispatched instead. |
+| `method call on non-object (got <T>)`            | `v:m()` on a non-object value.                     |
+| `method is not callable`                         | `v:m()` where `m` resolved but isn't a function.   |
+| `meta-method is not callable`                    | A meta-method field (`__add`, `__lt`, …) resolved to a non-callable value. |
+| `call stack overflow`                            | Recursion depth exceeds `CANDO_FRAMES_MAX` (256).  |
+| `stack overflow in method call`                  | Value stack exhausted while building the call frame (default 2048). |
+| `undefined variable '<name>'`                    | Read of a global that was never assigned.          |
+
+### Control flow and bindings
+
+| Message                                  | Cause                                               |
+|---                                       |---                                                  |
+| `cannot assign to constant '<name>'`     | Reassigning a `CONST` binding.                      |
+| `BREAK outside loop`                     | `BREAK` (or `BREAK n`) used where no loop is active. |
+| `CONTINUE outside loop`                  | `CONTINUE` used where no loop is active.            |
+| `RERAISE outside of catch block`         | `RERAISE` used outside a `CATCH` body.              |
+
+### Threads and concurrency
+
+| Message                                  | Cause                                               |
+|---                                       |---                                                  |
+| `thread: expected a function`            | `thread.spawn(v)` with a non-function `v`.          |
+| `thread: failed to create OS thread`     | `pthread_create` / Windows equivalent failed.       |
+| `await: expected a thread handle`        | `await v` with no operand, or wrong type.           |
+| `await: value is not a thread`           | `await v` where `v` is not a thread object.         |
+
+### Class machinery
+
+These come from class compilation primitives and only appear if the
+bytecode was hand-crafted or corrupted; ordinary scripts never see them.
+
+| Message                                       | Notes                                |
+|---                                            |---                                   |
+| `INHERIT: expected class objects`             | `OP_INHERIT` saw bad operands.       |
+| `BIND_METHOD: expected class object`          | Method-binding failed.               |
+| `BIND_DEFAULT_CALL: expected class object`    | Default `__call` setup failed.       |
+| `class __call: missing class receiver`        | Default class `__call` invoked with no class. |
+| `class __call: invalid class handle`          | Default class `__call` saw an invalid handle. |
+
+### Not-yet-implemented
+
+| Message                                  | Notes                                                |
+|---                                       |---                                                   |
+| `tail call not yet implemented`          | The `OP_TAIL_CALL` opcode is reserved.               |
+| `ASYNC not implemented (use 'thread' instead)` | Reserved keyword; use `thread` for concurrency. |
+| `YIELD not implemented (use 'thread' instead)` | Same.                                          |
+
+### Catching a runtime error
+
+```cando
+TRY {
+    VAR v = 1 / 0;
+} CATCH (msg) {
+    print("caught:", msg);    // caught: division by zero
+}
+```
+
+`THROW` produces an error whose value is whatever you threw — typically
+a string but any value is accepted.  `THROW` with multiple values
+unpacks into the `CATCH` parameter list:
+
+```cando
+TRY {
+    THROW "validation", 422, "missing 'name'";
+} CATCH (kind, code, detail) {
+    print(kind, code, detail);
+}
+```
+
+If the `CATCH` parameter list is shorter than the throw's value list,
+the extras are dropped.  If longer, the extras are `NULL`.

--- a/docs/metamethods.md
+++ b/docs/metamethods.md
@@ -29,7 +29,7 @@ All meta-key strings are pre-interned at startup.  The corresponding global
 | `__mod`       | `g_meta_mod`       | `a % b`                                  |
 | `__pow`       | `g_meta_pow`       | `a ^ b`                                  |
 | `__unm`       | `g_meta_unm`       | Unary `-obj`                             |
-| `__idiv`      | `g_meta_idiv`      | Integer division (reserved)              |
+| `__idiv`      | `g_meta_idiv`      | *Reserved name; no `//` operator yet*    |
 | `__call`      | `g_meta_call`      | `obj(...)` when `obj` is not a function  |
 | `__constructor` | `g_meta_constructor` | Run by the default class `__call`       |
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,0 +1,597 @@
+# Common Patterns and Idioms
+
+A field guide for everyday CanDo scripting.  These are not new features —
+they are the conventions that experienced CanDo authors reach for.
+
+The cross-references go to [language-reference.md](language-reference.md)
+for syntax details and [standard-library.md](standard-library.md) for the
+library functions used.
+
+---
+
+## Variables and scope
+
+### Always use `VAR` inside functions
+
+A bare assignment to an undeclared name creates a global.  This is
+convenient at the top level, but inside a function it leaks state across
+calls and across threads.
+
+```cando
+FUNCTION bad(n) {
+    sum = 0;            // global! shared by every call
+    FOR i IN 1 -> n { sum = sum + i; }
+    RETURN sum;
+}
+
+FUNCTION good(n) {
+    VAR sum = 0;        // local — fresh on each call
+    FOR i IN 1 -> n { sum = sum + i; }
+    RETURN sum;
+}
+```
+
+### Use `CONST` for things that don't change
+
+Module-level configuration is the prototypical case:
+
+```cando
+CONST MAX_RETRIES = 5;
+CONST TIMEOUT_MS  = 30000;
+CONST ENDPOINT    = "https://api.example.com";
+```
+
+Reassigning a `CONST` is a runtime error, which catches mistakes early.
+
+### Block-scope short-lived bindings
+
+Variables declared inside `{ … }` (an `IF` body, a loop body, an explicit
+block expression) disappear at the closing brace.  Use this to keep
+helper variables out of the surrounding scope:
+
+```cando
+IF need_token() {
+    VAR tok = fetch_token();
+    headers.authorization = `Bearer ${tok}`;
+}
+// `tok` is gone here
+```
+
+---
+
+## Strings
+
+### Use backticks for templates
+
+Backtick strings interpolate `${expr}` and span multiple lines.  Reach
+for them whenever you build a user-facing message:
+
+```cando
+VAR name = "Alice";
+VAR n    = 3;
+print(`Hello ${name}, you have ${n} new message${IF n == 1 { "" } ELSE { "s" }}.`);
+```
+
+### Use single quotes for raw multiline blobs
+
+Single-quoted strings have no escape processing.  They are perfect for
+SQL queries, regex source, and embedded scripts:
+
+```cando
+VAR query = '
+    SELECT id, name, email
+    FROM users
+    WHERE active = 1
+      AND created_at > ?
+';
+```
+
+### Coerce numbers with unary `+`
+
+`+s` parses a numeric string into a number.  Use it on CSV/JSON-string
+fields and on `args[]`:
+
+```cando
+VAR threshold = +args[0];
+VAR row_score = +row.score;
+```
+
+Returns `NULL` if the string isn't a valid number — combine with a
+`IF v == NULL` guard.
+
+---
+
+## Numbers
+
+### Integer math via `math.floor`
+
+Numbers are always doubles.  When you want integer division, do the
+divide and floor:
+
+```cando
+VAR pages = math.floor(#items / page_size);
+VAR last  = #items - pages * page_size;
+```
+
+### Random integer in a range
+
+`math.random()` returns `[0, 1)`.  Scale and floor:
+
+```cando
+FUNCTION rand_between(lo, hi) {
+    RETURN lo + math.floor(math.random() * (hi - lo + 1));
+}
+print(rand_between(1, 6));    // d6
+```
+
+---
+
+## Arrays
+
+### `map`, `filter`, `reduce`
+
+The functional trio comes from the array prototype:
+
+```cando
+VAR doubled = [1, 2, 3]:map(FUNCTION(x) { RETURN x * 2; });
+VAR evens   = [1, 2, 3, 4]:filter(FUNCTION(x) { RETURN x % 2 == 0; });
+VAR sum     = [1, 2, 3, 4]:reduce(FUNCTION(a, b) { RETURN a + b; }, 0);
+```
+
+For simple element-wise transforms reach for the pipe instead — it reads
+better and avoids the closure allocation:
+
+```cando
+VAR doubled = [1, 2, 3] ~> pipe * 2;
+VAR evens   = [1, 2, 3, 4] ~!> { IF pipe % 2 == 0 { RETURN pipe; } };
+```
+
+### Stack and queue
+
+`push` / `pop` give you a stack; `push` / `shift` give you a queue:
+
+```cando
+VAR stack = [];
+stack:push(1); stack:push(2); stack:push(3);
+print(stack:pop());      // 3 — LIFO
+
+VAR queue = [];
+queue:push("a"); queue:push("b"); queue:push("c");
+print(queue:shift());    // a — FIFO
+```
+
+### Build then return
+
+Inside a function, build into a local array and return it.  Avoid the
+temptation to mutate a parameter — that surprises callers.
+
+```cando
+FUNCTION grades_for(rows) {
+    VAR out = [];
+    FOR r OF rows {
+        VAR g = "F";
+        IF r.score >= 90      { g = "A"; }
+        ELSE IF r.score >= 80 { g = "B"; }
+        ELSE IF r.score >= 70 { g = "C"; }
+        out:push({ name: r.name, grade: g });
+    }
+    RETURN out;
+}
+```
+
+---
+
+## Objects
+
+### Use objects as named records
+
+Objects are key-value maps with insertion-order iteration and prototype
+inheritance.  They double as records:
+
+```cando
+VAR user = {
+    id:    42,
+    name:  "Alice",
+    email: "alice@example.com",
+    roles: ["admin", "editor"]
+};
+```
+
+### Sentinels and defaults
+
+Looking up an absent field returns `NULL`.  Combine with an `OR`-style
+default:
+
+```cando
+VAR port = config.port;
+IF port == NULL { port = 8080; }
+```
+
+### Merge two objects
+
+There is no built-in `Object.assign` — write the loop:
+
+```cando
+FUNCTION merge(dst, src) {
+    FOR k IN src { dst[k] = src[k]; }
+    RETURN dst;
+}
+
+VAR opts = merge(merge({}, defaults), overrides);
+```
+
+### Use a prototype to share methods
+
+If two objects need the same methods, set the methods on a parent and
+chain them via `__index`:
+
+```cando
+VAR shape_proto = {};
+shape_proto.area = FUNCTION(self) { RETURN self.w * self.h; };
+
+VAR a = { w: 3, h: 4 };
+VAR b = { w: 5, h: 6 };
+object.setPrototype(a, shape_proto);
+object.setPrototype(b, shape_proto);
+
+print(a:area(), b:area());     // 12 30
+```
+
+`CLASS` does this for you (see *Classes* below).
+
+---
+
+## Functions
+
+### Default arguments via `OR NULL` test
+
+CanDo has no default-parameter syntax — write the test in the body:
+
+```cando
+FUNCTION greet(name, greeting) {
+    IF greeting == NULL { greeting = "Hello"; }
+    RETURN `${greeting}, ${name}!`;
+}
+print(greet("Alice"));                  // Hello, Alice!
+print(greet("Bob", "Hi"));              // Hi, Bob!
+```
+
+### Returning failure with multi-return
+
+Two-value `(result, err)` returns are an idiomatic Go-style failure
+channel.  Don't `THROW` for *expected* failures — return them:
+
+```cando
+FUNCTION read_config(path) {
+    IF !file.exists(path) { RETURN NULL, "no such file"; }
+    VAR text = file.read(path);
+    IF text == NULL       { RETURN NULL, "cannot read"; }
+    RETURN json.parse(text), NULL;
+}
+
+VAR cfg, err = read_config("config.json");
+IF err != NULL { print("error:", err); os.exit(1); }
+```
+
+### Higher-order helpers
+
+A function that returns a function is the classic factory:
+
+```cando
+FUNCTION multiplier_by(n) {
+    RETURN FUNCTION(x) { RETURN x * n; };
+}
+
+VAR triple = multiplier_by(3);
+print(triple(7));            // 21
+```
+
+### The pipe-as-DSL
+
+The pipe variable `pipe` plus a block makes one-liners read like a
+dataflow:
+
+```cando
+VAR usernames = users ~> pipe.name;
+VAR active    = users ~!> { IF pipe.active { RETURN pipe; } };
+VAR shouts    = words ~> pipe:toUpper();
+```
+
+---
+
+## Error handling
+
+### Catch what you expect, let the rest crash
+
+Wrap the small section that can fail.  Don't wrap the whole function —
+that hides programmer errors:
+
+```cando
+FUNCTION load_settings(path) {
+    VAR raw;
+    TRY {
+        raw = file.read(path);
+    } CATCH (msg) {
+        RETURN NULL;             // file may be absent — caller decides
+    }
+    RETURN json.parse(raw);      // a JSON error here is a *bug*, not a config issue
+}
+```
+
+### Re-throw with extra context
+
+After cleaning up or logging, throw a richer error:
+
+```cando
+TRY {
+    do_step();
+} CATCH (msg) {
+    log.write("step failed: " + msg);
+    THROW "while loading config: " + msg;
+}
+```
+
+### Multi-value throws
+
+`THROW` accepts multiple values, mirrored on the `CATCH` parameter list:
+
+```cando
+TRY {
+    THROW "validation", 422, "missing field 'name'";
+} CATCH (kind, code, detail) {
+    print(kind, code, detail);
+}
+```
+
+If the catch has fewer parameters than the throw, the extras are
+discarded; if it has more, the extras are `NULL`.
+
+### Always release with `FINALY`
+
+`FINALY` runs whether the `TRY` succeeded, threw, returned early, or was
+broken out of:
+
+```cando
+VAR fh = file.open("data.bin", "rb");
+TRY {
+    process(fh);
+} FINALY {
+    fh:close();
+}
+```
+
+> Spelled with one **L**.
+
+---
+
+## Classes
+
+### Constructor in `()`, methods after
+
+`CLASS` body is the constructor.  Methods are field assignments:
+
+```cando
+CLASS Stack = (self) {
+    self.items = [];
+}
+
+Stack.push = FUNCTION(self, v) { self.items:push(v); };
+Stack.pop  = FUNCTION(self) {
+    IF #self.items == 0 { THROW "stack empty"; }
+    RETURN self.items:pop();
+};
+Stack.peek = FUNCTION(self) {
+    IF #self.items == 0 { RETURN NULL; }
+    RETURN self.items[#self.items - 1];
+};
+Stack.size = FUNCTION(self) { RETURN #self.items; };
+```
+
+### Inheritance with `EXTENDS`
+
+```cando
+CLASS Animal = (self, name) {
+    self.name = name;
+}
+Animal.speak = FUNCTION(self) { RETURN self.name + " makes a sound"; };
+
+CLASS Dog EXTENDS Animal = (self, name, breed) {
+    Animal.__constructor(self, name);   // super-style call
+    self.breed = breed;
+}
+Dog.speak = FUNCTION(self) {
+    RETURN Animal.speak(self) + " (woof)";
+};
+```
+
+There is no `super` keyword.  Call the parent's method via the parent
+class object — `Animal.speak(self)` — and the parent's constructor via
+`Animal.__constructor(self, ...)`.
+
+### Operator overloading
+
+A few `__op` fields turn a record into something that looks built-in.
+See [metamethods.md](metamethods.md).
+
+```cando
+CLASS Vec2 = (self, x, y) { self.x = x; self.y = y; }
+Vec2.__add      = FUNCTION(a, b) { RETURN Vec2(a.x + b.x, a.y + b.y); };
+Vec2.__tostring = FUNCTION(self) { RETURN `(${self.x}, ${self.y})`; };
+
+VAR p = Vec2(1, 2);
+VAR q = Vec2(3, 4);
+print(toString(p + q));          // (4, 6)
+```
+
+---
+
+## Modules
+
+### Single-export pattern
+
+Build a namespace object inside the module and `RETURN` it:
+
+```cando
+// strings_extra.cdo
+VAR M = {};
+
+M.titleCase = FUNCTION(s) { ... };
+M.camelCase = FUNCTION(s) { ... };
+
+RETURN M;
+```
+
+```cando
+// main.cdo
+VAR strx = include("./strings_extra.cdo");
+print(strx:titleCase("hello world"));
+```
+
+### Caching is automatic
+
+`include(path)` runs the file the first time and caches its return value
+keyed by canonical path.  Subsequent `include`s of the same path return
+the cached object — useful for shared singletons.
+
+### Hot-loaded YAML / JSON
+
+`include()` can also load `.yaml` / `.json` directly into a value:
+
+```cando
+CONST cfg = include("./config.yaml");
+print(cfg.server.host);
+```
+
+See [yaml.md](yaml.md) for the loading rules.
+
+---
+
+## Threads
+
+### Fire-and-forget vs. await
+
+Use `await` when you need the return value or want backpressure.  Skip
+it for background tasks that own their own results (sockets, queues):
+
+```cando
+// joining
+VAR result = await thread { return long_compute(); };
+
+// fire-and-forget — kept alive by the runtime until it returns
+thread {
+    log_async("started at " + datetime.now());
+};
+```
+
+### Worker pool
+
+A common pattern: fan out N workers, each pulling from a shared queue:
+
+```cando
+VAR jobs    = [...];                 // input queue
+VAR results = [];
+
+VAR lock = {};
+FUNCTION pop_job() {
+    object.lock(lock);
+    VAR j = jobs:shift();
+    object.unlock(lock);
+    RETURN j;
+}
+
+FUNCTION push_result(r) {
+    object.lock(lock);
+    results:push(r);
+    object.unlock(lock);
+}
+
+VAR workers = [];
+FOR i IN 1 -> 4 {
+    workers:push(thread {
+        WHILE TRUE {
+            VAR j = pop_job();
+            IF j == NULL { BREAK; }
+            push_result(handle(j));
+        }
+    });
+}
+
+FOR w OF workers { await w; }
+```
+
+### Avoid sharing closures over plain locals
+
+Each thread observes the **same** captured variable — read/write races
+will happen.  Wrap shared mutable state in an object and lock it.
+
+See [threading.md](threading.md) for the full treatment.
+
+---
+
+## I/O
+
+### Read-then-process is fine for small files
+
+Up to a few MiB, just read it all:
+
+```cando
+VAR text = file.read("input.txt");
+VAR rows = text:split("\n");
+```
+
+### Stream large inputs
+
+For larger or unknown-sized inputs use [streaming.md](streaming.md):
+
+```cando
+VAR src = stream.openFile("big.csv");
+VAR sink = stream.openFile("out.bin", "w");
+src:pipe(sink);
+src:close(); sink:close();
+```
+
+### Writing a JSON report atomically
+
+Write to a temp path, then rename — readers either see the old or the
+new contents, never a half-written file:
+
+```cando
+VAR tmp = path + ".tmp";
+file.write(tmp, json.stringify(report));
+file.rename(tmp, path);
+```
+
+---
+
+## CLI scripts
+
+### Required arg with friendly error
+
+```cando
+IF #args < 1 {
+    print("usage: cando script.cdo <input.csv>");
+    os.exit(1);
+}
+
+VAR input = args[0];
+```
+
+### Flag parsing
+
+CanDo doesn't ship a `getopt`.  For trivial flags walk `args` directly;
+for non-trivial CLIs write your own dispatcher:
+
+```cando
+VAR opts = { verbose: FALSE, output: "out.txt" };
+VAR rest = [];
+VAR i = 0;
+WHILE i < #args {
+    VAR a = args[i];
+    IF a == "-v", "--verbose" { opts.verbose = TRUE; }
+    ELSE IF a == "-o" { i = i + 1; opts.output = args[i]; }
+    ELSE { rest:push(a); }
+    i = i + 1;
+}
+```
+
+See [cli.md](cli.md) for the surrounding `cando` invocation conventions.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -3,7 +3,31 @@
 A hands-on introduction to CanDo.  Work through the sections in order —
 each one builds on the previous.  For lookup tables covering every
 function and operator see [language-reference.md](language-reference.md)
-and [standard-library.md](standard-library.md).
+and [standard-library.md](standard-library.md); for everyday idioms see
+[patterns.md](patterns.md).
+
+## Contents
+
+1. [Running a script](#running-a-script)
+2. [Values and types](#values-and-types)
+3. [Variables](#variables)
+4. [Strings](#strings)
+5. [Numbers and math](#numbers-and-math)
+6. [Arrays](#arrays)
+7. [Objects](#objects)
+8. [Control flow](#control-flow)
+9. [Functions](#functions)
+10. [Method calls](#method-calls)
+11. [Error handling](#error-handling)
+12. [Pipe and filter](#pipe-and-filter)
+13. [Classes](#classes)
+14. [Threads](#threads)
+15. [Modules](#modules)
+16. [**Working with the standard library**](#working-with-the-standard-library)
+    - File I/O · JSON · HTTP client · HTTP server · Crypto · Date and time · OS · eval
+17. [Mask syntax](#mask-syntax)
+18. [`FOR ... OVER` (generic iterators)](#for--over-generic-iterators)
+19. [Putting it together](#putting-it-together)
 
 ## Running a script
 
@@ -18,8 +42,10 @@ cando hello.cdo
 print("hello, world!");
 ```
 
-Keywords are case-insensitive (`VAR`, `var`, and `Var` all work), but the
-convention is uppercase.  This guide uses uppercase throughout.
+Keywords accept all-uppercase or all-lowercase spelling — `VAR` and `var`
+both work — but **mixed case is not a keyword**: `Var` is just an ordinary
+identifier.  The convention is uppercase, and this guide uses uppercase
+throughout.
 
 ## Values and types
 
@@ -553,6 +579,15 @@ print(mu.clamp(15, 0, 10));  // 10
 Calling `include()` with the same path again returns the cached value
 without re-executing the file.
 
+---
+
+# Working with the standard library
+
+The rest of this guide is a tour of the most-used standard-library
+modules.  Read [standard-library.md](standard-library.md) for the full
+function-by-function reference; the snippets below show the shape of
+each module and the patterns that come up daily.
+
 ## File I/O
 
 ```cando
@@ -792,5 +827,8 @@ print("wrote report.json with", #results, "entries");
 |---|---|
 | Every operator, keyword, and syntax rule | [language-reference.md](language-reference.md) |
 | All library functions | [standard-library.md](standard-library.md) |
+| Common idioms and best practice | [patterns.md](patterns.md) |
+| The `cando` CLI: flags, `args[]`, exit codes | [cli.md](cli.md) |
 | Threading in depth | [threading.md](threading.md) |
+| Networking sockets in depth | [socket.md](socket.md) |
 | Building the interpreter | [getting-started.md](getting-started.md) |


### PR DESCRIPTION
## Summary

This PR adds three new documentation files and updates existing references to provide comprehensive guidance for CanDo script authors. The additions cover everyday coding patterns, command-line usage, and clarifications to the language reference.

## Key Changes

**New Documentation:**
- **`docs/patterns.md`** (597 lines): A field guide to common CanDo idioms and conventions covering:
  - Variable scope and binding best practices (`VAR` vs globals, `CONST`, block-scoping)
  - String handling (backtick templates, single-quote raw strings, numeric coercion)
  - Functional array operations (`map`, `filter`, `reduce`, pipe syntax)
  - Object patterns (records, prototypes, merging)
  - Function idioms (default arguments, multi-return error handling, higher-order functions)
  - Error handling strategies (selective catching, re-throwing with context, multi-value throws)
  - Class design (constructors, inheritance, operator overloading)
  - Module patterns (single-export, caching, YAML/JSON loading)
  - Threading patterns (fire-and-forget vs await, worker pools, closure safety)
  - I/O best practices (streaming large files, atomic writes)
  - CLI script conventions (argument parsing, flag handling)

- **`docs/cli.md`** (138 lines): Complete guide to the `cando` command-line interpreter:
  - Command syntax and argument handling
  - Exit codes and error reporting
  - The global `args` array and string coercion
  - Standard stream usage (stdout, stderr, stdin)
  - Bytecode disassembly with `--disasm` flag
  - Environment variable reference
  - Embedding API equivalent

**Updated Documentation:**
- **`docs/language-reference.md`**: 
  - Clarified keyword case-insensitivity rules (all-upper, all-lower accepted; mixed-case rejected)
  - Moved keyword case explanation from Classes section to Keywords section
  - Expanded runtime error documentation with comprehensive error message table covering arithmetic, type access, calls, control flow, and threading errors
  
- **`docs/user-guide.md`**:
  - Added table of contents with 19 sections
  - Clarified keyword case conventions in opening section
  - Added "Working with the standard library" section header to organize stdlib examples
  - Cross-referenced `patterns.md` in introduction

- **`docs/README.md`**:
  - Reorganized documentation index with "Start here" section
  - Added new subsections: Concurrency, Networking, Data formats, Graphics & UI
  - Moved `patterns.md` and `cli.md` to prominent positions
  - Improved document categorization and navigation

- **`docs/metamethods.md`**: Minor formatting adjustments to table structure

## Notable Details

- The patterns guide emphasizes practical conventions reached by experienced authors, not new language features
- Error documentation now provides a complete reference table of runtime errors with causes and examples
- CLI documentation covers both the `cando` executable and its embedding API equivalent
- Documentation structure now guides users from getting started → tutorial → reference → patterns → specialized topics

https://claude.ai/code/session_018khxLkAww6AuRRVo89ZpJn