### PR TITLE
Fix stack traces and chunk name lifetime issues

### DIFF
--- a/source/vm/chunk.c
+++ b/source/vm/chunk.c
@@ -26,7 +26,19 @@ CandoChunk *cando_chunk_new(const char *name, u32 arity, bool has_vararg) {
     c->const_count = 0;
     c->const_cap   = 0;
     c->lines       = NULL;
-    c->name        = name ? name : "<anonymous>";
+    /* The chunk owns its name string.  The previous "store-by-pointer"
+     * convention silently broke down whenever a chunk outlived its caller's
+     * stack frame (e.g. include() caches its compiled chunk and returns to
+     * the script -- the canonical[PATH_MAX] buffer that was passed in goes
+     * out of scope, leaving chunk->name dangling and producing garbled
+     * "[`¶Àïú☻ line N]" tails in subsequent error messages). */
+    {
+        const char *src = name ? name : "<anonymous>";
+        size_t len = strlen(src);
+        char *dup = (char *)cando_alloc(len + 1);
+        memcpy(dup, src, len + 1);
+        c->name = dup;
+    }
     c->arity       = arity;
     c->local_count = arity;   /* parameters occupy the first local slots  */
     c->upval_count = 0;
@@ -45,6 +57,7 @@ void cando_chunk_free(CandoChunk *chunk) {
     cando_free(chunk->code);
     cando_free(chunk->constants);
     cando_free(chunk->lines);
+    cando_free(chunk->name);
     cando_free(chunk);
 }
 

--- a/source/vm/chunk.h
+++ b/source/vm/chunk.h
@@ -40,7 +40,7 @@ typedef struct CandoChunk {
     u32 *lines;         /* lines[i] = source line for code[i]             */
 
     /* Metadata --------------------------------------------------------- */
-    const char *name;   /* function / chunk name (static or heap string)  */
+    char *name;         /* function / chunk name (heap-owned, strdup'd)   */
     u32  arity;         /* number of named parameters                     */
     u32  local_count;   /* total local variable slots (incl. parameters)  */
     u32  upval_count;   /* number of captured upvalues                    */
@@ -52,7 +52,8 @@ typedef struct CandoChunk {
  * ---------------------------------------------------------------------- */
 
 /* cando_chunk_new -- allocate and zero-initialise a fresh chunk.
- * `name` is stored by pointer (caller must ensure lifetime). */
+ * `name` is duplicated into heap-owned storage; the caller's string can
+ * be freed immediately after this call returns. */
 CANDO_API CandoChunk *cando_chunk_new(const char *name, u32 arity, bool has_vararg);
 
 /* cando_chunk_free -- release all internal storage and the chunk itself. */

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -1098,28 +1098,58 @@ void cando_vm_log_uncaught(CandoVM *vm, const char *context) {
     vm->error_val_count = 0;
 }
 
-/* vm_runtime_error -- internal; like cando_vm_error but appends the
- * current source file + line number from the active call frame.          */
+/* vm_append_stack_trace -- append a multi-line "  at <file>:<line>" trace
+ * to vm->error_msg covering every active call frame, innermost first.
+ * Truncation is bounded by the fixed error_msg buffer; if a frame would
+ * not fit, append a "  ... N more frame(s)" summary and stop.            */
+static void vm_append_stack_trace(CandoVM *vm) {
+    if (vm->frame_count == 0) return;
+
+    size_t cap = sizeof(vm->error_msg);
+    size_t used = strlen(vm->error_msg);
+
+    for (int i = (int)vm->frame_count - 1; i >= 0; i--) {
+        CandoCallFrame *f     = &vm->frames[i];
+        CandoChunk     *chunk = f->closure->chunk;
+        u32 line = 0;
+        /* The innermost frame has just executed (or attempted) one byte
+         * past the failing instruction; deeper frames record the IP as
+         * "the byte after the call site that pushed this frame". In both
+         * cases stepping back one byte lands on the relevant opcode.    */
+        u32 offset = (u32)(f->ip - chunk->code);
+        if (offset > 0) offset--;
+        if (offset < chunk->code_len) line = chunk->lines[offset];
+
+        char entry[256];
+        int n = snprintf(entry, sizeof(entry),
+                         "\n  at %s:%u",
+                         chunk->name ? chunk->name : "<anonymous>",
+                         line);
+        if (n < 0) break;
+        if (used + (size_t)n + 1 >= cap) {
+            /* Not enough room for this frame; summarise remainder. */
+            char tail[64];
+            int tn = snprintf(tail, sizeof(tail),
+                              "\n  ... %d more frame(s)", i + 1);
+            if (tn > 0 && used + (size_t)tn + 1 < cap) {
+                memcpy(vm->error_msg + used, tail, (size_t)tn + 1);
+            }
+            break;
+        }
+        memcpy(vm->error_msg + used, entry, (size_t)n + 1);
+        used += (size_t)n;
+    }
+}
+
+/* vm_runtime_error -- internal; like cando_vm_error but appends a stack
+ * trace covering every active call frame.                                */
 static void vm_runtime_error(CandoVM *vm, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     vsnprintf(vm->error_msg, sizeof(vm->error_msg), fmt, ap);
     va_end(ap);
 
-    /* Attach source location from current frame. */
-    if (vm->frame_count > 0) {
-        CandoCallFrame *frame = &vm->frames[vm->frame_count - 1];
-        CandoChunk     *chunk = frame->closure->chunk;
-        u32 offset = (u32)(frame->ip - chunk->code - 1); /* -1: already advanced */
-        if (offset < chunk->code_len) {
-            u32 line = chunk->lines[offset];
-            char loc[128];
-            snprintf(loc, sizeof(loc), " [%s line %u]", chunk->name, line);
-            strncat(vm->error_msg, loc,
-                    sizeof(vm->error_msg) - strlen(vm->error_msg) - 1);
-        }
-    }
-
+    vm_append_stack_trace(vm);
     vm_error_commit(vm);
 }
 
@@ -3661,10 +3691,13 @@ static CandoVMResult vm_run(CandoVM *vm) {
             for (u32 i = count; i-- > 0; )
                 vm->error_vals[i] = POP();
             vm->has_error = true;
-            /* Format error_msg from first thrown value. */
+            /* Format error_msg from first thrown value, then append a
+             * stack trace so an uncaught throw is debuggable.            */
             char *s = cando_value_tostring(vm->error_vals[0]);
             snprintf(vm->error_msg, sizeof(vm->error_msg), "%s", s);
             cando_free(s);
+            SYNC_IP();
+            vm_append_stack_trace(vm);
             goto handle_error;
         }
         OP_CASE(OP_RERAISE): {


### PR DESCRIPTION
## Summary
This PR fixes two critical issues in error reporting and memory management:
1. Stack traces now include all active call frames instead of just the innermost one
2. Chunk names are now properly heap-allocated to prevent use-after-free bugs

## Key Changes

- **Enhanced stack trace reporting**: Refactored `vm_runtime_error()` to use a new `vm_append_stack_trace()` function that walks all active call frames (innermost first) and appends formatted "at <file>:<line>" entries to the error message. Gracefully handles buffer overflow by appending a "... N more frame(s)" summary when truncation occurs.

- **Fixed chunk name lifetime bug**: Changed `CandoChunk.name` from a `const char*` (stored-by-pointer) to a `char*` (heap-owned). The chunk now duplicates the name string during initialization and frees it during cleanup. This prevents dangling pointer bugs where chunks outlived their caller's stack frame (e.g., in `include()` caching scenarios).

- **Improved thrown exception tracing**: When an exception is thrown via `OP_THROW`, the error message is now formatted from the thrown value and a full stack trace is appended before error handling, making uncaught throws fully debuggable.

## Implementation Details

- Stack trace generation correctly handles the IP offset: the innermost frame has advanced one byte past the failing instruction, while deeper frames record the IP as "the byte after the call site," so both cases step back one byte to land on the relevant opcode.

- Buffer overflow handling is bounded by the fixed `error_msg` buffer size; frames that don't fit trigger a summary line showing the count of remaining frames.

- The chunk name duplication uses `cando_alloc()` and `memcpy()` to ensure proper memory ownership semantics throughout the chunk's lifetime.

https://claude.ai/code/session_012snR1DCytYAUj7gwFskB9g