### PR TITLE
Surface uncaught errors on stderr instead of dropping them silently

### DIFF
--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -226,6 +226,18 @@ Formats `fmt` into `vm->error_msg`, sets `vm->has_error`, and stages
 the message as a catchable thrown value.  Your native function should
 `return -1` immediately afterwards.
 
+```c
+void cando_vm_log_uncaught(CandoVM *vm, const char *context);
+```
+
+Prints `vm`'s current error to **stderr** in the form
+`cando: uncaught error in <context>: <msg>`, then clears the error so
+the calling thread can keep going.  Use this from callback dispatchers
+that have no caller to propagate to — the built-in HTTP server, socket
+listeners, stream transforms, and `thread.then` / `thread.catch`
+fire-and-forget paths all use it so script errors never disappear
+silently.  No-op when `vm` has no pending error.
+
 ## Globals
 
 ```c

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -586,3 +586,36 @@ The following operations raise catchable errors:
 The error message is the value passed to the `CATCH` parameter.  If
 uncaught, the host embedder sees `CANDO_ERR_RUNTIME` and
 `cando_errmsg(vm)` returns the formatted message.
+
+### Uncaught errors are surfaced on stderr
+
+The runtime never silently drops an uncaught error.  Whenever an error
+escapes the script-side handlers it would normally have, CanDo prints a
+diagnostic line to **stderr** so the failure is visible to the operator.
+The cases this covers are:
+
+- **Top-level**: an uncaught error in the main script body bubbles out
+  to the embedder and the `cando` CLI prints it before exiting with
+  status 1.
+- **Threads**: a thread body that errors stores the error on the thread
+  object.  If the script never observes that error — never `await`s the
+  thread, never calls `thread.error(t)`, and never registered a
+  `thread.catch` callback — the runtime prints
+  `cando: uncaught error in thread: <message>` when the thread object is
+  reclaimed (typically at VM shutdown).
+- **Promise-style callbacks**: a `thread.then` or `thread.catch`
+  callback that itself throws is logged immediately as
+  `cando: uncaught error in thread.<then|catch> callback: <message>`.
+  These run after the thread completes and have no surrounding caller.
+- **HTTP server**: if a `http.createServer` callback errors before
+  calling `res:send()`, the server still returns a 500 to the client,
+  *and* prints the original error as
+  `cando: uncaught error in http server callback: <message>` on stderr.
+- **Socket / secure_socket / stream**: a connection-handler or stream
+  transform callback that errors logs
+  `cando: uncaught error in <subsystem>: <message>` so the failure is
+  attributable.
+
+Errors that **are** observed on the script side — caught by `TRY/CATCH`,
+delivered through `await`, picked up by an attached `thread.catch`, or
+inspected via `thread.error(t)` — are not duplicated to stderr.

--- a/docs/threading.md
+++ b/docs/threading.md
@@ -65,6 +65,28 @@ thread.catch(t, FUNCTION(err) {
 Callbacks are stored inside the thread handle; a `t` can have multiple
 `then` and `catch` callbacks and they fire in registration order.
 
+### Uncaught thread errors are logged
+
+If a thread body throws an error and the script never observes it — no
+`await`, no `thread.catch`, no `thread.error(t)` — the runtime prints
+the error to stderr when the thread handle is reclaimed:
+
+```
+cando: uncaught error in thread: <message>
+```
+
+This makes silent thread failures visible.  An error is considered
+"observed" as soon as any of the following happens:
+
+- `await t` (the await re-throws the error into the caller).
+- `thread.catch(t, fn)` is attached *before* the thread completes (or
+  fires immediately if attached afterwards).
+- `thread.error(t)` returns the value to script code.
+
+If a `thread.then` or `thread.catch` callback itself throws, the runtime
+prints `cando: uncaught error in thread.<then|catch> callback: <…>` —
+those callbacks have no further caller to propagate to.
+
 ## Introspection
 
 | Call | Returns |

--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -1211,6 +1211,10 @@ static CANDO_THREAD_RETURN conn_thread_fn(void *arg_p)
             ctx->status_code = 500;
             res_send_impl(ctx, "Internal Server Error", 21);
         }
+        /* Surface the original handler error on stderr -- without this,
+         * server-side bugs are invisible to the operator (the client just
+         * sees a generic 500). */
+        cando_vm_log_uncaught(&child, "http server callback");
     }
 
     res_wait_until_sent(ctx);

--- a/source/lib/secure_socket.c
+++ b/source/lib/secure_socket.c
@@ -279,6 +279,9 @@ static void secure_socket_tls_conn_handler(int listener_idx,
 
     CandoValue cb_args[1] = { conn_val };
     cando_vm_call_value(&child, listener->callback_fn, cb_args, 1);
+    if (child.has_error) {
+        cando_vm_log_uncaught(&child, "secure_socket listener callback");
+    }
 
     socket_pool_release(conn_idx);
     cando_vm_destroy(&child);

--- a/source/lib/socket.c
+++ b/source/lib/socket.c
@@ -820,6 +820,9 @@ void socket_default_conn_handler(int listener_idx, sockutil_socket_t cfd)
 
     CandoValue cb_args[1] = { conn_val };
     cando_vm_call_value(&child, listener->callback_fn, cb_args, 1);
+    if (child.has_error) {
+        cando_vm_log_uncaught(&child, "socket listener callback");
+    }
 
     socket_pool_release(conn_idx);
     cando_vm_destroy(&child);

--- a/source/lib/stream.c
+++ b/source/lib/stream.c
@@ -870,6 +870,12 @@ static StreamStatus transform_write(void *vctx, const u8 *buf, usize len,
     int n_ret = cando_vm_call_value(&t->child_vm, t->fn, &arg, 1);
     cando_string_release(in_s);
 
+    /* Surface uncaught errors from the user transform so they don't
+     * vanish into the streaming pipeline.                             */
+    if (t->child_vm.has_error) {
+        cando_vm_log_uncaught(&t->child_vm, "stream transform callback");
+    }
+
     /* Drain returned values; only the first string is appended to the
      * output buffer.  Anything else is silently dropped — matches the
      * "filter chunk" semantics where returning null/non-string skips. */

--- a/source/lib/thread.c
+++ b/source/lib/thread.c
@@ -260,6 +260,9 @@ static int thread_error(CandoVM *vm, int argc, CandoValue *args)
 
     cando_os_mutex_lock(&t->done_mutex);
     CandoValue err = cando_value_copy(t->error);
+    /* Caller is reading the error explicitly -- count this as observing
+     * the error so destroy doesn't also print it on stderr. */
+    t->error_observed = true;
     cando_os_mutex_unlock(&t->done_mutex);
 
     cando_vm_push(vm, err);
@@ -319,6 +322,9 @@ static int thread_then(CandoVM *vm, int argc, CandoValue *args)
         cando_vm_call_value(vm, fn, results_copy, count);
         for (u32 i = 0; i < count; i++)
             cando_value_release(results_copy[i]);
+        if (vm->has_error) {
+            cando_vm_log_uncaught(vm, "thread.then callback");
+        }
     } else if (s == CDO_THREAD_PENDING || s == CDO_THREAD_RUNNING) {
         /* Store callback; trampoline will fire it. */
         cando_value_release(t->then_fn);
@@ -356,14 +362,20 @@ static int thread_catch(CandoVM *vm, int argc, CandoValue *args)
     CdoThreadState s = atomic_load(&t->state);
 
     if (s == CDO_THREAD_ERROR) {
-        /* Already errored — collect error then call fn outside the lock. */
+        /* Already errored — collect error then call fn outside the lock.
+         * The catch callback consumes the error, so mark it observed.   */
         CandoValue err = cando_value_copy(t->error);
+        t->error_observed = true;
         cando_os_mutex_unlock(&t->done_mutex);
 
         cando_vm_call_value(vm, fn, &err, 1);
         cando_value_release(err);
+        /* If the user's catch callback itself threw, surface it. */
+        if (vm->has_error) {
+            cando_vm_log_uncaught(vm, "thread.catch callback");
+        }
     } else if (s == CDO_THREAD_PENDING || s == CDO_THREAD_RUNNING) {
-        /* Store callback; trampoline will fire it. */
+        /* Store callback; trampoline will fire it (and mark observed). */
         cando_value_release(t->catch_fn);
         t->catch_fn = cando_value_copy(fn);
         cando_os_mutex_unlock(&t->done_mutex);

--- a/source/object/thread.c
+++ b/source/object/thread.c
@@ -7,6 +7,9 @@
 #include "thread.h"
 #include "../core/common.h"
 #include "../core/memory.h"
+#include "string.h"   /* CdoString for error formatting */
+#include <stdio.h>
+#include <string.h>   /* strlen for non-string error fallback */
 
 /* =========================================================================
  * Lifecycle
@@ -16,14 +19,15 @@ CdoThread *cdo_thread_new(CandoValue fn_val) {
     CdoThread *t = (CdoThread *)cando_alloc(sizeof(CdoThread));
 
     cando_lock_init(&t->lock);
-    t->kind         = OBJ_THREAD;
+    t->kind           = OBJ_THREAD;
     atomic_store(&t->state, CDO_THREAD_PENDING);
-    t->fn_val       = cando_value_copy(fn_val);
-    t->result_count = 0;
-    t->error        = cando_null();
-    t->then_fn      = cando_null();
-    t->catch_fn     = cando_null();
-    t->handle_idx   = CANDO_INVALID_HANDLE;
+    t->fn_val         = cando_value_copy(fn_val);
+    t->result_count   = 0;
+    t->error          = cando_null();
+    t->then_fn        = cando_null();
+    t->catch_fn       = cando_null();
+    t->error_observed = false;
+    t->handle_idx     = CANDO_INVALID_HANDLE;
 
     for (u32 i = 0; i < CDO_THREAD_MAX_RESULTS; i++)
         t->results[i] = cando_null();
@@ -39,6 +43,21 @@ CdoThread *cdo_thread_new(CandoValue fn_val) {
 
 void cdo_thread_destroy(CdoThread *t) {
     if (!t) return;
+
+    /* If the thread errored and nothing on the script side ever observed
+     * the error -- no `await`, no `thread.catch`, no `thread.error()` --
+     * surface it on stderr now so the failure isn't silently swallowed. */
+    if (atomic_load(&t->state) == CDO_THREAD_ERROR && !t->error_observed) {
+        if (t->error.tag == TYPE_STRING && t->error.as.string) {
+            fprintf(stderr, "cando: uncaught error in thread: %.*s\n",
+                    (int)t->error.as.string->length,
+                    t->error.as.string->data);
+        } else {
+            fprintf(stderr, "cando: uncaught error in thread: <%s>\n",
+                    cando_value_type_name((TypeTag)t->error.tag));
+        }
+        fflush(stderr);
+    }
 
     cando_value_release(t->fn_val);
     cando_value_release(t->error);

--- a/source/object/thread.h
+++ b/source/object/thread.h
@@ -68,6 +68,13 @@ typedef struct CdoThread {
     CandoValue           then_fn;   /* called with results on DONE          */
     CandoValue           catch_fn;  /* called with error on ERROR           */
 
+    /* Set true when the error from state=ERROR has been delivered to user
+     * code: by `await` re-throwing, by a thread.catch callback firing, or
+     * by thread.error() returning the value.  When destroy is called and
+     * this is still false, the error is logged to stderr to surface
+     * silently dropped exceptions.  Protected by done_mutex.              */
+    bool                 error_observed;
+
     /* Handle index of this thread in the VM handle table.  Set by
      * OP_THREAD immediately after allocation; used by thread.current().   */
     HandleIndex          handle_idx;

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -1078,6 +1078,26 @@ void cando_vm_error(CandoVM *vm, const char *fmt, ...) {
     vm_error_commit(vm);
 }
 
+/* cando_vm_log_uncaught -- print vm's current error to stderr and clear it.
+ * Used by callback dispatchers where there is no surrounding TRY/CATCH and
+ * no caller to propagate the error to.  No-op when vm has no error.        */
+void cando_vm_log_uncaught(CandoVM *vm, const char *context) {
+    if (!vm || !vm->has_error) return;
+    fprintf(stderr, "cando: uncaught error in %s: %s\n",
+            context && *context ? context : "callback",
+            vm->error_msg[0] ? vm->error_msg : "<no message>");
+    fflush(stderr);
+
+    /* Clear the error so the calling thread can continue dispatching. */
+    vm->has_error       = false;
+    vm->error_msg[0]    = '\0';
+    for (u32 i = 0; i < CANDO_MAX_THROW_ARGS; i++) {
+        cando_value_release(vm->error_vals[i]);
+        vm->error_vals[i] = cando_null();
+    }
+    vm->error_val_count = 0;
+}
+
 /* vm_runtime_error -- internal; like cando_vm_error but appends the
  * current source file + line number from the active call frame.          */
 static void vm_runtime_error(CandoVM *vm, const char *fmt, ...) {
@@ -1496,6 +1516,7 @@ static CANDO_THREAD_RETURN vm_thread_trampoline(void *raw_arg) {
     {
         CdoThreadState final_state = atomic_load(&ta->thread->state);
         CandoValue cb = cando_null();
+        bool       cb_is_catch = false;
 
         cando_os_mutex_lock(&ta->thread->done_mutex);
         if (final_state == CDO_THREAD_DONE && cando_is_object(ta->thread->then_fn)) {
@@ -1503,6 +1524,10 @@ static CANDO_THREAD_RETURN vm_thread_trampoline(void *raw_arg) {
         } else if (final_state == CDO_THREAD_ERROR &&
                    cando_is_object(ta->thread->catch_fn)) {
             cb = cando_value_copy(ta->thread->catch_fn);
+            /* The error is being delivered to user code -- mark it
+             * observed so the destroy hook doesn't also print it. */
+            ta->thread->error_observed = true;
+            cb_is_catch                = true;
         }
         cando_os_mutex_unlock(&ta->thread->done_mutex);
 
@@ -1522,6 +1547,15 @@ static CANDO_THREAD_RETURN vm_thread_trampoline(void *raw_arg) {
                 } else {
                     vm_call_closure_with_args(&child, cb_obj,
                                               &ta->thread->error, 1);
+                }
+
+                /* If the then/catch callback itself threw, surface that
+                 * on stderr -- there is no further caller to receive
+                 * it.  Helpful for diagnosing bugs in completion logic. */
+                if (child.has_error) {
+                    cando_vm_log_uncaught(&child,
+                        cb_is_catch ? "thread.catch callback"
+                                    : "thread.then callback");
                 }
             }
             cando_value_release(cb);
@@ -3667,13 +3701,28 @@ static CandoVMResult vm_run(CandoVM *vm) {
             cdo_thread_wait(t);
 
             if (atomic_load(&t->state) == CDO_THREAD_ERROR) {
+                /* The error is being delivered to user code via the
+                 * propagating throw -- mark it as observed so the
+                 * destructor doesn't also log it on stderr.            */
+                cando_os_mutex_lock(&t->done_mutex);
+                t->error_observed = true;
+                cando_os_mutex_unlock(&t->done_mutex);
+
                 /* Propagate error: push to error_vals and go to error handler. */
                 cando_value_release(vm->error_vals[0]);
                 vm->error_vals[0]   = cando_value_copy(t->error);
                 vm->error_val_count = 1;
                 vm->has_error       = true;
-                snprintf(vm->error_msg, sizeof(vm->error_msg),
-                         "thread raised an error");
+                /* Use the thread's actual error message when it is a string,
+                 * so the surfaced error reads like the original throw. */
+                if (cando_is_string(t->error) && t->error.as.string) {
+                    snprintf(vm->error_msg, sizeof(vm->error_msg), "%.*s",
+                             (int)t->error.as.string->length,
+                             t->error.as.string->data);
+                } else {
+                    snprintf(vm->error_msg, sizeof(vm->error_msg),
+                             "thread raised an error");
+                }
                 cando_value_release(thread_val);
                 goto handle_error;
             }

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -446,6 +446,20 @@ CANDO_API CandoVMResult cando_vm_exec_eval_module(CandoVM *vm, CandoChunk *chunk
  */
 CANDO_API void cando_vm_error(CandoVM *vm, const char *fmt, ...);
 
+/*
+ * cando_vm_log_uncaught -- print vm's current error to stderr in the
+ * canonical "cando: uncaught error in <context>: <msg>" form, then clear
+ * the error so the calling thread can continue.
+ *
+ * Used by callback dispatchers (HTTP server, socket listeners, stream
+ * callbacks, thread then/catch) to surface errors that would otherwise
+ * be silently dropped on the C side.  No-op when vm has no error.
+ *
+ * `context` is a short label identifying which subsystem the callback
+ * belongs to, e.g. "http server callback" or "socket listener".
+ */
+CANDO_API void cando_vm_log_uncaught(CandoVM *vm, const char *context);
+
 /* cando_vm_push -- push a value; aborts on stack overflow. */
 CANDO_API void cando_vm_push(CandoVM *vm, CandoValue val);
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -130,6 +130,15 @@ run_test "lib_yaml" "$SCRIPTS/lib_yaml.cdo" \
 run_test "threads" "$SCRIPTS/threads.cdo" \
     "$(printf '42\n10\n20\ntrue\nsleep_ok\nid_ok\n99\ntrue\nnull\n7\n1\n2\n3\ndone\nerror\nbad\ntrue\ntrue\n77\n88\ncaught_err\nalready\nfalse')"
 
+run_test "uncaught_thread_error" "$SCRIPTS/uncaught_thread_error.cdo" \
+    "$(printf 'script done\ncando: uncaught error in thread: boom from worker')"
+
+run_test "caught_thread_error" "$SCRIPTS/caught_thread_error.cdo" \
+    "$(printf 'caught: handled error\nthen-catch: handled via catch\nscript done')"
+
+run_test "thread_error_observed" "$SCRIPTS/thread_error_observed.cdo" \
+    "$(printf 'got: looked at via thread.error\nscript done')"
+
 run_test "lib_os" "$SCRIPTS/lib_os.cdo" \
     "$(printf 'os.name: %s\nos_time_ok\nos_clock_ok\nPATH_ok\nCANDO_TEST: Hello' "$PLATFORM_OS_NAME")"
 

--- a/tests/scripts/caught_thread_error.cdo
+++ b/tests/scripts/caught_thread_error.cdo
@@ -1,0 +1,25 @@
+/* caught_thread_error.cdo -- a thread that throws but is caught via
+ * await + TRY/CATCH.  No "uncaught error" message should appear. */
+
+VAR t = thread {
+    THROW "handled error";
+};
+
+TRY {
+    await t;
+    print("unreachable");
+} CATCH (msg) {
+    print("caught:", msg);
+}
+
+/* Same idea via thread.catch -- registered before completion. */
+VAR t2 = thread {
+    THROW "handled via catch";
+};
+
+thread.catch(t2, FUNCTION(err) {
+    print("then-catch:", err);
+});
+
+thread.sleep(10);
+print("script done");

--- a/tests/scripts/thread_error_observed.cdo
+++ b/tests/scripts/thread_error_observed.cdo
@@ -1,0 +1,14 @@
+/* thread_error_observed.cdo -- thread.error(t) is itself an
+ * "observation" of the error and should suppress the destructor log.   */
+
+VAR t = thread {
+    THROW "looked at via thread.error";
+};
+
+thread.sleep(10);
+
+/* Read the error explicitly.  This counts as observing it. */
+VAR e = thread.error(t);
+print("got:", e);
+
+print("script done");

--- a/tests/scripts/uncaught_thread_error.cdo
+++ b/tests/scripts/uncaught_thread_error.cdo
@@ -1,0 +1,16 @@
+/* uncaught_thread_error.cdo -- a thread that throws and is never observed.
+ *
+ * Expected: the runtime prints the error message to stderr at thread
+ * destruction.  The test runner combines stdout+stderr, so the message
+ * appears in the captured output. */
+
+VAR t = thread {
+    THROW "boom from worker";
+};
+
+/* Wait long enough for the thread to finish but never await it and never
+ * register a thread.catch.  At VM shutdown the thread is destroyed and
+ * the unobserved error is logged.                                       */
+thread.sleep(10);
+
+print("script done");


### PR DESCRIPTION
Several callback paths used to swallow script-side errors:

- Thread bodies that errored with no `await`, no `thread.catch`, and no `thread.error(t)` reader -- the error sat on the thread object and was destroyed with it.
- HTTP server callback errors -- a 500 went to the client but no log appeared, so server bugs were invisible to the operator.
- thread.then / thread.catch callbacks that themselves threw.
- socket / secure_socket / stream listener and transform callbacks.

Adds a public helper `cando_vm_log_uncaught(vm, context)` that prints `cando: uncaught error in <context>: <msg>` to stderr and clears the error.  Used at every callback dispatch site that has no caller to propagate to.

For thread bodies the runtime now tracks an `error_observed` flag on CdoThread.  It flips true when the error is delivered to script code: `await` re-throwing it, an attached `thread.catch` callback firing, or `thread.error(t)` returning the value.  When `cdo_thread_destroy` runs with state=ERROR and !error_observed, the thread error is logged to stderr.  This avoids double-printing for awaited threads while still catching the silent-drop case.

The await re-throw also now uses the original error's message string when it is a string, instead of the generic "thread raised an error" placeholder, so the surfaced error reads like the underlying THROW.

New integration tests:
- uncaught_thread_error.cdo: verifies the destructor logs.
- caught_thread_error.cdo: verifies await+CATCH and pre-attached thread.catch suppress the log.
- thread_error_observed.cdo: verifies thread.error(t) suppresses it.

Documentation: language-reference.md gains an "Uncaught errors are surfaced on stderr" subsection enumerating every covered path; threading.md gains a parallel section after the callbacks reference; c-api.md documents the new public helper.