### PR TITLE
forms: panels relay WM_SIZE to anchor + dock children

### DIFF
--- a/modules/forms/forms_module.c
+++ b/modules/forms/forms_module.c
@@ -955,6 +955,22 @@ static LRESULT CALLBACK panel_wndproc(HWND h, UINT msg, WPARAM w, LPARAM l)
         if (parent) return SendMessageW(parent, msg, w, l);
         break;
     }
+    case WM_SIZE: {
+        /* When a panel changes size -- because its own parent's dock
+         * pass moved it, or the script called setSize/setDock on it --
+         * its docked / anchored children need the same re-layout pass
+         * the form's WndProc runs on its top-level resize.  Without
+         * this, children that were docked while the panel was 0x0
+         * would never grow into the panel's eventual real size.       */
+        if (slot > 0 && slot < FORMS_MAX_SLOTS) {
+            int cw = LOWORD(l), ch = HIWORD(l);
+            g_slots[slot].w = cw;
+            g_slots[slot].h = ch;
+            layout_anchor_children(slot);
+            layout_dock_children(slot);
+        }
+        break;
+    }
     }
     if (orig) return CallWindowProcW(orig, h, msg, w, l);
     return DefWindowProcW(h, msg, w, l);


### PR DESCRIPTION
## Summary

`panel_wndproc` currently doesn't handle `WM_SIZE`, so when a `Panel` is resized (by its parent's dock pass, or by a `setSize` / `setDock` call) its docked / anchored children are not re-laid out.  The practical symptom: a script that wraps a panel-of-controls in a constructor and sets the panel's size after the children have been added ends up with all the children stuck at their original 0×0 positions.

This adds a `WM_SIZE` arm to `panel_wndproc` that mirrors what `form_wndproc` already does on a top-level resize — update the slot's cached `w`/`h`, then rerun `layout_anchor_children` followed by `layout_dock_children` for that panel.

## Test plan

- [x] `make -C modules/forms clean all` — Linux stub builds clean (only the pre-existing `nanosleep` warning).
- [x] `make -C modules/forms test` — all C unit tests still pass.
- [ ] Manual: build a nested `Panel(Panel(controls))` on Windows, size the outer panel after construction, confirm children fill correctly.

https://claude.ai/code/session_01CzjrLSwFbnXKwPgNUytuFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzjrLSwFbnXKwPgNUytuFT)_