### PR TITLE
window/forms: surface uncaught errors from user callbacks

### DIFF
--- a/modules/forms/forms_module.c
+++ b/modules/forms/forms_module.c
@@ -1535,14 +1535,17 @@ static void dispatch_one(FormsEvent ev)
     }
 
     cando_vm_call_value(&g_dispatch_vm, fn, argv, argc);
+    /* Surface uncaught errors from the user handler in the canonical
+     * "cando: uncaught error in <ctx>: <msg>" form.  The message already
+     * carries the stack trace produced by the VM, and log_uncaught
+     * clears has_error / error_vals so the next dispatch starts clean. */
     if (g_dispatch_vm.has_error) {
-        fprintf(stderr, "[forms] %s handler error: %s\n",
-                name, g_dispatch_vm.error_msg);
+        char ctx[128];
+        snprintf(ctx, sizeof(ctx), "forms %s handler", name);
+        cando_vm_log_uncaught(&g_dispatch_vm, ctx);
     }
     g_dispatch_vm.stack_top   = g_dispatch_vm.stack;
     g_dispatch_vm.frame_count = 0;
-    g_dispatch_vm.has_error   = false;
-    g_dispatch_vm.error_val_count = 0;
 }
 
 static void dispatch_drain(void)

--- a/modules/window/window_module.c
+++ b/modules/window/window_module.c
@@ -290,15 +290,21 @@ static void dispatch_call(WindowSlot *s, const char *name,
     /* The dispatch VM is single-threaded (only the manager touches it),
      * so no locking is needed around this call. */
     cando_vm_call_value(&g_dispatch_vm, fn, argv, 1 + extra_argc);
-    /* Discard any return values left on the child VM's stack and
-     * clear any per-call error state so the next dispatch starts
+    /* Surface uncaught errors from the user-supplied callback so they
+     * don't silently vanish.  cando_vm_log_uncaught prints the canonical
+     * "cando: uncaught error in <ctx>: <msg>" line (the message already
+     * carries the stack trace) and clears has_error / error_vals. */
+    if (g_dispatch_vm.has_error) {
+        char ctx[128];
+        snprintf(ctx, sizeof(ctx), "window %s callback", name);
+        cando_vm_log_uncaught(&g_dispatch_vm, ctx);
+    }
+    /* Reset the per-call stack/frame state so the next dispatch starts
      * clean.  Don't release `fn` here: cando_bridge_to_cando produced
      * a borrowed handle that the parent VM owns through the instance
      * field, so releasing would over-decref. */
     g_dispatch_vm.stack_top   = g_dispatch_vm.stack;
     g_dispatch_vm.frame_count = 0;
-    g_dispatch_vm.has_error   = false;
-    g_dispatch_vm.error_val_count = 0;
 }
 
 typedef enum {


### PR DESCRIPTION
## Summary
- The window and forms modules dispatch user event handlers (onResize, onClick, onKeyDown, ...) on a manager-thread child VM, then silently zeroed `has_error` before the next dispatch. Uncaught throws / runtime errors inside any handler vanished without ever reaching stderr, leaving GUI scripts to look "frozen" with no diagnostic output.
- Route both modules through `cando_vm_log_uncaught` (the same helper used for thread / socket / stream / http callbacks) so the canonical `cando: uncaught error in <ctx>: <msg>` line is printed, including the stack trace the VM embeds in `error_msg`.
- Replace forms' custom `[forms] <name> handler error: ...` line with the same canonical form for consistency with the rest of the runtime (and to pick up the stack trace automatically). Per-call stack/frame state is still reset afterwards so the next event starts clean; `log_uncaught` itself clears `has_error` and `error_vals`.

Context strings are `window <eventName> callback` and `forms <eventName> handler` so it's clear which handler blew up.

## Test plan
- [ ] Run a window script whose `onResize` / `onKeyDown` throws and confirm `cando: uncaught error in window <name> callback: ...` plus stack trace lands on stderr.
- [ ] Same for a forms script's `onClick` / `onClose`.
- [ ] Confirm subsequent events still dispatch (state reset works).
- [ ] `make test` passes (no behavioural change to non-GUI paths).

https://claude.ai/code/session_012snR1DCytYAUj7gwFskB9g

---
_Generated by [Claude Code](https://claude.ai/code/session_012snR1DCytYAUj7gwFskB9g)_