### PR TITLE
Add cross-file completion, hover, and signature help to language server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,20 +287,14 @@ jobs:
           path: cando-windows-x86_64
 
       - name: Download VS Code extension artifact
+        # The extension has its own dedicated release channel
+        # (`vscode-latest` below) so we no longer bundle the .vsix into the
+        # platform zips. We still need to download it here so the standalone
+        # publish step can pick it up.
         uses: actions/download-artifact@v4
         with:
           name: vscode-cando-extension
           path: vscode-cando-extension
-
-      - name: Bundle VS Code extension into platform artifacts
-        # Ship the .vsix alongside each platform binary so a single
-        # download gives users both the interpreter and the editor
-        # integration.  Also publish it standalone on its own channel.
-        run: |
-          set -e
-          mkdir -p cando-linux-x86_64/editors cando-windows-x86_64/editors
-          cp vscode-cando-extension/vscode-cando.vsix cando-linux-x86_64/editors/
-          cp vscode-cando-extension/vscode-cando.vsix cando-windows-x86_64/editors/
 
       - name: Zip platform artifacts
         run: |

--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes to the **CanDo Language** VS Code extension are
 documented in this file.
 
+## 0.2.0 -- 2026-05-01
+
+### Added
+
+- Filesystem path completion inside `include("...")`. Lists workspace
+  `.cdo`, `.json`, `.csv`, `.yaml`, `.yml`, `.so`, `.dylib`, and `.dll`
+  files, walking up parent directories the same way the runtime resolver
+  does. Folder entries re-trigger completion automatically.
+- Cross-file member completion. When a variable is bound to
+  `include("./mod.cdo")` or `include("./data.json")`, typing
+  `name.` / `name:` offers that module's exported keys (object literal
+  returned at the top level, or top-level declarations as a fallback).
+  Results are cached by mtime.
+- Object-literal member completion: `VAR cfg = { host: ..., port: ... };`
+  followed by `cfg.` now suggests `host` / `port`.
+- Class member completion: instance methods, static members, and fields
+  are surfaced under both `Cls.` and `Cls:`.
+- Signature help: invoking a function shows its parameter list, with the
+  active parameter highlighted as you type commas. Works for in-file
+  functions, the `include` / `print` / `type` / `inspect` / `toString`
+  globals, and known `array.*` / `string.*` / `math.*` members.
+- `include()` registered as a global builtin with hover documentation;
+  go-to-definition on an `include(...)`-bound variable now jumps to the
+  resolved file.
+- Snippets: `include`, `includeso` (cross-platform binary loader), and
+  `return`/`export` for module exports.
+- Settings: `cando.completion.includePaths`,
+  `cando.completion.crossFile`.
+
+### Changed
+
+- The analyzer now records `include(...)` bindings, top-level object
+  literal keys, the last top-level `RETURN { ... }` (treated as the
+  module's export shape), and class members.
+- Function and method completion items now expand into snippet calls
+  with each parameter as a tab stop.
+
 ## 0.1.0 -- 2026-04-29
 
 Initial release.

--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the **CanDo Language** VS Code extension are
 documented in this file.
 
+## 0.3.2 -- 2026-05-01
+
+### Fixed
+
+- **`::` is the fluent-chain operator.** CanDo distinguishes `:` (method
+  call -- result is whatever the method returns) from `::` (chain --
+  result is always the receiver). The lexer already tokenises `::` as a
+  single op, but the type tracker was treating it like `:`. Both the
+  receiver walk-back (`inferReceiverAt`) and the postfix step
+  (`inferPostfix`) now recognise `::` and preserve the receiver type
+  regardless of the method's declared return. So
+  `t::set_v(200)::set_v(300)` keeps its type on `t`, matching
+  `tests/scripts/method_call.cdo`.
+- **Runtime member attachments to records.** `VAR t = { v: 100 };
+  t.meth = FUNCTION(self) { ... };` -- the `meth` assignment was
+  invisible to completion. The type tracker now runs a second pass and
+  augments record-typed bindings with `name.member = ...` and
+  `name:member = ...` patterns so `t.|` includes both `v` and `meth`.
+
 ## 0.3.1 -- 2026-05-01
 
 Edge-case sweep for the type tracker. 63-case harness in

--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to the **CanDo Language** VS Code extension are
 documented in this file.
 
+## 0.3.1 -- 2026-05-01
+
+Edge-case sweep for the type tracker. 63-case harness in
+`server/test/edge_cases.js`; all green.
+
+### Fixed
+
+- **CLASS syntax.** The analyzer was assuming `CLASS Name { body }`,
+  but CanDo's actual syntax is
+  `CLASS Name [EXTENDS Parent] = [(params)] { body }`. The fix parses
+  the constructor params, captures `self.x = …` assignments inside
+  the constructor as fields/methods, and runs a second pass that
+  picks up methods attached after the body via
+  `Name.method = FUNCTION(self) { … }` (the canonical CanDo idiom).
+- **No `NEW` keyword.** Removed a fictional `NEW` branch from the type
+  tracker. Calling a class directly (`Animal("Rex")`) now produces
+  an instance of the class, matching the runtime.
+- **Class-name shadowing.** `CLASS Foo = { }` was being misread by
+  the type tracker as a bare `Foo = { }` assignment, shadowing the
+  class with an empty record. The tracker now skips past CLASS
+  declarations and refuses to bind class names via bare assignment.
+- **Self-typed returns.** Fluent chaining (`f:setText("…"):center()`)
+  was collapsing to `Control` -- the class declaring `setText`. The
+  manifest schema now supports `"returns": "self"` (alias `"this"`)
+  meaning "preserve the receiver's type". 90 chainable methods in the
+  forms manifest were migrated.
+
+### Added
+
+- `server/test/edge_cases.js`: a node-based harness covering receiver
+  detection, type inference, include/path detection, manifest
+  pathologies (cycles, missing types, malformed JSON), real-world
+  class idioms from `tests/scripts/metamethods.cdo`, performance
+  (1k-line files), CRLF/tabs, empty documents, and 50+ smaller
+  shapes. Run with `node server/test/edge_cases.js` after `tsc -b`.
+
 ## 0.3.0 -- 2026-05-01
 
 ### Added

--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to the **CanDo Language** VS Code extension are
 documented in this file.
 
+## 0.3.0 -- 2026-05-01
+
+### Added
+
+- **Module manifests (`cando.api.json`).** Each module folder can now
+  ship a JSON file describing the value `include(...)` returns -- its
+  exported names, their parameter signatures, and the named types
+  reachable from them (`forms.TextBox`, `sql.Statement`, …). The
+  language server reads it next to any binary or `.cdo` target. Schema
+  is documented in `server/src/manifest.ts`. `forms`, `sql`, `sqlite`,
+  `ldap`, `window`, and `draw` ship a manifest in-tree.
+- **Type tracker.** The server now infers a best-effort type for every
+  variable in a buffer:
+  - `VAR mod = include("./forms.so")` → the manifest's exports type
+  - `VAR f = forms.Form()` → `forms.Form`
+  - `VAR b = forms.Button(f); b:` → completion offers every method on
+    `Button`, including those inherited from `Control` and the Derma
+    aliases (`SetText`, `MoveToFront`, …).
+  - Method chains resolve through `returns`: `forms.createTextBox(p).`
+    completes `TextBox`.
+- **Inheritance.** Manifests support both `extends` (single classical
+  parent) and `indexes` (single string or array, mirroring the
+  runtime's `__index` prototype-chain mechanism). Both are walked
+  during member lookup.
+- **`__index` in user code.** Object literals with an `__index: parent`
+  field are treated as inheriting the parent's members:
+
+      VAR Animal = { speak: FUNCTION() { } };
+      VAR dog    = { __index: Animal, bark: FUNCTION() { } };
+      dog.       // suggests bark, speak
+
+- **Manifest-aware completion / hover / signature help.**
+  - Completion items expand with parameter snippets and show
+    `member(arg: type) -> Returns` in the detail row.
+  - Hover on a member shows the resolved owner type and the formatted
+    signature pulled from the manifest.
+  - Signature help walks the receiver chain so
+    `forms.Button(f):setText("|")` highlights the right argument.
+- Manifest discovery is tolerant of missing binaries: a manifest is
+  found even when `forms.so` / `forms.dll` hasn't been built yet, so
+  completion works on a clean checkout.
+
 ## 0.2.0 -- 2026-05-01
 
 ### Added

--- a/editors/vscode-cando/package.json
+++ b/editors/vscode-cando/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cando",
   "displayName": "CanDo Language",
   "description": "Syntax highlighting, snippets and IntelliSense for the CanDo scripting language (.cdo).",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "CandoProject",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "icons/cando.png",

--- a/editors/vscode-cando/package.json
+++ b/editors/vscode-cando/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cando",
   "displayName": "CanDo Language",
   "description": "Syntax highlighting, snippets and IntelliSense for the CanDo scripting language (.cdo).",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "CandoProject",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "icons/cando.png",

--- a/editors/vscode-cando/package.json
+++ b/editors/vscode-cando/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cando",
   "displayName": "CanDo Language",
   "description": "Syntax highlighting, snippets and IntelliSense for the CanDo scripting language (.cdo).",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "CandoProject",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "icons/cando.png",

--- a/editors/vscode-cando/package.json
+++ b/editors/vscode-cando/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cando",
   "displayName": "CanDo Language",
   "description": "Syntax highlighting, snippets and IntelliSense for the CanDo scripting language (.cdo).",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "CandoProject",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "icons/cando.png",
@@ -66,6 +66,16 @@
           "type": "boolean",
           "default": true,
           "description": "Include built-in standard library functions in completion suggestions."
+        },
+        "cando.completion.includePaths": {
+          "type": "boolean",
+          "default": true,
+          "description": "Suggest workspace files when typing a path inside an include(\"...\") call."
+        },
+        "cando.completion.crossFile": {
+          "type": "boolean",
+          "default": true,
+          "description": "Resolve include(\"./mod.cdo\") / .json bindings and offer their exports as member completions."
         },
         "cando.keywordCase": {
           "type": "string",

--- a/editors/vscode-cando/server/src/analyzer.ts
+++ b/editors/vscode-cando/server/src/analyzer.ts
@@ -3,7 +3,10 @@
  *   - top-level VAR / CONST / GLOBAL bindings (and bindings inside FUNCTION
  *     bodies for parameter / locals capture)
  *   - FUNCTION declarations (with parameter names)
- *   - CLASS declarations with their methods and fields
+ *   - CLASS declarations with their methods and fields. CanDo's class
+ *     statement is `CLASS Name [EXTENDS Parent] = [(params)] { body }`;
+ *     methods are typically attached afterwards via
+ *     `Name.method = FUNCTION(self) { ... }`. Both shapes are captured.
  *   - Object literals bound to top-level VAR/CONST/GLOBAL (for `name.member`
  *     completion)
  *   - `include("path")` bindings (for cross-file member completion)
@@ -182,27 +185,59 @@ export function analyze(tokens: Token[]): AnalysisResult {
         if (depth === 0 && isKw(tok, 'CLASS')) {
             const nameTok = t[i + 1];
             if (nameTok && nameTok.kind === 'ident') {
-                let detail = `CLASS ${nameTok.value}`;
                 let scan = i + 2;
-                if (isKw(t[i + 2], 'EXTENDS') && t[i + 3]?.kind === 'ident') {
-                    detail += ` EXTENDS ${t[i + 3].value}`;
-                    scan = i + 4;
+                let parent: string | undefined;
+                let detail = `CLASS ${nameTok.value}`;
+
+                if (isKw(t[scan], 'EXTENDS') && t[scan + 1]?.kind === 'ident') {
+                    parent = t[scan + 1].value;
+                    detail += ` EXTENDS ${parent}`;
+                    scan += 2;
                 }
-                const members = collectClassMembers(scan);
+
+                /* `=` is mandatory in the statement form. */
+                if (!isOp(t[scan], '=')) {
+                    /* Not a class declaration we recognise -- skip and keep
+                     * walking. */
+                    continue;
+                }
+                scan++;
+
+                /* Optional `(params)` for the constructor. */
+                let params: Symbol[] = [];
+                if (isPunct(t[scan], '(')) {
+                    const collected = collectParams(scan);
+                    params = collected.params;
+                    scan = collected.end + 1;
+                }
+
+                /* Mandatory `{ body }`. */
+                let bodyEnd = scan;
+                const fields: Symbol[] = [];
+                if (isPunct(t[scan], '{')) {
+                    fields.push(...collectSelfAssignments(scan));
+                    bodyEnd = skipBalanced(scan, '{', '}');
+                }
+
+                if (params.length) {
+                    detail += `(${params.map(p => p.name).join(', ')})`;
+                }
+
                 const sym: Symbol = {
                     name: nameTok.value,
                     kind: 'class',
                     range: nameTok.range,
                     selectionRange: nameTok.range,
                     detail,
-                    children: members
+                    children: [...params, ...fields],
+                    parameters: params.map(p => p.name)
                 };
                 symbols.push(sym);
                 if (!byName.has(sym.name)) byName.set(sym.name, sym);
-                /* Skip past the class body so its inner `{` doesn't confuse depth. */
-                if (isPunct(t[scan], '{')) {
-                    i = skipBalanced(scan, '{', '}') - 1;
-                }
+
+                /* Skip past the class body so its inner braces don't perturb
+                 * the depth tracker. */
+                i = bodyEnd - 1;
                 continue;
             }
         }
@@ -280,10 +315,12 @@ export function analyze(tokens: Token[]): AnalysisResult {
         }
     }
 
-    /* CLASS body member collection: starts at the `{` after the class header. */
-    function collectClassMembers(headerEnd: number): Symbol[] {
+    /* Collect `self.X = ...` patterns inside the constructor body to surface
+     * fields (and inline method assignments) on the class. */
+    function collectSelfAssignments(headerEnd: number): Symbol[] {
         const members: Symbol[] = [];
         if (!isPunct(t[headerEnd], '{')) return members;
+        const seen = new Set<string>();
 
         let j = headerEnd + 1;
         let d = 1;
@@ -292,54 +329,73 @@ export function analyze(tokens: Token[]): AnalysisResult {
             if (isPunct(tok, '{')) { d++; j++; continue; }
             if (isPunct(tok, '}')) { d--; j++; continue; }
 
-            if (d === 1) {
-                /* Optional STATIC / PRIVATE / ASYNC modifier prefix. */
-                let k = j;
-                while (isKw(t[k], 'STATIC', 'PRIVATE', 'ASYNC')) k++;
-
-                if (isKw(t[k], 'FUNCTION')) {
-                    const nameTok = t[k + 1];
-                    if (nameTok && nameTok.kind === 'ident') {
-                        const { params, end } = collectParams(k + 2);
-                        members.push({
-                            name: nameTok.value,
-                            kind: 'method',
-                            range: nameTok.range,
-                            selectionRange: nameTok.range,
-                            detail: `FUNCTION ${nameTok.value}(${params.map(p => p.name).join(', ')})`,
-                            children: params,
-                            parameters: params.map(p => p.name)
-                        });
-                        /* Skip the method body. */
-                        const bodyOpen = end + 1;
-                        if (isPunct(t[bodyOpen], '{')) {
-                            j = skipBalanced(bodyOpen, '{', '}');
-                            continue;
-                        }
-                        j = end + 1;
-                        continue;
-                    }
+            /* Look for `self.name = ...` or `self:name = ...` at any nesting
+             * level inside the constructor. Don't restrict by depth -- this
+             * is safe because we only key off the literal token sequence. */
+            if (
+                tok.kind === 'ident' && tok.value === 'self' &&
+                isOp(t[j + 1], '.') &&
+                t[j + 2]?.kind === 'ident' &&
+                isOp(t[j + 3], '=')
+            ) {
+                const fieldTok = t[j + 2];
+                if (!seen.has(fieldTok.value)) {
+                    seen.add(fieldTok.value);
+                    const isFn = isKw(t[j + 4], 'FUNCTION');
+                    members.push({
+                        name: fieldTok.value,
+                        kind: isFn ? 'method' : 'field',
+                        range: fieldTok.range,
+                        selectionRange: fieldTok.range,
+                        detail: isFn ? `self.${fieldTok.value}(...)` : `self.${fieldTok.value}`
+                    });
                 }
-                if (isKw(t[k], 'VAR', 'CONST', 'GLOBAL')) {
-                    const nameTok = t[k + 1];
-                    if (nameTok && nameTok.kind === 'ident') {
-                        members.push({
-                            name: nameTok.value,
-                            kind: 'field',
-                            range: nameTok.range,
-                            selectionRange: nameTok.range,
-                            detail: `${t[k].value.toUpperCase()} ${nameTok.value}`
-                        });
-                        /* Advance past the declaration so we don't re-enter
-                         * on the same VAR after a STATIC/PRIVATE prefix. */
-                        j = k + 2;
-                        continue;
-                    }
-                }
+                j += 4;
+                continue;
             }
             j++;
         }
         return members;
+    }
+
+    /* Second pass: methods are usually attached to a class *after* its body
+     * via `Name.method = FUNCTION(...) { ... }`. Walk the whole token stream
+     * once more and add those to the class symbol's children. */
+    const classByName = new Map<string, Symbol>();
+    for (const s of symbols) if (s.kind === 'class') classByName.set(s.name, s);
+
+    if (classByName.size > 0) {
+        for (let i = 0; i < t.length; i++) {
+            const head = t[i];
+            if (head.kind !== 'ident') continue;
+            const cls = classByName.get(head.value);
+            if (!cls) continue;
+            if (!isOp(t[i + 1], '.')) continue;
+            const memberTok = t[i + 2];
+            if (memberTok?.kind !== 'ident') continue;
+            if (!isOp(t[i + 3], '=')) continue;
+
+            if (cls.children?.some(c => c.name === memberTok.value)) continue;
+
+            const isFn = isKw(t[i + 4], 'FUNCTION');
+            let params: Symbol[] = [];
+            let detail = isFn ? `${cls.name}.${memberTok.value}(...)` : `${cls.name}.${memberTok.value}`;
+            if (isFn && isPunct(t[i + 5], '(')) {
+                const collected = collectParams(i + 5);
+                params = collected.params;
+                detail = `${cls.name}.${memberTok.value}(${params.map(p => p.name).join(', ')})`;
+            }
+            const child: Symbol = {
+                name: memberTok.value,
+                kind: isFn ? 'method' : 'field',
+                range: memberTok.range,
+                selectionRange: memberTok.range,
+                detail,
+                children: params,
+                parameters: isFn ? params.map(p => p.name) : undefined
+            };
+            (cls.children ??= []).push(child);
+        }
     }
 
     return { symbols, byName, includes, objectLiterals, moduleExports };

--- a/editors/vscode-cando/server/src/analyzer.ts
+++ b/editors/vscode-cando/server/src/analyzer.ts
@@ -1,8 +1,13 @@
 /*
  * Walk a token stream from the lexer and produce a lightweight symbol table:
- *   - top-level VAR / CONST / GLOBAL bindings
+ *   - top-level VAR / CONST / GLOBAL bindings (and bindings inside FUNCTION
+ *     bodies for parameter / locals capture)
  *   - FUNCTION declarations (with parameter names)
- *   - CLASS declarations
+ *   - CLASS declarations with their methods and fields
+ *   - Object literals bound to top-level VAR/CONST/GLOBAL (for `name.member`
+ *     completion)
+ *   - `include("path")` bindings (for cross-file member completion)
+ *   - Module exports via a top-level `RETURN { ... }` literal
  *
  * This is intentionally shallow -- enough to drive completion, document
  * symbols and go-to-definition, not enough to be a real semantic analyzer.
@@ -10,7 +15,7 @@
 
 import { Token, Range } from './lexer';
 
-export type SymbolKind = 'function' | 'class' | 'variable' | 'constant' | 'parameter';
+export type SymbolKind = 'function' | 'class' | 'variable' | 'constant' | 'parameter' | 'method' | 'field';
 
 export interface Symbol {
     name: string;
@@ -19,110 +24,323 @@ export interface Symbol {
     selectionRange: Range; /* same as range; kept separate to mirror LSP */
     detail?: string;
     children?: Symbol[];
+    parameters?: string[]; /* for functions / methods */
+}
+
+export interface IncludeBinding {
+    /* The path string with quotes already stripped. */
+    path: string;
+    /* The string token's range, useful for hover / goto. */
+    range: Range;
 }
 
 export interface AnalysisResult {
     symbols: Symbol[];
     /* Flat name -> first occurrence map for goto-def. */
     byName: Map<string, Symbol>;
+    /* `VAR/CONST/GLOBAL name = include("path")` bindings. */
+    includes: Map<string, IncludeBinding>;
+    /* `VAR/CONST/GLOBAL name = { a: ..., b: ... }` -- captured top-level keys. */
+    objectLiterals: Map<string, string[]>;
+    /* Object literal keys from the last top-level `RETURN { ... }` statement,
+     * used to surface a module's exports to its callers. */
+    moduleExports: string[];
 }
 
 export function analyze(tokens: Token[]): AnalysisResult {
     const symbols: Symbol[] = [];
     const byName = new Map<string, Symbol>();
-    const idents: Token[] = tokens.filter(t => t.kind !== 'comment');
+    const includes = new Map<string, IncludeBinding>();
+    const objectLiterals = new Map<string, string[]>();
+    let moduleExports: string[] = [];
 
-    const isKw = (t: Token | undefined, ...names: string[]): boolean => {
-        if (!t || t.kind !== 'keyword') return false;
-        const v = t.value;
+    /* Filter out comments and newlines so the index-arithmetic below is
+     * straightforward. Strings, numbers and template-strings are kept so
+     * we can read RHS values. */
+    const t: Token[] = tokens.filter(x => x.kind !== 'comment' && x.kind !== 'newline');
+
+    const isKw = (tok: Token | undefined, ...names: string[]): boolean => {
+        if (!tok || tok.kind !== 'keyword') return false;
+        const v = tok.value;
         return names.some(n => v === n || v === n.toLowerCase());
     };
+    const isPunct = (tok: Token | undefined, v: string): boolean =>
+        !!tok && tok.kind === 'punct' && tok.value === v;
+    const isOp = (tok: Token | undefined, v: string): boolean =>
+        !!tok && tok.kind === 'op' && tok.value === v;
+
+    /* ---------------------------------------------------------------
+     * Helpers
+     * ------------------------------------------------------------- */
+
+    /* Skip a balanced bracket starting at `from` (inclusive of opening token).
+     * Returns the index just past the closing bracket, or t.length if EOF. */
+    function skipBalanced(from: number, open: string, close: string): number {
+        let depth = 0;
+        let j = from;
+        while (j < t.length) {
+            if (isPunct(t[j], open)) depth++;
+            else if (isPunct(t[j], close)) {
+                depth--;
+                if (depth === 0) return j + 1;
+            }
+            j++;
+        }
+        return j;
+    }
+
+    /* Strip surrounding quote characters from a string token's raw value. */
+    function unquote(raw: string): string {
+        if (raw.length >= 2) {
+            const a = raw[0];
+            const b = raw[raw.length - 1];
+            if ((a === '"' || a === '\'' || a === '`') && a === b) {
+                return raw.slice(1, -1);
+            }
+        }
+        return raw;
+    }
+
+    /* Collect identifier keys from an object literal whose opening `{` is at
+     * index `start`. Returns the keys and the index just past `}`. */
+    function collectObjectKeys(start: number): { keys: string[]; end: number } {
+        const keys: string[] = [];
+        if (!isPunct(t[start], '{')) return { keys, end: start };
+        let j = start + 1;
+        let depth = 1;
+        while (j < t.length && depth > 0) {
+            const tok = t[j];
+            if (isPunct(tok, '{')) { depth++; j++; continue; }
+            if (isPunct(tok, '}')) { depth--; j++; continue; }
+            if (isPunct(tok, '[')) { j = skipBalanced(j, '[', ']'); continue; }
+            if (isPunct(tok, '(')) { j = skipBalanced(j, '(', ')'); continue; }
+            /* Only collect identifiers at the literal's top level. */
+            if (depth === 1 && (tok.kind === 'ident' || tok.kind === 'keyword')) {
+                const next = t[j + 1];
+                if (isOp(next, ':')) {
+                    keys.push(tok.value);
+                }
+            }
+            /* Quoted string keys: `"foo": ...` */
+            if (depth === 1 && tok.kind === 'string') {
+                const next = t[j + 1];
+                if (isOp(next, ':')) {
+                    const k = unquote(tok.value);
+                    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) keys.push(k);
+                }
+            }
+            j++;
+        }
+        return { keys, end: j };
+    }
+
+    /* Collect parameters between `(` at idx and matching `)`. Returns names
+     * and the index of the closing paren (or last index if unbalanced). */
+    function collectParams(openIdx: number): { params: Symbol[]; end: number } {
+        const params: Symbol[] = [];
+        if (!isPunct(t[openIdx], '(')) return { params, end: openIdx };
+        let j = openIdx + 1;
+        let depth = 1;
+        while (j < t.length && depth > 0) {
+            const tok = t[j];
+            if (isPunct(tok, '(')) depth++;
+            else if (isPunct(tok, ')')) {
+                depth--;
+                if (depth === 0) break;
+            }
+            else if (depth === 1 && tok.kind === 'ident') {
+                /* Only the first identifier in each comma-separated slot,
+                 * to skip default-value expressions. */
+                const prev = t[j - 1];
+                if (isPunct(prev, '(') || isPunct(prev, ',')) {
+                    params.push({
+                        name: tok.value,
+                        kind: 'parameter',
+                        range: tok.range,
+                        selectionRange: tok.range
+                    });
+                }
+            }
+            j++;
+        }
+        return { params, end: j };
+    }
+
+    /* ---------------------------------------------------------------
+     * Walk tokens
+     * ------------------------------------------------------------- */
 
     let depth = 0;
 
-    for (let i = 0; i < idents.length; i++) {
-        const t = idents[i];
+    for (let i = 0; i < t.length; i++) {
+        const tok = t[i];
 
-        if (t.kind === 'punct' && t.value === '{') depth++;
-        else if (t.kind === 'punct' && t.value === '}') depth = Math.max(0, depth - 1);
+        if (isPunct(tok, '{')) { depth++; continue; }
+        if (isPunct(tok, '}')) { depth = Math.max(0, depth - 1); continue; }
 
-        if (depth !== 0) continue;
-
-        // FUNCTION name(args)
-        if (isKw(t, 'FUNCTION')) {
-            const nameTok = idents[i + 1];
+        /* CLASS body capture happens regardless of depth (handled inline). */
+        if (depth === 0 && isKw(tok, 'CLASS')) {
+            const nameTok = t[i + 1];
             if (nameTok && nameTok.kind === 'ident') {
-                const params: Symbol[] = [];
-                // collect parameters between ( and )
-                let j = i + 2;
-                if (idents[j]?.value === '(') {
-                    j++;
-                    while (j < idents.length && idents[j].value !== ')') {
-                        const p = idents[j];
-                        if (p.kind === 'ident') {
-                            params.push({
-                                name: p.value,
-                                kind: 'parameter',
-                                range: p.range,
-                                selectionRange: p.range
-                            });
-                        }
-                        j++;
-                    }
+                let detail = `CLASS ${nameTok.value}`;
+                let scan = i + 2;
+                if (isKw(t[i + 2], 'EXTENDS') && t[i + 3]?.kind === 'ident') {
+                    detail += ` EXTENDS ${t[i + 3].value}`;
+                    scan = i + 4;
                 }
+                const members = collectClassMembers(scan);
+                const sym: Symbol = {
+                    name: nameTok.value,
+                    kind: 'class',
+                    range: nameTok.range,
+                    selectionRange: nameTok.range,
+                    detail,
+                    children: members
+                };
+                symbols.push(sym);
+                if (!byName.has(sym.name)) byName.set(sym.name, sym);
+                /* Skip past the class body so its inner `{` doesn't confuse depth. */
+                if (isPunct(t[scan], '{')) {
+                    i = skipBalanced(scan, '{', '}') - 1;
+                }
+                continue;
+            }
+        }
+
+        /* Top-level FUNCTION declarations only -- methods are caught above. */
+        if (depth === 0 && isKw(tok, 'FUNCTION')) {
+            const nameTok = t[i + 1];
+            if (nameTok && nameTok.kind === 'ident') {
+                const { params, end } = collectParams(i + 2);
                 const sym: Symbol = {
                     name: nameTok.value,
                     kind: 'function',
                     range: nameTok.range,
                     selectionRange: nameTok.range,
                     detail: `FUNCTION ${nameTok.value}(${params.map(p => p.name).join(', ')})`,
-                    children: params
+                    children: params,
+                    parameters: params.map(p => p.name)
                 };
                 symbols.push(sym);
                 if (!byName.has(sym.name)) byName.set(sym.name, sym);
+                i = end;
                 continue;
             }
         }
 
-        // CLASS Name [EXTENDS Parent]
-        if (isKw(t, 'CLASS')) {
-            const nameTok = idents[i + 1];
+        /* VAR / CONST / GLOBAL name [= rhs] */
+        if (depth === 0 && isKw(tok, 'VAR', 'CONST', 'GLOBAL')) {
+            const nameTok = t[i + 1];
             if (nameTok && nameTok.kind === 'ident') {
-                let detail = `CLASS ${nameTok.value}`;
-                if (isKw(idents[i + 2], 'EXTENDS') && idents[i + 3]?.kind === 'ident') {
-                    detail += ` EXTENDS ${idents[i + 3].value}`;
-                }
-                const sym: Symbol = {
-                    name: nameTok.value,
-                    kind: 'class',
-                    range: nameTok.range,
-                    selectionRange: nameTok.range,
-                    detail
-                };
-                symbols.push(sym);
-                if (!byName.has(sym.name)) byName.set(sym.name, sym);
-                continue;
-            }
-        }
-
-        // VAR / CONST / GLOBAL name
-        if (isKw(t, 'VAR', 'CONST', 'GLOBAL')) {
-            const nameTok = idents[i + 1];
-            if (nameTok && nameTok.kind === 'ident') {
-                const kind: SymbolKind = isKw(t, 'CONST') ? 'constant' : 'variable';
+                const kind: SymbolKind = isKw(tok, 'CONST') ? 'constant' : 'variable';
                 const sym: Symbol = {
                     name: nameTok.value,
                     kind,
                     range: nameTok.range,
                     selectionRange: nameTok.range,
-                    detail: `${t.value.toUpperCase()} ${nameTok.value}`
+                    detail: `${tok.value.toUpperCase()} ${nameTok.value}`
                 };
                 symbols.push(sym);
                 if (!byName.has(sym.name)) byName.set(sym.name, sym);
+
+                /* Inspect the RHS for include() / object-literal bindings. */
+                if (isOp(t[i + 2], '=')) {
+                    const rhs = i + 3;
+                    /* include("path") */
+                    if (
+                        t[rhs]?.kind === 'ident' &&
+                        t[rhs]?.value === 'include' &&
+                        isPunct(t[rhs + 1], '(') &&
+                        t[rhs + 2]?.kind === 'string'
+                    ) {
+                        const strTok = t[rhs + 2]!;
+                        includes.set(nameTok.value, {
+                            path: unquote(strTok.value),
+                            range: strTok.range
+                        });
+                    }
+                    /* { a: 1, b: 2 } */
+                    if (isPunct(t[rhs], '{')) {
+                        const { keys } = collectObjectKeys(rhs);
+                        if (keys.length) objectLiterals.set(nameTok.value, keys);
+                    }
+                }
+                continue;
+            }
+        }
+
+        /* Top-level `RETURN { ... }` -- capture as module exports. */
+        if (depth === 0 && isKw(tok, 'RETURN')) {
+            if (isPunct(t[i + 1], '{')) {
+                const { keys, end } = collectObjectKeys(i + 1);
+                if (keys.length) moduleExports = keys;
+                i = end - 1;
                 continue;
             }
         }
     }
 
-    return { symbols, byName };
+    /* CLASS body member collection: starts at the `{` after the class header. */
+    function collectClassMembers(headerEnd: number): Symbol[] {
+        const members: Symbol[] = [];
+        if (!isPunct(t[headerEnd], '{')) return members;
+
+        let j = headerEnd + 1;
+        let d = 1;
+        while (j < t.length && d > 0) {
+            const tok = t[j];
+            if (isPunct(tok, '{')) { d++; j++; continue; }
+            if (isPunct(tok, '}')) { d--; j++; continue; }
+
+            if (d === 1) {
+                /* Optional STATIC / PRIVATE / ASYNC modifier prefix. */
+                let k = j;
+                while (isKw(t[k], 'STATIC', 'PRIVATE', 'ASYNC')) k++;
+
+                if (isKw(t[k], 'FUNCTION')) {
+                    const nameTok = t[k + 1];
+                    if (nameTok && nameTok.kind === 'ident') {
+                        const { params, end } = collectParams(k + 2);
+                        members.push({
+                            name: nameTok.value,
+                            kind: 'method',
+                            range: nameTok.range,
+                            selectionRange: nameTok.range,
+                            detail: `FUNCTION ${nameTok.value}(${params.map(p => p.name).join(', ')})`,
+                            children: params,
+                            parameters: params.map(p => p.name)
+                        });
+                        /* Skip the method body. */
+                        const bodyOpen = end + 1;
+                        if (isPunct(t[bodyOpen], '{')) {
+                            j = skipBalanced(bodyOpen, '{', '}');
+                            continue;
+                        }
+                        j = end + 1;
+                        continue;
+                    }
+                }
+                if (isKw(t[k], 'VAR', 'CONST', 'GLOBAL')) {
+                    const nameTok = t[k + 1];
+                    if (nameTok && nameTok.kind === 'ident') {
+                        members.push({
+                            name: nameTok.value,
+                            kind: 'field',
+                            range: nameTok.range,
+                            selectionRange: nameTok.range,
+                            detail: `${t[k].value.toUpperCase()} ${nameTok.value}`
+                        });
+                        /* Advance past the declaration so we don't re-enter
+                         * on the same VAR after a STATIC/PRIVATE prefix. */
+                        j = k + 2;
+                        continue;
+                    }
+                }
+            }
+            j++;
+        }
+        return members;
+    }
+
+    return { symbols, byName, includes, objectLiterals, moduleExports };
 }

--- a/editors/vscode-cando/server/src/builtins.ts
+++ b/editors/vscode-cando/server/src/builtins.ts
@@ -14,12 +14,17 @@ export interface BuiltinInfo {
     name: string;
     detail: string;
     doc: string;
+    /** Optional snippet body. When present, completion inserts this and
+     * positions the cursor between the parens / args. */
+    snippet?: string;
 }
 
 export interface NamespaceInfo {
     name: string;
     doc: string;
     members: string[];
+    /** Per-member detail (signature) shown in completion / hover. */
+    memberDetails?: Record<string, string>;
 }
 
 export const KEYWORDS_UPPER: KeywordInfo[] = [
@@ -60,20 +65,59 @@ export const PIPE_KEYWORD: KeywordInfo = {
 };
 
 export const GLOBAL_BUILTINS: BuiltinInfo[] = [
-    { name: 'print',    detail: 'print(...args)',     doc: 'Write space-separated args to stdout, followed by a newline. Arrays are expanded element-by-element.' },
-    { name: 'type',     detail: 'type(value)',        doc: 'Return the type name of `value` as a string. Honours an object\'s `__type` metafield.' },
-    { name: 'toString', detail: 'toString(value)',    doc: 'Return the string form of `value`.' },
-    { name: 'inspect',  detail: 'inspect(value)',     doc: 'Return a debug representation of `value`, including object internals.' }
+    { name: 'print',    detail: 'print(...args)',     doc: 'Write space-separated args to stdout, followed by a newline. Arrays are expanded element-by-element.', snippet: 'print($0)' },
+    { name: 'type',     detail: 'type(value)',        doc: 'Return the type name of `value` as a string. Honours an object\'s `__type` metafield.', snippet: 'type($0)' },
+    { name: 'toString', detail: 'toString(value)',    doc: 'Return the string form of `value`.', snippet: 'toString($0)' },
+    { name: 'inspect',  detail: 'inspect(value)',     doc: 'Return a debug representation of `value`, including object internals.', snippet: 'inspect($0)' },
+    {
+        name: 'include',
+        detail: 'include(path) -> value',
+        doc:
+            'Load and cache a module by path.\n\n' +
+            'Accepts `.cdo` source files, binary extensions (`.so` / `.dylib` / `.dll`), ' +
+            'or data files (`.json` / `.csv` / `.yaml` / `.yml`). With no extension, ' +
+            'the runtime probes `.so → .dylib → .dll → .cdo` in order.\n\n' +
+            'Relative paths resolve from the calling script\'s directory and walk up to the ' +
+            'process working directory. The first call executes/parses the module and caches ' +
+            'the result; subsequent calls return the cached value (Node.js `require` semantics).',
+        snippet: 'include("$0")'
+    }
 ];
 
 export const NAMESPACES: NamespaceInfo[] = [
     {
         name: 'array', doc: 'Array helpers (mostly chainable via the `:` method syntax).',
-        members: ['copy', 'filter', 'length', 'map', 'pop', 'push', 'reduce', 'remove', 'splice']
+        members: ['copy', 'filter', 'length', 'map', 'pop', 'push', 'reduce', 'remove', 'splice'],
+        memberDetails: {
+            copy:   'array.copy(arr) -> array',
+            filter: 'array.filter(arr, fn) -> array',
+            length: 'array.length(arr) -> number',
+            map:    'array.map(arr, fn) -> array',
+            pop:    'array.pop(arr) -> value',
+            push:   'array.push(arr, value)',
+            reduce: 'array.reduce(arr, fn, init) -> value',
+            remove: 'array.remove(arr, index) -> value',
+            splice: 'array.splice(arr, start, count, ...inserts) -> array'
+        }
     },
     {
         name: 'string', doc: 'String helpers.',
-        members: ['char', 'chars', 'find', 'format', 'left', 'length', 'match', 'repeat', 'replace', 'right', 'split', 'sub', 'trim']
+        members: ['char', 'chars', 'find', 'format', 'left', 'length', 'match', 'repeat', 'replace', 'right', 'split', 'sub', 'trim'],
+        memberDetails: {
+            char:    'string.char(str, index) -> string',
+            chars:   'string.chars(str) -> array',
+            find:    'string.find(str, needle [, from]) -> number',
+            format:  'string.format(fmt, ...args) -> string',
+            left:    'string.left(str, n) -> string',
+            length:  'string.length(str) -> number',
+            match:   'string.match(str, pattern) -> array',
+            repeat:  'string.repeat(str, n) -> string',
+            replace: 'string.replace(str, find, repl) -> string',
+            right:   'string.right(str, n) -> string',
+            split:   'string.split(str, sep) -> array',
+            sub:     'string.sub(str, start [, end]) -> string',
+            trim:    'string.trim(str) -> string'
+        }
     },
     {
         name: 'math', doc: 'Math functions and constants.',
@@ -82,7 +126,21 @@ export const NAMESPACES: NamespaceInfo[] = [
             'floor', 'log', 'max', 'min', 'pow', 'rad', 'random', 'round', 'sign', 'sin',
             'sinh', 'sqrt', 'tan',
             'pi', 'tau', 'e', 'huge'
-        ]
+        ],
+        memberDetails: {
+            abs:    'math.abs(x) -> number',
+            clamp:  'math.clamp(x, lo, hi) -> number',
+            max:    'math.max(...nums) -> number',
+            min:    'math.min(...nums) -> number',
+            pow:    'math.pow(x, y) -> number',
+            random: 'math.random([lo, hi]) -> number',
+            round:  'math.round(x) -> number',
+            sqrt:   'math.sqrt(x) -> number',
+            pi:     'math.pi (constant)',
+            tau:    'math.tau (constant)',
+            e:      'math.e (constant)',
+            huge:   'math.huge (constant)'
+        }
     },
     {
         name: 'json', doc: 'JSON encoder / decoder.',
@@ -148,6 +206,14 @@ export const NAMESPACES: NamespaceInfo[] = [
 
 export function namespaceByName(name: string): NamespaceInfo | undefined {
     return NAMESPACES.find(ns => ns.name === name);
+}
+
+export function namespaceMemberDetail(ns: NamespaceInfo, member: string): string | undefined {
+    return ns.memberDetails?.[member];
+}
+
+export function builtinByName(name: string): BuiltinInfo | undefined {
+    return GLOBAL_BUILTINS.find(b => b.name === name);
 }
 
 export function isKeywordUpper(name: string): boolean {

--- a/editors/vscode-cando/server/src/crossfile.ts
+++ b/editors/vscode-cando/server/src/crossfile.ts
@@ -1,0 +1,100 @@
+/*
+ * Resolve `include("...")` arguments and harvest the exported member names
+ * of the included file so that `name.member` completion can offer them.
+ *
+ * Supported sources:
+ *   - .cdo  : lexed and analyzed; the keys of the top-level `RETURN { ... }`
+ *             statement are returned. If there is no such statement we fall
+ *             back to top-level VAR / CONST / GLOBAL / FUNCTION names.
+ *   - .json : parsed; top-level object keys are returned.
+ *   - .yaml / .yml / .csv / .so / .dylib / .dll : skipped (no static
+ *             introspection possible).
+ *
+ * Results are cached per absolute path with the file's mtime so an edit to
+ * the included module invalidates the cache automatically.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { Lexer } from './lexer';
+import { analyze } from './analyzer';
+import { resolveIncludePath } from './paths';
+
+interface CacheEntry {
+    members: string[];
+    mtimeMs: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export interface IncludeExports {
+    members: string[];
+    /* Resolved absolute path; useful for hover / diagnostics. */
+    path: string;
+}
+
+export function getIncludeExports(
+    rawPath: string,
+    documentUri: string,
+    workspaceRoots: string[]
+): IncludeExports | null {
+    const abs = resolveIncludePath(rawPath, documentUri, workspaceRoots);
+    if (!abs) return null;
+
+    let mtimeMs = 0;
+    try {
+        mtimeMs = fs.statSync(abs).mtimeMs;
+    } catch {
+        return null;
+    }
+
+    const cached = cache.get(abs);
+    if (cached && cached.mtimeMs === mtimeMs) {
+        return { members: cached.members, path: abs };
+    }
+
+    const members = readMembers(abs);
+    cache.set(abs, { members, mtimeMs });
+    return { members, path: abs };
+}
+
+function readMembers(abs: string): string[] {
+    const ext = path.extname(abs).toLowerCase();
+    let text: string;
+    try {
+        text = fs.readFileSync(abs, 'utf8');
+    } catch {
+        return [];
+    }
+
+    if (ext === '.cdo') {
+        const tokens = new Lexer(text).tokenize();
+        const result = analyze(tokens);
+        if (result.moduleExports.length) return dedupe(result.moduleExports);
+        /* Fallback: surface the module's top-level declarations. */
+        return dedupe(result.symbols.map(s => s.name));
+    }
+
+    if (ext === '.json') {
+        try {
+            const parsed = JSON.parse(text);
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                return Object.keys(parsed);
+            }
+        } catch { /* fallthrough */ }
+        return [];
+    }
+
+    return [];
+}
+
+function dedupe(xs: string[]): string[] {
+    return [...new Set(xs)];
+}
+
+/** Test hook: drop the cache (used to keep memory bounded across very long
+ * sessions). Currently unused. */
+export function clearCrossFileCache(): void {
+    cache.clear();
+}

--- a/editors/vscode-cando/server/src/manifest.ts
+++ b/editors/vscode-cando/server/src/manifest.ts
@@ -58,7 +58,10 @@ export interface MemberSpec {
     /* Type of the value (for non-function members) or member-of relationship. */
     type?: string;
     params?: Param[];
-    /* Function/method return type; defaults to `void` if absent on a function. */
+    /* Function/method return type; defaults to `void` if absent on a
+     * function. Special value `"self"` (or `"this"`) means the method
+     * returns its receiver's type, which is how fluent chaining like
+     * `f:setText("hi"):center()` keeps its type. */
     returns?: string;
     doc?: string;
     /* Aliases that resolve to the same spec (`SetText` -> `setText` etc.). */
@@ -126,8 +129,10 @@ export function loadManifestFile(filePath: string): Manifest | null {
         }
     } catch (e) {
         /* Don't let a malformed manifest break completion for the rest of
-         * the workspace. */
-        console.warn(`[cando] failed to load manifest ${filePath}: ${(e as Error).message}`);
+         * the workspace. We swallow the error silently rather than
+         * console.warn to avoid noise in the language-server output --
+         * the editor's diagnostics layer is the right place to surface
+         * authoring problems if we ever want to. */
         manifest = null;
     }
 

--- a/editors/vscode-cando/server/src/manifest.ts
+++ b/editors/vscode-cando/server/src/manifest.ts
@@ -1,0 +1,209 @@
+/*
+ * Module manifests (`cando.api.json`).
+ *
+ * A manifest sits next to a binary or .cdo module and describes the value
+ * the module returns from `include(...)`. The language server reads it to
+ * power completion, hover and signature help on values that the runtime
+ * itself can't be introspected (binary `.so`/`.dll` modules) or to
+ * supplement what's visible in source (`.cdo` modules with native-style
+ * sub-objects).
+ *
+ * Schema -- see `docs/cando-api-manifest.md` for the long form.
+ *
+ *   {
+ *     "name":    "forms",
+ *     "version": "1.0.0",
+ *     "doc":     "Native UI toolkit.",
+ *     "exports": {                       // the value `include(...)` returns
+ *       "VERSION":       { "kind": "value", "type": "string" },
+ *       "Button":        { "kind": "function",
+ *                          "params": [{ "name": "parent", "type": "Control" }],
+ *                          "returns": "Button" }
+ *     },
+ *     "types": {
+ *       "Control": {                     // base class for every widget
+ *         "doc":     "Common UI control surface.",
+ *         "members": { "setText": { ... }, ... }
+ *       },
+ *       "Button": {
+ *         "extends": "Control",          // semantic inheritance
+ *         "indexes": ["Control"],        // mirrors the runtime's __index chain;
+ *                                        // accepts an array for multiple parents
+ *         "members": { "onClick": { "kind": "event", "signature": "function(self)" } }
+ *       }
+ *     }
+ *   }
+ *
+ * `extends` and `indexes` are equivalent for completion / hover purposes;
+ * they exist as separate fields so a manifest can mirror the runtime's
+ * actual prototype-chain wiring (CanDo objects inherit through a `__index`
+ * field) without losing the conceptual `extends` relation between types.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface Param {
+    name: string;
+    type?: string;
+    optional?: boolean;
+    rest?: boolean;
+    doc?: string;
+}
+
+export type MemberKind = 'function' | 'value' | 'event' | 'constant';
+
+export interface MemberSpec {
+    kind?: MemberKind;
+    /* Type of the value (for non-function members) or member-of relationship. */
+    type?: string;
+    params?: Param[];
+    /* Function/method return type; defaults to `void` if absent on a function. */
+    returns?: string;
+    doc?: string;
+    /* Aliases that resolve to the same spec (`SetText` -> `setText` etc.). */
+    aliases?: string[];
+    /* Hand-written event signature, e.g. "function(self, x, y)". */
+    signature?: string;
+    /* When true the member is a method called via `:` syntax; the first
+     * param is implicit `self`. Inferred from the manifest when omitted. */
+    self?: boolean;
+}
+
+export interface TypeDef {
+    doc?: string;
+    /* A single parent type. The whole chain is included in completion. */
+    extends?: string;
+    /* Prototype-chain parents (`__index` value at runtime). Either a single
+     * type name or an array of them. Equivalent to `extends` for typing
+     * purposes, kept distinct so manifests can mirror runtime layout. */
+    indexes?: string | string[];
+    members: Record<string, MemberSpec>;
+}
+
+export interface Manifest {
+    /* Logical module name (typically the directory name). */
+    name: string;
+    version?: string;
+    doc?: string;
+    /* Shape of the value `include("…")` returns for this module. */
+    exports: Record<string, MemberSpec>;
+    types?: Record<string, TypeDef>;
+}
+
+/* -------------------------------------------------------------------------
+ * Loading + caching
+ * ----------------------------------------------------------------------- */
+
+interface CacheEntry {
+    manifest: Manifest | null;
+    mtimeMs: number;
+}
+
+const fileCache = new Map<string, CacheEntry>();
+
+/**
+ * Read and parse the manifest at `filePath`. Cached by mtime; a corrupt
+ * file produces a one-time console warning and is treated as missing.
+ */
+export function loadManifestFile(filePath: string): Manifest | null {
+    let mtimeMs = 0;
+    try {
+        mtimeMs = fs.statSync(filePath).mtimeMs;
+    } catch {
+        fileCache.delete(filePath);
+        return null;
+    }
+    const cached = fileCache.get(filePath);
+    if (cached && cached.mtimeMs === mtimeMs) return cached.manifest;
+
+    let manifest: Manifest | null = null;
+    try {
+        const raw = fs.readFileSync(filePath, 'utf8');
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && parsed.exports && typeof parsed.exports === 'object') {
+            manifest = parsed as Manifest;
+        }
+    } catch (e) {
+        /* Don't let a malformed manifest break completion for the rest of
+         * the workspace. */
+        console.warn(`[cando] failed to load manifest ${filePath}: ${(e as Error).message}`);
+        manifest = null;
+    }
+
+    fileCache.set(filePath, { manifest, mtimeMs });
+    return manifest;
+}
+
+/**
+ * Walk the directory of `modulePath` and find a `cando.api.json` (or a
+ * sibling `<basename>.api.json`) describing it. Returns null if none is
+ * present.
+ *
+ * The runtime's include() always returns a single value, so a per-module
+ * manifest is the natural unit. We probe in this order:
+ *   - `<dir>/<basename>.api.json` (lets one folder host several modules)
+ *   - `<dir>/cando.api.json`      (the recommended default)
+ */
+export function findManifestFor(modulePath: string): Manifest | null {
+    const dir = path.dirname(modulePath);
+    const base = path.basename(modulePath, path.extname(modulePath));
+
+    const candidates = [
+        path.join(dir, base + '.api.json'),
+        path.join(dir, 'cando.api.json')
+    ];
+    for (const c of candidates) {
+        const m = loadManifestFile(c);
+        if (m) return m;
+    }
+    return null;
+}
+
+/* -------------------------------------------------------------------------
+ * Type-walk helpers
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Resolve every member visible on `typeName` within `manifest`, including
+ * those inherited via `extends` and `indexes`. Closer definitions win;
+ * cycles short-circuit.
+ */
+export function resolveTypeMembers(
+    manifest: Manifest,
+    typeName: string
+): Map<string, MemberSpec> {
+    const out = new Map<string, MemberSpec>();
+    const seen = new Set<string>();
+    const visit = (name: string): void => {
+        if (seen.has(name)) return;
+        seen.add(name);
+        const def = manifest.types?.[name];
+        if (!def) return;
+        /* Walk parents first so closer (more-specific) definitions overwrite. */
+        if (def.extends) visit(def.extends);
+        if (def.indexes) {
+            const list = Array.isArray(def.indexes) ? def.indexes : [def.indexes];
+            for (const parent of list) visit(parent);
+        }
+        for (const [memberName, spec] of Object.entries(def.members ?? {})) {
+            out.set(memberName, spec);
+            for (const alias of spec.aliases ?? []) out.set(alias, spec);
+        }
+    };
+    visit(typeName);
+    return out;
+}
+
+/**
+ * Same as resolveTypeMembers but for the manifest's top-level exports.
+ * (Exports don't inherit from anything, but we still expand aliases.)
+ */
+export function resolveExportMembers(manifest: Manifest): Map<string, MemberSpec> {
+    const out = new Map<string, MemberSpec>();
+    for (const [name, spec] of Object.entries(manifest.exports ?? {})) {
+        out.set(name, spec);
+        for (const alias of spec.aliases ?? []) out.set(alias, spec);
+    }
+    return out;
+}

--- a/editors/vscode-cando/server/src/paths.ts
+++ b/editors/vscode-cando/server/src/paths.ts
@@ -1,0 +1,286 @@
+/*
+ * Filesystem-aware completion helpers for `include(...)` strings.
+ *
+ * CanDo's include() resolver (source/lib/include.c) accepts:
+ *   - .cdo, .json, .csv, .yaml, .yml  (data / source modules)
+ *   - .so, .dylib, .dll                (binary modules)
+ *   - bare paths with no extension     (probed in the order so → dylib → dll → cdo)
+ *
+ * Resolution starts in the calling script's directory and walks up to the
+ * process cwd. We mirror that on the editor side: we look in the document's
+ * directory first and then its ancestors, stopping at the workspace root
+ * (or the filesystem root if no workspace is open).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { CompletionItem, CompletionItemKind, InsertReplaceEdit, Range as LspRange } from 'vscode-languageserver/node';
+
+const INCLUDABLE_EXT = new Set([
+    '.cdo', '.json', '.csv', '.yaml', '.yml',
+    '.so', '.dylib', '.dll'
+]);
+
+export interface IncludeStringContext {
+    /* Text the user has already typed inside the quotes, up to the cursor. */
+    typed: string;
+    /* The opening quote character. */
+    quote: string;
+    /* Range in the document covering `typed` (so completions can replace it
+     * cleanly when the user is editing in the middle of a path). */
+    range: LspRange;
+}
+
+/**
+ * If `offset` falls inside the string argument of an `include(...)` call,
+ * return a context describing what the user has typed so far. Otherwise
+ * `null`.
+ *
+ * The detection is intentionally permissive: we walk backwards from the
+ * cursor across plain string content, then expect `("` or `('` and the bare
+ * word `include` immediately before that. This keeps the parser dependency
+ * minimal and works inside half-typed expressions.
+ */
+export function detectIncludeString(text: string, offset: number): IncludeStringContext | null {
+    /* Walk back to the opening quote, bailing on newline or another delimiter. */
+    let i = offset - 1;
+    while (i >= 0) {
+        const c = text[i];
+        if (c === '"' || c === '\'') break;
+        if (c === '\n') return null;
+        if (c === '`') return null;
+        i--;
+    }
+    if (i < 0) return null;
+    const quote = text[i];
+    const stringStart = i + 1;
+
+    /* Skip whitespace before the quote. */
+    let j = i - 1;
+    while (j >= 0 && (text[j] === ' ' || text[j] === '\t')) j--;
+    if (text[j] !== '(') return null;
+
+    /* Skip whitespace before the paren and check for the `include` identifier. */
+    j--;
+    while (j >= 0 && (text[j] === ' ' || text[j] === '\t')) j--;
+    const wordEnd = j + 1;
+    while (j >= 0 && /[A-Za-z0-9_]/.test(text[j])) j--;
+    const word = text.slice(j + 1, wordEnd);
+    if (word !== 'include') return null;
+
+    const typed = text.slice(stringStart, offset);
+    return {
+        typed,
+        quote,
+        range: {
+            start: offsetToPosition(text, stringStart),
+            end: offsetToPosition(text, offset)
+        }
+    };
+}
+
+/**
+ * Build completion items for the partial path `ctx.typed`, resolved relative
+ * to the document at `documentUri`. `workspaceRoots` bounds the upward search
+ * just like the runtime resolver bounds itself to cwd.
+ */
+export function completeIncludePath(
+    ctx: IncludeStringContext,
+    documentUri: string,
+    workspaceRoots: string[]
+): CompletionItem[] {
+    const docPath = uriToFsPath(documentUri);
+    if (!docPath) return [];
+
+    /* Decide which directory the user's typed prefix is anchored to. */
+    const docDir = path.dirname(docPath);
+    const typed = ctx.typed;
+    const isExplicitlyRelative = typed.startsWith('./') || typed.startsWith('../') || typed.startsWith('/');
+    const lastSep = typed.lastIndexOf('/');
+    const dirPart = lastSep >= 0 ? typed.slice(0, lastSep + 1) : '';
+    const filePart = lastSep >= 0 ? typed.slice(lastSep + 1) : typed;
+
+    const items = new Map<string, CompletionItem>();
+    const seenDirs = new Set<string>();
+
+    const searchRoots: string[] = [];
+    if (path.isAbsolute(typed) || typed.startsWith('/')) {
+        searchRoots.push(path.parse(docPath).root);
+    } else {
+        /* Walk from the document's directory up toward the workspace root,
+         * mirroring the include() resolver. */
+        let cur = docDir;
+        const stop = workspaceRoots.length
+            ? workspaceRoots.map(r => path.resolve(r))
+            : [path.parse(docDir).root];
+        while (true) {
+            searchRoots.push(cur);
+            if (stop.includes(path.resolve(cur))) break;
+            const parent = path.dirname(cur);
+            if (parent === cur) break;
+            cur = parent;
+            /* Cap the walk so a deeply nested file doesn't blow up. */
+            if (searchRoots.length > 16) break;
+        }
+        /* For explicitly-relative prefixes we should not climb. */
+        if (isExplicitlyRelative) searchRoots.length = 1;
+    }
+
+    for (const root of searchRoots) {
+        const dir = path.resolve(root, dirPart || '.');
+        if (seenDirs.has(dir)) continue;
+        seenDirs.add(dir);
+
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+
+        for (const ent of entries) {
+            if (ent.name.startsWith('.')) continue;
+            if (ent.isDirectory()) {
+                const insertText = dirPart + ent.name + '/';
+                items.set(insertText, makeItem(ent.name + '/', insertText, ctx, CompletionItemKind.Folder, dir));
+                continue;
+            }
+            if (!ent.isFile()) continue;
+            const ext = path.extname(ent.name).toLowerCase();
+            if (!INCLUDABLE_EXT.has(ext)) continue;
+            const insertText = dirPart + ent.name;
+            items.set(insertText, makeItem(ent.name, insertText, ctx, kindForExt(ext), dir));
+        }
+    }
+
+    /* Lightly prefer entries whose basename matches the user's filePart prefix. */
+    const lower = filePart.toLowerCase();
+    for (const it of items.values()) {
+        const base = (it.label as string).toLowerCase();
+        it.sortText = (base.startsWith(lower) ? '0_' : '1_') + base;
+    }
+
+    return [...items.values()];
+}
+
+function makeItem(
+    label: string,
+    insertText: string,
+    ctx: IncludeStringContext,
+    kind: CompletionItemKind,
+    dir: string
+): CompletionItem {
+    const edit: InsertReplaceEdit = {
+        newText: insertText,
+        insert: ctx.range,
+        replace: ctx.range
+    };
+    return {
+        label,
+        kind,
+        detail: dir,
+        textEdit: edit,
+        /* Trigger another completion round after a folder is inserted, so the
+         * user sees its contents immediately. */
+        command: insertText.endsWith('/')
+            ? { command: 'editor.action.triggerSuggest', title: 'Re-trigger' }
+            : undefined
+    };
+}
+
+function kindForExt(ext: string): CompletionItemKind {
+    switch (ext) {
+        case '.cdo': return CompletionItemKind.Module;
+        case '.json':
+        case '.yaml':
+        case '.yml':
+        case '.csv': return CompletionItemKind.File;
+        case '.so':
+        case '.dylib':
+        case '.dll': return CompletionItemKind.Module;
+        default: return CompletionItemKind.File;
+    }
+}
+
+/**
+ * Resolve an `include("path")` argument to an absolute filesystem path,
+ * mirroring source/lib/include.c. Tries each candidate extension when the
+ * path has none. Returns `null` if nothing exists.
+ */
+export function resolveIncludePath(
+    raw: string,
+    documentUri: string,
+    workspaceRoots: string[]
+): string | null {
+    const docPath = uriToFsPath(documentUri);
+    if (!docPath) return null;
+    const docDir = path.dirname(docPath);
+
+    const candidates: string[] = [];
+    const probe = (base: string) => {
+        if (path.extname(base)) {
+            candidates.push(base);
+        } else {
+            for (const ext of ['.cdo', '.json', '.yaml', '.yml', '.csv']) {
+                candidates.push(base + ext);
+            }
+        }
+    };
+
+    if (path.isAbsolute(raw)) {
+        probe(raw);
+    } else {
+        let cur = docDir;
+        const stop = workspaceRoots.map(r => path.resolve(r));
+        const tried = new Set<string>();
+        while (!tried.has(cur)) {
+            tried.add(cur);
+            probe(path.resolve(cur, raw));
+            if (stop.includes(path.resolve(cur))) break;
+            const parent = path.dirname(cur);
+            if (parent === cur) break;
+            cur = parent;
+            if (tried.size > 16) break;
+        }
+    }
+
+    for (const c of candidates) {
+        try {
+            const st = fs.statSync(c);
+            if (st.isFile()) return c;
+        } catch { /* not present, keep trying */ }
+    }
+    return null;
+}
+
+/**
+ * Lightweight `file://` URI -> filesystem path decoder. Avoids pulling in
+ * `vscode-uri` since the language-server bundle only ever sees file URIs.
+ */
+function uriToFsPath(uri: string): string | null {
+    if (!uri.startsWith('file://')) return null;
+    let p = uri.slice('file://'.length);
+    /* Strip optional authority component (`file://host/path` -> `/path`). */
+    const slash = p.indexOf('/');
+    if (slash > 0) p = p.slice(slash);
+    try {
+        p = decodeURIComponent(p);
+    } catch {
+        /* Leave unencoded characters as-is. */
+    }
+    /* Windows: `/C:/foo` -> `C:/foo`. */
+    if (/^\/[A-Za-z]:/.test(p)) p = p.slice(1);
+    return p;
+}
+
+function offsetToPosition(text: string, offset: number): { line: number; character: number } {
+    let line = 0;
+    let lineStart = 0;
+    for (let i = 0; i < offset; i++) {
+        if (text[i] === '\n') {
+            line++;
+            lineStart = i + 1;
+        }
+    }
+    return { line, character: offset - lineStart };
+}

--- a/editors/vscode-cando/server/src/server.ts
+++ b/editors/vscode-cando/server/src/server.ts
@@ -61,6 +61,16 @@ import {
     resolveIncludePath
 } from './paths';
 import { getIncludeExports } from './crossfile';
+import {
+    buildTypeEnv,
+    inferReceiverAt,
+    listMembers,
+    describeTypeForHover,
+    formatMemberDetail,
+    TypeEnv,
+    TypeRef
+} from './types';
+import { MemberSpec } from './manifest';
 
 interface CandoSettings {
     diagnostics: { enable: boolean };
@@ -91,6 +101,7 @@ interface CachedAnalysis {
     includes: Map<string, IncludeBinding>;
     objectLiterals: Map<string, string[]>;
     moduleExports: string[];
+    typeEnv: TypeEnv;
     version: number;
 }
 const analysisCache = new Map<string, CachedAnalysis>();
@@ -143,6 +154,7 @@ documents.onDidClose(e => analysisCache.delete(e.document.uri));
 function refresh(doc: TextDocument): void {
     const tokens = new Lexer(doc.getText()).tokenize();
     const result = analyze(tokens);
+    const typeEnv = buildTypeEnv(tokens, result.symbols, doc.uri, workspaceRoots);
     analysisCache.set(doc.uri, {
         tokens,
         symbols: result.symbols,
@@ -150,6 +162,7 @@ function refresh(doc: TextDocument): void {
         includes: result.includes,
         objectLiterals: result.objectLiterals,
         moduleExports: result.moduleExports,
+        typeEnv,
         version: doc.version
     });
     if (globalSettings.diagnostics.enable) {
@@ -228,20 +241,32 @@ connection.onCompletion(params => {
         }
     }
 
-    /* 2. `name.` or `name:` member access. */
-    const before = text.slice(Math.max(0, offset - 64), offset);
-    const dotMatch = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*$/.exec(before);
-    if (dotMatch) {
-        const name = dotMatch[1];
-
-        /* 2a. Standard-library namespace. */
-        const ns = namespaceByName(name);
-        if (ns) return namespaceMemberCompletions(ns);
-
-        /* 2b. Local symbol resolution. */
+    /* 2. Member access after `.` or `:`. We use the type tracker to walk
+     * back through the full receiver expression, so chains like
+     * `forms.createTextBox(parent).` resolve to the TextBox type. */
+    const dotIndex = receiverDotIndex(text, offset);
+    if (dotIndex !== null) {
         const cached = analysisCache.get(params.textDocument.uri);
-        if (cached) {
-            /* `VAR x = include("./mod.cdo")` -> exports of mod.cdo */
+        if (!cached) return [];
+
+        const tokenIdx = tokenIndexAt(doc, cached.tokens, dotIndex);
+        if (tokenIdx === null) return [];
+
+        /* Try the type tracker first -- handles manifest types, in-file
+         * classes, anonymous records, and chained member calls. */
+        const ref = inferReceiverAt(cached.tokens, tokenIdx, cached.typeEnv, workspaceRoots);
+        const members = listMembers(ref, cached.typeEnv);
+        if (members.size > 0) return memberMapToCompletions(members);
+
+        /* Fallback path: handle the bare-name shapes the analyzer indexed
+         * directly, even if the type tracker bailed. */
+        const name = bareReceiverName(text, dotIndex);
+        if (name) {
+            const ns = namespaceByName(name);
+            if (ns) return namespaceMemberCompletions(ns);
+
+            /* Cross-file include with no manifest -> use the harvested
+             * exports list. */
             const inc = cached.includes.get(name);
             if (inc && globalSettings.completion.crossFile) {
                 const ex = getIncludeExports(inc.path, params.textDocument.uri, workspaceRoots);
@@ -253,31 +278,8 @@ connection.onCompletion(params => {
                     }));
                 }
             }
-
-            /* `VAR x = { foo: 1, bar: 2 }` -> foo, bar */
-            const lit = cached.objectLiterals.get(name);
-            if (lit) {
-                return lit.map<CompletionItem>(m => ({
-                    label: m,
-                    kind: CompletionItemKind.Field,
-                    detail: `${name}.${m}`
-                }));
-            }
-
-            /* `CLASS C { ... }` -> instance / static members for `C.x` / `C:x` */
-            const sym = cached.byName.get(name);
-            if (sym && sym.kind === 'class' && sym.children) {
-                return sym.children.map<CompletionItem>(child => ({
-                    label: child.name,
-                    kind: child.kind === 'method'
-                        ? CompletionItemKind.Method
-                        : CompletionItemKind.Field,
-                    detail: child.detail
-                }));
-            }
         }
-        /* Unknown member target -- fall through and offer nothing rather than
-         * a misleading list of keywords. */
+
         return [];
     }
 
@@ -359,6 +361,84 @@ function namespaceMemberCompletions(ns: NamespaceInfo): CompletionItem[] {
     }));
 }
 
+function memberMapToCompletions(members: Map<string, MemberSpec>): CompletionItem[] {
+    const out: CompletionItem[] = [];
+    for (const [name, spec] of members) {
+        const item: CompletionItem = {
+            label: name,
+            kind: memberKindToCompletion(spec),
+            detail: formatMemberDetail(spec, name)
+        };
+        if (spec.doc) {
+            item.documentation = { kind: MarkupKind.Markdown, value: spec.doc };
+        }
+        if (spec.kind === 'function' && spec.params) {
+            const placeholders = spec.params
+                .filter(p => !p.optional && !p.rest)
+                .map((p, i) => `\${${i + 1}:${p.name}}`)
+                .join(', ');
+            item.insertText = `${name}(${placeholders})$0`;
+            item.insertTextFormat = InsertTextFormat.Snippet;
+        }
+        out.push(item);
+    }
+    return out;
+}
+
+function memberKindToCompletion(spec: MemberSpec): CompletionItemKind {
+    switch (spec.kind) {
+        case 'function': return CompletionItemKind.Method;
+        case 'event':    return CompletionItemKind.Event;
+        case 'constant': return CompletionItemKind.Constant;
+        case 'value':
+        default:         return CompletionItemKind.Field;
+    }
+}
+
+/* ----- Receiver-detection helpers --------------------------------------- */
+
+/**
+ * Return the character offset of the trailing `.` or `:` before the cursor
+ * if the user is typing a member-access expression, otherwise null.
+ * Skips trailing identifier characters so `forms.cre|ate` still resolves to
+ * the dot at `forms.`.
+ */
+function receiverDotIndex(text: string, offset: number): number | null {
+    let i = offset;
+    while (i > 0 && /[A-Za-z0-9_]/.test(text[i - 1])) i--;
+    if (i <= 0) return null;
+    /* Allow whitespace between the dot and the partial member name. */
+    let j = i;
+    while (j > 0 && (text[j - 1] === ' ' || text[j - 1] === '\t')) j--;
+    if (j <= 0) return null;
+    const c = text[j - 1];
+    if (c !== '.' && c !== ':') return null;
+    return j - 1;
+}
+
+/** If the receiver is a single bare identifier, return it. */
+function bareReceiverName(text: string, dotIndex: number): string | null {
+    let i = dotIndex;
+    while (i > 0 && (text[i - 1] === ' ' || text[i - 1] === '\t')) i--;
+    const end = i;
+    while (i > 0 && /[A-Za-z0-9_]/.test(text[i - 1])) i--;
+    if (i === end) return null;
+    return text.slice(i, end);
+}
+
+/**
+ * Find the index of the first token whose start offset is greater than or
+ * equal to `offset`. Returns null when no such token exists. Used to
+ * locate the receiver expression preceding a `.` or `:` in the buffer.
+ */
+function tokenIndexAt(doc: TextDocument, tokens: Token[], offset: number): number | null {
+    for (let i = 0; i < tokens.length; i++) {
+        const startOffset = doc.offsetAt(tokens[i].range.start);
+        if (startOffset >= offset) return i;
+    }
+    return null;
+}
+
 function docSymbolKindToCompletion(k: CandoSymbol['kind']): CompletionItemKind {
     switch (k) {
         case 'function':  return CompletionItemKind.Function;
@@ -398,23 +478,27 @@ connection.onHover((params): Hover | null => {
         return md(`**${ns.name}** (standard library)\n\n${ns.doc}\n\nMembers: ${ns.members.map(m => `\`${m}\``).join(', ') || '_(none registered)_'}`);
     }
 
-    /* Namespace member: `ns.name` or `ns:name` */
+    /* Member access hover: walk back through the receiver chain via the
+     * type tracker, then look the word up on the resolved type. */
     const before = text.slice(Math.max(0, word.start - 64), word.start);
-    const m = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*$/.exec(before);
-    if (m) {
-        const ownerName = m[1];
-        const owner = namespaceByName(ownerName);
-        if (owner && owner.members.includes(word.value)) {
-            const sig = namespaceMemberDetail(owner, word.value);
-            return md(`**${owner.name}.${word.value}**${sig ? `  \n\`${sig}\`` : ''}\n\nMember of the \`${owner.name}\` standard library.`);
-        }
-
+    const dotMatch = /[.:]\s*$/.test(before);
+    if (dotMatch) {
         const cached = analysisCache.get(params.textDocument.uri);
-        const inc = cached?.includes.get(ownerName);
-        if (inc) {
-            const ex = getIncludeExports(inc.path, params.textDocument.uri, workspaceRoots);
-            if (ex && ex.members.includes(word.value)) {
-                return md(`**${ownerName}.${word.value}**\n\nExported by \`${path.basename(ex.path)}\`.`);
+        if (cached) {
+            const dotIdx = receiverDotIndex(text, word.start);
+            if (dotIdx !== null) {
+                const tokIdx = tokenIndexAt(doc, cached.tokens, dotIdx);
+                if (tokIdx !== null) {
+                    const ref = inferReceiverAt(cached.tokens, tokIdx, cached.typeEnv, workspaceRoots);
+                    const member = listMembers(ref, cached.typeEnv).get(word.value);
+                    if (member) {
+                        const ownerLabel = describeTypeForHover(ref);
+                        const detail = formatMemberDetail(member, word.value);
+                        const lines = [`**${ownerLabel}.${word.value}**`, '', '`' + detail + '`'];
+                        if (member.doc) { lines.push('', member.doc); }
+                        return md(lines.join('\n'));
+                    }
+                }
             }
         }
     }
@@ -452,15 +536,34 @@ connection.onSignatureHelp((params): SignatureHelp | null => {
     const ctx = findEnclosingCall(text, offset);
     if (!ctx) return null;
 
-    /* `ns.method(` or `ns:method(` */
-    const dotMatch = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*([A-Za-z_][A-Za-z0-9_]*)$/.exec(
-        text.slice(0, ctx.callerEnd)
-    );
-    if (dotMatch) {
-        const ns = namespaceByName(dotMatch[1]);
-        if (ns) {
-            const sig = namespaceMemberDetail(ns, dotMatch[2]) ?? `${ns.name}.${dotMatch[2]}(...)`;
-            return makeSignature(sig, ctx.activeParameter);
+    /* Chained call: walk back from the function name through the receiver
+     * expression so `forms.createTextBox(parent).setText("|")` finds the
+     * TextBox.setText signature. */
+    const cached = analysisCache.get(params.textDocument.uri);
+    const headMatch = /([A-Za-z_][A-Za-z0-9_]*)$/.exec(text.slice(0, ctx.callerEnd));
+    if (cached && headMatch) {
+        const fnName = headMatch[1];
+        const fnStart = ctx.callerEnd - fnName.length;
+        const dotIdx = receiverDotIndex(text, fnStart);
+        if (dotIdx !== null) {
+            const tokIdx = tokenIndexAt(doc, cached.tokens, dotIdx);
+            if (tokIdx !== null) {
+                const ref = inferReceiverAt(cached.tokens, tokIdx, cached.typeEnv, workspaceRoots);
+                const spec = listMembers(ref, cached.typeEnv).get(fnName);
+                if (spec) {
+                    const sig = formatMemberDetail(spec, fnName);
+                    return makeSignature(sig, ctx.activeParameter);
+                }
+            }
+            /* Fall through to the std-library namespace heuristic. */
+            const dotName = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*$/.exec(text.slice(0, dotIdx + 1));
+            if (dotName) {
+                const ns = namespaceByName(dotName[1]);
+                if (ns) {
+                    const sig = namespaceMemberDetail(ns, fnName) ?? `${ns.name}.${fnName}(...)`;
+                    return makeSignature(sig, ctx.activeParameter);
+                }
+            }
         }
     }
 
@@ -469,7 +572,6 @@ connection.onSignatureHelp((params): SignatureHelp | null => {
     if (!bareMatch) return null;
     const name = bareMatch[1];
 
-    const cached = analysisCache.get(params.textDocument.uri);
     const sym = cached?.byName.get(name);
     if (sym && sym.parameters !== undefined) {
         const sig = `${name}(${sym.parameters.join(', ')})`;

--- a/editors/vscode-cando/server/src/server.ts
+++ b/editors/vscode-cando/server/src/server.ts
@@ -6,12 +6,19 @@
  *                  bracket-balance check.
  *   - Completion:  keywords, global builtins, std-lib namespaces,
  *                  namespace member completion after `name.` or `name:`,
- *                  document symbols.
- *   - Hover:       short docs for keywords, builtins and namespace members.
+ *                  document symbols, cross-file member completion for
+ *                  `include(...)` bindings, object-literal members,
+ *                  filesystem path completion inside `include("...")`.
+ *   - Hover:       short docs for keywords, builtins, namespace members,
+ *                  document symbols, and resolved include paths.
+ *   - Signature help: parameter list for the function call surrounding the
+ *                  cursor (in-file functions and namespace methods).
  *   - Document symbols + go-to-definition for in-file functions, classes,
- *                  vars, constants, globals.
+ *                  vars, constants, globals; goto for `include(...)` jumps
+ *                  to the included file.
  */
 
+import * as path from 'path';
 import {
     createConnection,
     TextDocuments,
@@ -21,6 +28,7 @@ import {
     TextDocumentSyncKind,
     CompletionItem,
     CompletionItemKind,
+    InsertTextFormat,
     Diagnostic,
     DiagnosticSeverity,
     Hover,
@@ -28,33 +36,50 @@ import {
     Location,
     DocumentSymbol,
     SymbolKind as LspSymbolKind,
-    Range as LspRange
+    Range as LspRange,
+    SignatureHelp,
+    SignatureInformation,
+    ParameterInformation
 } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { Lexer, Token, Range as LexRange } from './lexer';
-import { analyze, Symbol as CandoSymbol } from './analyzer';
+import { analyze, Symbol as CandoSymbol, IncludeBinding } from './analyzer';
 import {
     KEYWORDS_UPPER,
     PIPE_KEYWORD,
     GLOBAL_BUILTINS,
     NAMESPACES,
-    namespaceByName
+    NamespaceInfo,
+    namespaceByName,
+    namespaceMemberDetail,
+    builtinByName
 } from './builtins';
+import {
+    detectIncludeString,
+    completeIncludePath,
+    resolveIncludePath
+} from './paths';
+import { getIncludeExports } from './crossfile';
 
 interface CandoSettings {
     diagnostics: { enable: boolean };
-    completion: { includeBuiltins: boolean };
+    completion: {
+        includeBuiltins: boolean;
+        includePaths: boolean;
+        crossFile: boolean;
+    };
     keywordCase: 'upper' | 'lower';
 }
 
 const DEFAULT_SETTINGS: CandoSettings = {
     diagnostics: { enable: true },
-    completion: { includeBuiltins: true },
+    completion: { includeBuiltins: true, includePaths: true, crossFile: true },
     keywordCase: 'upper'
 };
 
 let globalSettings: CandoSettings = DEFAULT_SETTINGS;
+let workspaceRoots: string[] = [];
 
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments<TextDocument>(TextDocument);
@@ -63,21 +88,37 @@ interface CachedAnalysis {
     tokens: Token[];
     symbols: CandoSymbol[];
     byName: Map<string, CandoSymbol>;
+    includes: Map<string, IncludeBinding>;
+    objectLiterals: Map<string, string[]>;
+    moduleExports: string[];
     version: number;
 }
 const analysisCache = new Map<string, CachedAnalysis>();
 
-connection.onInitialize((_params: InitializeParams): InitializeResult => {
+connection.onInitialize((params: InitializeParams): InitializeResult => {
+    workspaceRoots = (params.workspaceFolders ?? [])
+        .map(f => uriToFsPath(f.uri))
+        .filter((p): p is string => !!p);
+    if (!workspaceRoots.length && params.rootUri) {
+        const r = uriToFsPath(params.rootUri);
+        if (r) workspaceRoots.push(r);
+    }
     return {
         capabilities: {
             textDocumentSync: TextDocumentSyncKind.Incremental,
             completionProvider: {
                 resolveProvider: false,
-                triggerCharacters: ['.', ':']
+                /* `(`, `"`, `'`, `/` cover include() string completion;
+                 * `.` and `:` drive member access; space allows keyword
+                 * follow-ups (e.g. after `EXTENDS `). */
+                triggerCharacters: ['.', ':', '(', '"', '\'', '/']
             },
             hoverProvider: true,
             definitionProvider: true,
-            documentSymbolProvider: true
+            documentSymbolProvider: true,
+            signatureHelpProvider: {
+                triggerCharacters: ['(', ',']
+            }
         }
     };
 });
@@ -86,7 +127,11 @@ connection.onDidChangeConfiguration(change => {
     const cfg = (change.settings as { cando?: Partial<CandoSettings> } | undefined)?.cando;
     globalSettings = {
         diagnostics: { enable: cfg?.diagnostics?.enable ?? DEFAULT_SETTINGS.diagnostics.enable },
-        completion: { includeBuiltins: cfg?.completion?.includeBuiltins ?? DEFAULT_SETTINGS.completion.includeBuiltins },
+        completion: {
+            includeBuiltins: cfg?.completion?.includeBuiltins ?? DEFAULT_SETTINGS.completion.includeBuiltins,
+            includePaths:    cfg?.completion?.includePaths    ?? DEFAULT_SETTINGS.completion.includePaths,
+            crossFile:       cfg?.completion?.crossFile       ?? DEFAULT_SETTINGS.completion.crossFile
+        },
         keywordCase: cfg?.keywordCase ?? DEFAULT_SETTINGS.keywordCase
     };
     documents.all().forEach(refresh);
@@ -97,8 +142,16 @@ documents.onDidClose(e => analysisCache.delete(e.document.uri));
 
 function refresh(doc: TextDocument): void {
     const tokens = new Lexer(doc.getText()).tokenize();
-    const { symbols, byName } = analyze(tokens);
-    analysisCache.set(doc.uri, { tokens, symbols, byName, version: doc.version });
+    const result = analyze(tokens);
+    analysisCache.set(doc.uri, {
+        tokens,
+        symbols: result.symbols,
+        byName: result.byName,
+        includes: result.includes,
+        objectLiterals: result.objectLiterals,
+        moduleExports: result.moduleExports,
+        version: doc.version
+    });
     if (globalSettings.diagnostics.enable) {
         connection.sendDiagnostics({ uri: doc.uri, diagnostics: makeDiagnostics(tokens) });
     } else {
@@ -167,22 +220,68 @@ connection.onCompletion(params => {
     const text = doc.getText();
     const offset = doc.offsetAt(params.position);
 
-    /* Look back to detect `name.` or `name:` */
+    /* 1. Path completion inside `include("...")`. */
+    if (globalSettings.completion.includePaths) {
+        const ictx = detectIncludeString(text, offset);
+        if (ictx) {
+            return completeIncludePath(ictx, params.textDocument.uri, workspaceRoots);
+        }
+    }
+
+    /* 2. `name.` or `name:` member access. */
     const before = text.slice(Math.max(0, offset - 64), offset);
     const dotMatch = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*$/.exec(before);
     if (dotMatch) {
-        const ns = namespaceByName(dotMatch[1]);
-        if (ns) {
-            return ns.members.map<CompletionItem>(m => ({
-                label: m,
-                kind: CompletionItemKind.Function,
-                detail: `${ns.name}.${m}`,
-                documentation: { kind: MarkupKind.Markdown, value: `Member of \`${ns.name}\`.` }
-            }));
+        const name = dotMatch[1];
+
+        /* 2a. Standard-library namespace. */
+        const ns = namespaceByName(name);
+        if (ns) return namespaceMemberCompletions(ns);
+
+        /* 2b. Local symbol resolution. */
+        const cached = analysisCache.get(params.textDocument.uri);
+        if (cached) {
+            /* `VAR x = include("./mod.cdo")` -> exports of mod.cdo */
+            const inc = cached.includes.get(name);
+            if (inc && globalSettings.completion.crossFile) {
+                const ex = getIncludeExports(inc.path, params.textDocument.uri, workspaceRoots);
+                if (ex && ex.members.length) {
+                    return ex.members.map<CompletionItem>(m => ({
+                        label: m,
+                        kind: CompletionItemKind.Field,
+                        detail: `${name} (from ${path.basename(ex.path)})`
+                    }));
+                }
+            }
+
+            /* `VAR x = { foo: 1, bar: 2 }` -> foo, bar */
+            const lit = cached.objectLiterals.get(name);
+            if (lit) {
+                return lit.map<CompletionItem>(m => ({
+                    label: m,
+                    kind: CompletionItemKind.Field,
+                    detail: `${name}.${m}`
+                }));
+            }
+
+            /* `CLASS C { ... }` -> instance / static members for `C.x` / `C:x` */
+            const sym = cached.byName.get(name);
+            if (sym && sym.kind === 'class' && sym.children) {
+                return sym.children.map<CompletionItem>(child => ({
+                    label: child.name,
+                    kind: child.kind === 'method'
+                        ? CompletionItemKind.Method
+                        : CompletionItemKind.Field,
+                    detail: child.detail
+                }));
+            }
         }
-        // Document-symbol member completion not yet implemented; fall through.
+        /* Unknown member target -- fall through and offer nothing rather than
+         * a misleading list of keywords. */
+        return [];
     }
 
+    /* 3. General completion: keywords + builtins + namespaces + symbols. */
     const items: CompletionItem[] = [];
     const kwCase = globalSettings.keywordCase;
 
@@ -204,12 +303,17 @@ connection.onCompletion(params => {
 
     if (globalSettings.completion.includeBuiltins) {
         for (const b of GLOBAL_BUILTINS) {
-            items.push({
+            const item: CompletionItem = {
                 label: b.name,
                 kind: CompletionItemKind.Function,
                 detail: b.detail,
                 documentation: { kind: MarkupKind.Markdown, value: b.doc }
-            });
+            };
+            if (b.snippet) {
+                item.insertText = b.snippet;
+                item.insertTextFormat = InsertTextFormat.Snippet;
+            }
+            items.push(item);
         }
         for (const ns of NAMESPACES) {
             items.push({
@@ -224,23 +328,45 @@ connection.onCompletion(params => {
     const cached = analysisCache.get(params.textDocument.uri);
     if (cached) {
         for (const s of cached.symbols) {
-            items.push({
+            const item: CompletionItem = {
                 label: s.name,
                 kind: docSymbolKindToCompletion(s.kind),
                 detail: s.detail
-            });
+            };
+            if (s.parameters !== undefined && s.parameters.length === 0) {
+                item.insertText = `${s.name}()$0`;
+                item.insertTextFormat = InsertTextFormat.Snippet;
+            } else if (s.parameters !== undefined) {
+                const placeholders = s.parameters
+                    .map((p, i) => `\${${i + 1}:${p}}`)
+                    .join(', ');
+                item.insertText = `${s.name}(${placeholders})$0`;
+                item.insertTextFormat = InsertTextFormat.Snippet;
+            }
+            items.push(item);
         }
     }
 
     return items;
 });
 
+function namespaceMemberCompletions(ns: NamespaceInfo): CompletionItem[] {
+    return ns.members.map<CompletionItem>(m => ({
+        label: m,
+        kind: CompletionItemKind.Function,
+        detail: namespaceMemberDetail(ns, m) ?? `${ns.name}.${m}`,
+        documentation: { kind: MarkupKind.Markdown, value: `Member of \`${ns.name}\`.` }
+    }));
+}
+
 function docSymbolKindToCompletion(k: CandoSymbol['kind']): CompletionItemKind {
     switch (k) {
         case 'function':  return CompletionItemKind.Function;
+        case 'method':    return CompletionItemKind.Method;
         case 'class':     return CompletionItemKind.Class;
         case 'constant':  return CompletionItemKind.Constant;
         case 'parameter': return CompletionItemKind.Variable;
+        case 'field':     return CompletionItemKind.Field;
         default:          return CompletionItemKind.Variable;
     }
 }
@@ -263,7 +389,7 @@ connection.onHover((params): Hover | null => {
     if (word.value === 'pipe') {
         return md(`**pipe** -- ${PIPE_KEYWORD.doc}`);
     }
-    const bi = GLOBAL_BUILTINS.find(b => b.name === word.value);
+    const bi = builtinByName(word.value);
     if (bi) {
         return md(`**${bi.name}** -- ${bi.detail}\n\n${bi.doc}`);
     }
@@ -276,16 +402,36 @@ connection.onHover((params): Hover | null => {
     const before = text.slice(Math.max(0, word.start - 64), word.start);
     const m = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*$/.exec(before);
     if (m) {
-        const owner = namespaceByName(m[1]);
+        const ownerName = m[1];
+        const owner = namespaceByName(ownerName);
         if (owner && owner.members.includes(word.value)) {
-            return md(`**${owner.name}.${word.value}**\n\nMember of the \`${owner.name}\` standard library.`);
+            const sig = namespaceMemberDetail(owner, word.value);
+            return md(`**${owner.name}.${word.value}**${sig ? `  \n\`${sig}\`` : ''}\n\nMember of the \`${owner.name}\` standard library.`);
+        }
+
+        const cached = analysisCache.get(params.textDocument.uri);
+        const inc = cached?.includes.get(ownerName);
+        if (inc) {
+            const ex = getIncludeExports(inc.path, params.textDocument.uri, workspaceRoots);
+            if (ex && ex.members.includes(word.value)) {
+                return md(`**${ownerName}.${word.value}**\n\nExported by \`${path.basename(ex.path)}\`.`);
+            }
         }
     }
 
     const cached = analysisCache.get(params.textDocument.uri);
     const sym = cached?.byName.get(word.value);
     if (sym) {
-        return md(`**${sym.name}** -- ${sym.detail ?? sym.kind}`);
+        const lines = [`**${sym.name}** -- ${sym.detail ?? sym.kind}`];
+        const inc = cached?.includes.get(sym.name);
+        if (inc) {
+            const resolved = resolveIncludePath(inc.path, params.textDocument.uri, workspaceRoots);
+            lines.push('');
+            lines.push(resolved
+                ? `Module: \`${inc.path}\` -> \`${resolved}\``
+                : `Module: \`${inc.path}\` *(not found)*`);
+        }
+        return md(lines.join('\n'));
     }
 
     return null;
@@ -293,6 +439,93 @@ connection.onHover((params): Hover | null => {
 
 function md(text: string): Hover {
     return { contents: { kind: MarkupKind.Markdown, value: text } };
+}
+
+/* -- Signature help ------------------------------------------------------- */
+
+connection.onSignatureHelp((params): SignatureHelp | null => {
+    const doc = documents.get(params.textDocument.uri);
+    if (!doc) return null;
+    const text = doc.getText();
+    const offset = doc.offsetAt(params.position);
+
+    const ctx = findEnclosingCall(text, offset);
+    if (!ctx) return null;
+
+    /* `ns.method(` or `ns:method(` */
+    const dotMatch = /([A-Za-z_][A-Za-z0-9_]*)\s*[.:]\s*([A-Za-z_][A-Za-z0-9_]*)$/.exec(
+        text.slice(0, ctx.callerEnd)
+    );
+    if (dotMatch) {
+        const ns = namespaceByName(dotMatch[1]);
+        if (ns) {
+            const sig = namespaceMemberDetail(ns, dotMatch[2]) ?? `${ns.name}.${dotMatch[2]}(...)`;
+            return makeSignature(sig, ctx.activeParameter);
+        }
+    }
+
+    /* Bare `name(` */
+    const bareMatch = /([A-Za-z_][A-Za-z0-9_]*)$/.exec(text.slice(0, ctx.callerEnd));
+    if (!bareMatch) return null;
+    const name = bareMatch[1];
+
+    const cached = analysisCache.get(params.textDocument.uri);
+    const sym = cached?.byName.get(name);
+    if (sym && sym.parameters !== undefined) {
+        const sig = `${name}(${sym.parameters.join(', ')})`;
+        return makeSignature(sig, ctx.activeParameter);
+    }
+
+    const bi = builtinByName(name);
+    if (bi) return makeSignature(bi.detail, ctx.activeParameter);
+
+    return null;
+});
+
+interface CallContext {
+    /* Index of the character immediately before the opening `(`. */
+    callerEnd: number;
+    /* Zero-based index of the parameter the cursor is currently on. */
+    activeParameter: number;
+}
+
+function findEnclosingCall(text: string, offset: number): CallContext | null {
+    let depth = 0;
+    let commas = 0;
+    for (let i = offset - 1; i >= 0; i--) {
+        const c = text[i];
+        if (c === ')') depth++;
+        else if (c === '(') {
+            if (depth === 0) return { callerEnd: i, activeParameter: commas };
+            depth--;
+        } else if (c === ',' && depth === 0) {
+            commas++;
+        } else if (c === '"' || c === '\'') {
+            /* Skip a balanced string by walking backwards to its match. */
+            const quote = c;
+            i--;
+            while (i >= 0 && text[i] !== quote) i--;
+        }
+    }
+    return null;
+}
+
+function makeSignature(label: string, activeParameter: number): SignatureHelp {
+    const params: ParameterInformation[] = [];
+    const open = label.indexOf('(');
+    const close = label.lastIndexOf(')');
+    if (open >= 0 && close > open) {
+        const inner = label.slice(open + 1, close);
+        if (inner.trim().length) {
+            for (const part of inner.split(',')) params.push({ label: part.trim() });
+        }
+    }
+    const sig: SignatureInformation = { label, parameters: params };
+    return {
+        signatures: [sig],
+        activeSignature: 0,
+        activeParameter: Math.min(activeParameter, Math.max(0, params.length - 1))
+    };
 }
 
 /* -- Definition + symbols ------------------------------------------------- */
@@ -303,6 +536,20 @@ connection.onDefinition(params => {
     const word = wordAt(doc.getText(), doc.offsetAt(params.position));
     if (!word) return null;
     const cached = analysisCache.get(params.textDocument.uri);
+
+    /* Jump to the included file when the user invokes goto on a name bound
+     * to `include(...)`. */
+    const inc = cached?.includes.get(word.value);
+    if (inc) {
+        const resolved = resolveIncludePath(inc.path, params.textDocument.uri, workspaceRoots);
+        if (resolved) {
+            return {
+                uri: fsPathToUri(resolved),
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } }
+            } as Location;
+        }
+    }
+
     const sym = cached?.byName.get(word.value);
     if (!sym) return null;
     const loc: Location = { uri: params.textDocument.uri, range: toLsp(sym.range) };
@@ -329,9 +576,11 @@ function toDocumentSymbol(s: CandoSymbol): DocumentSymbol {
 function mapKind(k: CandoSymbol['kind']): LspSymbolKind {
     switch (k) {
         case 'function':  return LspSymbolKind.Function;
+        case 'method':    return LspSymbolKind.Method;
         case 'class':     return LspSymbolKind.Class;
         case 'constant':  return LspSymbolKind.Constant;
         case 'parameter': return LspSymbolKind.Variable;
+        case 'field':     return LspSymbolKind.Field;
         default:          return LspSymbolKind.Variable;
     }
 }
@@ -346,6 +595,22 @@ function wordAt(text: string, offset: number): { value: string; start: number; e
     while (e < text.length && isIdentChar(text[e])) e++;
     if (s === e) return null;
     return { value: text.slice(s, e), start: s, end: e };
+}
+
+function uriToFsPath(uri: string): string | null {
+    if (!uri.startsWith('file://')) return null;
+    let p = uri.slice('file://'.length);
+    const slash = p.indexOf('/');
+    if (slash > 0) p = p.slice(slash);
+    try { p = decodeURIComponent(p); } catch { /* keep raw */ }
+    if (/^\/[A-Za-z]:/.test(p)) p = p.slice(1);
+    return p;
+}
+
+function fsPathToUri(p: string): string {
+    let normalized = p.replace(/\\/g, '/');
+    if (!normalized.startsWith('/')) normalized = '/' + normalized;
+    return 'file://' + encodeURI(normalized).replace(/[#?]/g, c => encodeURIComponent(c));
 }
 
 documents.listen(connection);

--- a/editors/vscode-cando/server/src/types.ts
+++ b/editors/vscode-cando/server/src/types.ts
@@ -96,6 +96,25 @@ export function buildTypeEnv(
      * everything except whitespace-shaped tokens. */
     const t = tokens.filter(x => x.kind !== 'comment' && x.kind !== 'newline');
 
+    /* First pass: capture every binding shape we recognise. */
+    walkBindings(t, env, workspaceRoots);
+
+    /* Second pass: pick up runtime member additions of the form
+     *   name.member  = rhs;
+     *   name:member  = rhs;
+     * When `name` resolves to a record, augment its member set so the
+     * captured field is offered on `name.` completion. This is the
+     * canonical CanDo pattern for attaching methods after a literal:
+     *
+     *     VAR t = { };
+     *     t.meth = FUNCTION(self) { ... };
+     */
+    augmentRecordsWithRuntimeMembers(t, env);
+
+    return env;
+}
+
+function walkBindings(t: Token[], env: TypeEnv, workspaceRoots: string[]): void {
     for (let i = 0; i < t.length; i++) {
         const tok = t[i];
 
@@ -157,8 +176,27 @@ export function buildTypeEnv(
             }
         }
     }
+}
 
-    return env;
+function augmentRecordsWithRuntimeMembers(t: Token[], env: TypeEnv): void {
+    for (let i = 0; i < t.length; i++) {
+        const head = t[i];
+        if (head.kind !== 'ident') continue;
+        const dot = t[i + 1];
+        if (dot?.kind !== 'op' || (dot.value !== '.' && dot.value !== ':')) continue;
+        const memberTok = t[i + 2];
+        if (memberTok?.kind !== 'ident') continue;
+        const eq = t[i + 3];
+        if (eq?.kind !== 'op' || eq.value !== '=') continue;
+
+        const ref = env.bindings.get(head.value);
+        if (!ref || ref.kind !== 'record') continue;
+        if (ref.members.has(memberTok.value)) continue;
+
+        const isFn = t[i + 4]?.kind === 'keyword'
+            && (t[i + 4].value === 'FUNCTION' || t[i + 4].value === 'function');
+        ref.members.set(memberTok.value, isFn ? { kind: 'function' } : { kind: 'value' });
+    }
 }
 
 /* -------------------------------------------------------------------------
@@ -285,13 +323,32 @@ function inferPostfix(
     while (j < endExclusive) {
         const tok = tokens[j];
 
-        /* Member access `name.x` or `name:x`. */
-        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':')) {
+        /* Member access:
+         *   `.`  -- field / method lookup; if called, the result has the
+         *           method's declared return type.
+         *   `:`  -- method call; same lookup as `.`, but the runtime passes
+         *           the receiver as the implicit first argument. From the
+         *           type tracker's perspective `:` and `.` resolve the
+         *           same way -- the difference is how the call is dispatched.
+         *   `::` -- fluent chain. `t::method(...)` ALWAYS returns `t` (the
+         *           receiver), regardless of what `method` actually returns.
+         *           This is how scripts daisy-chain calls on objects whose
+         *           methods don't explicitly `return self`.
+         */
+        if (
+            tok.kind === 'op' &&
+            (tok.value === '.' || tok.value === ':' || tok.value === '::')
+        ) {
+            const isChain = tok.value === '::';
             const nameTok = tokens[j + 1];
             if (nameTok?.kind !== 'ident') break;
             const member = lookupMemberSpec(ref, nameTok.value, env);
             if (!member) {
-                ref = UNKNOWN;
+                /* `::` still preserves the receiver even if we can't look
+                 * the member up -- you might be chaining through a runtime-
+                 * defined helper. For `.` and `:`, an unknown member kills
+                 * inference. */
+                if (!isChain) ref = UNKNOWN;
                 j += 2;
                 continue;
             }
@@ -299,15 +356,21 @@ function inferPostfix(
             const isCall = next?.kind === 'punct' && next.value === '(';
             if (isCall) {
                 const callEnd = skipBalanced(tokens, j + 2, '(', ')');
-                /* `"self"` / `"this"` return types preserve the receiver's
-                 * type, which is how fluent chaining stays on a Form when
-                 * Control declares `setText`. */
-                if (isSelfReturn(member.returns)) {
-                    /* ref is unchanged. */
+                if (isChain || isSelfReturn(member.returns)) {
+                    /* ref is unchanged: `::` is a fluent chain, and a
+                     * `"returns": "self"` declaration explicitly says the
+                     * method preserves its receiver's type. */
                 } else {
                     ref = resolveTypeReference(member.returns ?? 'any', env);
                 }
                 j = callEnd;
+                continue;
+            }
+            /* Bare member reference (no call). */
+            if (isChain) {
+                /* `t::method` without `()` is a syntax error in CanDo, but
+                 * be defensive -- preserve the receiver. */
+                j += 2;
                 continue;
             }
             if (member.kind === 'function') {
@@ -588,8 +651,8 @@ export function inferReceiverAt(
     workspaceRoots: string[]
 ): TypeRef {
     /* Walk back, skipping balanced `()` / `[]` groups, to find the start of
-     * the chain. Anything other than ident / `.` / `:` / `(` / `[` ends the
-     * receiver. */
+     * the chain. Anything other than ident / `.` / `:` / `::` / `(` / `[`
+     * ends the receiver. */
     let start = dotIndex - 1;
     while (start >= 0) {
         const tok = tokens[start];
@@ -600,7 +663,9 @@ export function inferReceiverAt(
             continue;
         }
         if (tok.kind === 'ident') { start--; continue; }
-        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':')) { start--; continue; }
+        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':' || tok.value === '::')) {
+            start--; continue;
+        }
         break;
     }
     start++;

--- a/editors/vscode-cando/server/src/types.ts
+++ b/editors/vscode-cando/server/src/types.ts
@@ -99,6 +99,28 @@ export function buildTypeEnv(
     for (let i = 0; i < t.length; i++) {
         const tok = t[i];
 
+        /* CLASS declarations are recognised by the analyzer and registered in
+         * env.classes. Skip past their `(params) { body }` here so the
+         * type-tracker doesn't mistake `CLASS Foo = { }` for a bare
+         * assignment binding `Foo` to an empty record. */
+        if (tok.kind === 'keyword' && isOneOf(tok.value, 'CLASS')) {
+            let j = i + 1;
+            if (t[j]?.kind === 'ident') j++;
+            if (t[j]?.kind === 'keyword' && isOneOf(t[j].value, 'EXTENDS')) {
+                j++;
+                if (t[j]?.kind === 'ident') j++;
+            }
+            if (t[j]?.kind === 'op' && t[j].value === '=') j++;
+            if (t[j]?.kind === 'punct' && t[j].value === '(') {
+                j = skipBalanced(t, j, '(', ')');
+            }
+            if (t[j]?.kind === 'punct' && t[j].value === '{') {
+                j = skipBalanced(t, j, '{', '}');
+            }
+            i = j - 1;
+            continue;
+        }
+
         /* `VAR|CONST|GLOBAL name = rhs` */
         if (tok.kind === 'keyword' && isOneOf(tok.value, 'VAR', 'CONST', 'GLOBAL')) {
             const nameTok = t[i + 1];
@@ -118,10 +140,16 @@ export function buildTypeEnv(
         }
 
         /* Bare assignment: `name = rhs`. Only honoured when `name` isn't
-         * already bound (so we don't clobber a stronger inference). */
+         * already bound (so we don't clobber a stronger inference) AND isn't
+         * the name of a class (class identifiers are a stronger hint than a
+         * stray `Cls = ...` line). */
         if (tok.kind === 'ident') {
             const eq = t[i + 1];
-            if (eq?.kind === 'op' && eq.value === '=' && !env.bindings.has(tok.value)) {
+            if (
+                eq?.kind === 'op' && eq.value === '='
+                && !env.bindings.has(tok.value)
+                && !env.classes.has(tok.value)
+            ) {
                 const { ref, next } = inferExpression(t, i + 2, env, workspaceRoots);
                 env.bindings.set(tok.value, ref);
                 i = next - 1;
@@ -175,18 +203,6 @@ function inferPrimary(
     if (tok.kind === 'keyword') {
         if (matches(tok.value, 'TRUE', 'FALSE')) return { ref: { kind: 'primitive', name: 'bool' }, next: i + 1 };
         if (matches(tok.value, 'NULL'))           return { ref: { kind: 'primitive', name: 'null' }, next: i + 1 };
-        if (matches(tok.value, 'NEW')) {
-            const cls = tokens[i + 1];
-            if (cls?.kind === 'ident') {
-                const ref: TypeRef = { kind: 'in-file-class', className: cls.value };
-                /* Skip past the optional argument list. */
-                let j = i + 2;
-                if (tokens[j]?.kind === 'punct' && tokens[j].value === '(') {
-                    j = skipBalanced(tokens, j, '(', ')');
-                }
-                return { ref, next: j };
-            }
-        }
         if (matches(tok.value, 'FUNCTION')) {
             /* Anonymous function literal -- skip its body and treat the value
              * as a generic function. */
@@ -283,7 +299,14 @@ function inferPostfix(
             const isCall = next?.kind === 'punct' && next.value === '(';
             if (isCall) {
                 const callEnd = skipBalanced(tokens, j + 2, '(', ')');
-                ref = resolveTypeReference(member.returns ?? 'any', env);
+                /* `"self"` / `"this"` return types preserve the receiver's
+                 * type, which is how fluent chaining stays on a Form when
+                 * Control declares `setText`. */
+                if (isSelfReturn(member.returns)) {
+                    /* ref is unchanged. */
+                } else {
+                    ref = resolveTypeReference(member.returns ?? 'any', env);
+                }
                 j = callEnd;
                 continue;
             }
@@ -298,10 +321,12 @@ function inferPostfix(
 
         /* Direct call `name(args)`. */
         if (tok.kind === 'punct' && tok.value === '(') {
-            /* If the current ref is a function value we don't know its return
-             * type. Best we can do is mark it unknown and skip past the call. */
             const end = skipBalanced(tokens, j, '(', ')');
-            ref = UNKNOWN;
+            /* Calling a class returns an instance of it. CanDo classes are
+             * callable directly (`Animal("Rex")`), no `NEW` keyword. */
+            if (ref.kind !== 'in-file-class') {
+                ref = UNKNOWN;
+            }
             j = end;
             continue;
         }
@@ -431,6 +456,10 @@ function lookupMemberSpec(ref: TypeRef, name: string, env: TypeEnv): MemberSpec 
 /* -------------------------------------------------------------------------
  * Type-string resolution (manifest "type" / "returns" -> TypeRef)
  * ----------------------------------------------------------------------- */
+
+function isSelfReturn(s: string | undefined): boolean {
+    return s === 'self' || s === 'this' || s === 'Self';
+}
 
 function resolveTypeReference(typeStr: string, env: TypeEnv): TypeRef {
     if (!typeStr) return ANY;
@@ -692,8 +721,3 @@ export function formatMemberDetail(spec: MemberSpec, name: string): string {
     return name;
 }
 
-/* Exports a synthetic path lookup module so server.ts can stay tidy. */
-export const _internal_for_tests = {
-    skipBalanced,
-    inferPrimary
-};

--- a/editors/vscode-cando/server/src/types.ts
+++ b/editors/vscode-cando/server/src/types.ts
@@ -1,0 +1,699 @@
+/*
+ * Lightweight type tracker.
+ *
+ * Walks a token stream once and builds a `TypeEnv` that maps every name
+ * the script binds (`VAR`/`CONST`/`GLOBAL` declarations, plus the lhs of
+ * top-level assignments) to a best-effort `TypeRef`. The tracker uses
+ * three sources of truth:
+ *
+ *   1. In-file information from `analyze()` -- classes, object literals,
+ *      `include(...)` bindings.
+ *   2. Module manifests (`cando.api.json`) discovered next to a binary or
+ *      .cdo target -- they describe the value `include(...)` returns and
+ *      the named types reachable from it.
+ *   3. The std-library namespace tables in `builtins.ts`.
+ *
+ * The tracker is deliberately conservative: when it can't make a confident
+ * inference it returns `unknown`, and the completion code surfaces no
+ * suggestions rather than misleading ones. It does NOT do flow-sensitive
+ * narrowing, generics, or closure return-type inference.
+ *
+ * Inheritance:
+ *   - `extends` on a manifest type behaves like classical single-inheritance.
+ *   - `indexes` (single string or array) mirrors CanDo's runtime
+ *     prototype-chain mechanism (`__index`) and walks the same way.
+ *   - In user code, an object literal with an `__index: parent` field is
+ *     recognised as a record that inherits from `parent`'s type.
+ *   - `CLASS Foo EXTENDS Bar` walks the in-file class chain.
+ */
+
+import * as path from 'path';
+
+import { Token } from './lexer';
+import { Symbol as CandoSymbol } from './analyzer';
+import {
+    Manifest,
+    MemberSpec,
+    findManifestFor,
+    resolveExportMembers,
+    resolveTypeMembers
+} from './manifest';
+import { resolveIncludePath } from './paths';
+import { NAMESPACES } from './builtins';
+
+/* -------------------------------------------------------------------------
+ * TypeRef
+ * ----------------------------------------------------------------------- */
+
+export type TypeRef =
+    | { kind: 'primitive'; name: 'string' | 'number' | 'bool' | 'null' | 'array' | 'function' | 'void' | 'any' }
+    | { kind: 'unknown' }
+    | { kind: 'manifest-exports'; manifest: Manifest }
+    | { kind: 'manifest-type'; manifest: Manifest; typeName: string }
+    /** Anonymous record built from an object literal in the user's code.
+     *  `indexParent` is set when the literal contained `__index: someExpr`. */
+    | { kind: 'record'; members: Map<string, MemberSpec>; indexParent?: TypeRef }
+    /** Reference to a `CLASS Foo { ... }` declared in the same file. */
+    | { kind: 'in-file-class'; className: string };
+
+const ANY: TypeRef = { kind: 'primitive', name: 'any' };
+const UNKNOWN: TypeRef = { kind: 'unknown' };
+
+/* -------------------------------------------------------------------------
+ * Type environment
+ * ----------------------------------------------------------------------- */
+
+export interface TypeEnv {
+    /* Variable / constant / parameter -> type. */
+    bindings: Map<string, TypeRef>;
+    /* In-file CLASS declarations, including parent (`EXTENDS`) chains. */
+    classes: Map<string, CandoSymbol>;
+    /* Manifests by their absolute file path; useful for hover detail. */
+    manifests: Map<string, Manifest>;
+    /* The document URI we built this env for; used to resolve include paths. */
+    documentUri: string;
+}
+
+export function buildTypeEnv(
+    tokens: Token[],
+    inFileSymbols: CandoSymbol[],
+    documentUri: string,
+    workspaceRoots: string[]
+): TypeEnv {
+    const env: TypeEnv = {
+        bindings: new Map(),
+        classes: new Map(),
+        manifests: new Map(),
+        documentUri
+    };
+
+    /* Index in-file classes so EXTENDS chains can be walked later. */
+    for (const s of inFileSymbols) {
+        if (s.kind === 'class') env.classes.set(s.name, s);
+    }
+
+    /* Filter to the tokens the inference helpers care about. We keep
+     * everything except whitespace-shaped tokens. */
+    const t = tokens.filter(x => x.kind !== 'comment' && x.kind !== 'newline');
+
+    for (let i = 0; i < t.length; i++) {
+        const tok = t[i];
+
+        /* `VAR|CONST|GLOBAL name = rhs` */
+        if (tok.kind === 'keyword' && isOneOf(tok.value, 'VAR', 'CONST', 'GLOBAL')) {
+            const nameTok = t[i + 1];
+            if (nameTok?.kind === 'ident') {
+                if (t[i + 2]?.kind === 'op' && t[i + 2].value === '=') {
+                    const { ref, next } = inferExpression(t, i + 3, env, workspaceRoots);
+                    if (!env.bindings.has(nameTok.value)) {
+                        env.bindings.set(nameTok.value, ref);
+                    }
+                    i = next - 1;
+                    continue;
+                }
+                /* `VAR name;` -- declared but unbound. */
+                env.bindings.set(nameTok.value, UNKNOWN);
+            }
+            continue;
+        }
+
+        /* Bare assignment: `name = rhs`. Only honoured when `name` isn't
+         * already bound (so we don't clobber a stronger inference). */
+        if (tok.kind === 'ident') {
+            const eq = t[i + 1];
+            if (eq?.kind === 'op' && eq.value === '=' && !env.bindings.has(tok.value)) {
+                const { ref, next } = inferExpression(t, i + 2, env, workspaceRoots);
+                env.bindings.set(tok.value, ref);
+                i = next - 1;
+                continue;
+            }
+        }
+    }
+
+    return env;
+}
+
+/* -------------------------------------------------------------------------
+ * Expression inference
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Read a primary expression starting at `tokens[i]`, then peel off any
+ * trailing `.x` / `:x` / `(...)` / `[...]` postfixes. Returns the inferred
+ * type and the index just past the consumed expression.
+ *
+ * `endExclusive`, if provided, caps how far postfix consumption may reach.
+ * Used by `inferReceiverAt` to stop right before the dot we're completing
+ * on rather than walking past it.
+ */
+export function inferExpression(
+    tokens: Token[],
+    i: number,
+    env: TypeEnv,
+    workspaceRoots: string[],
+    endExclusive: number = tokens.length
+): { ref: TypeRef; next: number } {
+    const primary = inferPrimary(tokens, i, env, workspaceRoots);
+    return inferPostfix(primary.ref, tokens, primary.next, env, workspaceRoots, endExclusive);
+}
+
+function inferPrimary(
+    tokens: Token[],
+    i: number,
+    env: TypeEnv,
+    workspaceRoots: string[]
+): { ref: TypeRef; next: number } {
+    const tok = tokens[i];
+    if (!tok) return { ref: UNKNOWN, next: i };
+
+    if (tok.kind === 'string' || tok.kind === 'template-string') {
+        return { ref: { kind: 'primitive', name: 'string' }, next: i + 1 };
+    }
+    if (tok.kind === 'number') {
+        return { ref: { kind: 'primitive', name: 'number' }, next: i + 1 };
+    }
+    if (tok.kind === 'keyword') {
+        if (matches(tok.value, 'TRUE', 'FALSE')) return { ref: { kind: 'primitive', name: 'bool' }, next: i + 1 };
+        if (matches(tok.value, 'NULL'))           return { ref: { kind: 'primitive', name: 'null' }, next: i + 1 };
+        if (matches(tok.value, 'NEW')) {
+            const cls = tokens[i + 1];
+            if (cls?.kind === 'ident') {
+                const ref: TypeRef = { kind: 'in-file-class', className: cls.value };
+                /* Skip past the optional argument list. */
+                let j = i + 2;
+                if (tokens[j]?.kind === 'punct' && tokens[j].value === '(') {
+                    j = skipBalanced(tokens, j, '(', ')');
+                }
+                return { ref, next: j };
+            }
+        }
+        if (matches(tok.value, 'FUNCTION')) {
+            /* Anonymous function literal -- skip its body and treat the value
+             * as a generic function. */
+            let j = i + 1;
+            if (tokens[j]?.kind === 'punct' && tokens[j].value === '(') {
+                j = skipBalanced(tokens, j, '(', ')');
+            }
+            if (tokens[j]?.kind === 'punct' && tokens[j].value === '{') {
+                j = skipBalanced(tokens, j, '{', '}');
+            }
+            return { ref: { kind: 'primitive', name: 'function' }, next: j };
+        }
+    }
+
+    if (tok.kind === 'punct' && tok.value === '[') {
+        const end = skipBalanced(tokens, i, '[', ']');
+        return { ref: { kind: 'primitive', name: 'array' }, next: end };
+    }
+
+    if (tok.kind === 'punct' && tok.value === '{') {
+        const lit = readObjectLiteral(tokens, i, env, workspaceRoots);
+        return { ref: lit.ref, next: lit.next };
+    }
+
+    if (tok.kind === 'punct' && tok.value === '(') {
+        /* Parenthesised expression -- infer the inner expression then return
+         * past the `)`. */
+        const inner = inferExpression(tokens, i + 1, env, workspaceRoots);
+        const end = skipBalanced(tokens, i, '(', ')');
+        return { ref: inner.ref, next: end };
+    }
+
+    if (tok.kind === 'ident') {
+        /* `include("path")` -- handled specially because the rhs determines
+         * the entire module-export type. */
+        if (tok.value === 'include' && tokens[i + 1]?.kind === 'punct' && tokens[i + 1].value === '(') {
+            const arg = tokens[i + 2];
+            const end = skipBalanced(tokens, i + 1, '(', ')');
+            if (arg?.kind === 'string') {
+                const ref = resolveIncludeType(unquote(arg.value), env, workspaceRoots);
+                return { ref, next: end };
+            }
+            return { ref: UNKNOWN, next: end };
+        }
+
+        /* Standard-library namespace: `string`, `math`, ... become a
+         * synthetic exports record so postfix `.method` works. */
+        const ns = NAMESPACES.find(n => n.name === tok.value);
+        if (ns) {
+            return { ref: namespaceAsRecord(ns), next: i + 1 };
+        }
+
+        /* User-defined name. */
+        const bound = env.bindings.get(tok.value);
+        if (bound) return { ref: bound, next: i + 1 };
+
+        /* Class names resolve as a function value -- `Cls(...)` constructs an
+         * instance. */
+        if (env.classes.has(tok.value)) {
+            return { ref: { kind: 'in-file-class', className: tok.value }, next: i + 1 };
+        }
+
+        return { ref: UNKNOWN, next: i + 1 };
+    }
+
+    return { ref: UNKNOWN, next: i + 1 };
+}
+
+function inferPostfix(
+    start: TypeRef,
+    tokens: Token[],
+    i: number,
+    env: TypeEnv,
+    workspaceRoots: string[],
+    endExclusive: number = tokens.length
+): { ref: TypeRef; next: number } {
+    let ref = start;
+    let j = i;
+
+    while (j < endExclusive) {
+        const tok = tokens[j];
+
+        /* Member access `name.x` or `name:x`. */
+        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':')) {
+            const nameTok = tokens[j + 1];
+            if (nameTok?.kind !== 'ident') break;
+            const member = lookupMemberSpec(ref, nameTok.value, env);
+            if (!member) {
+                ref = UNKNOWN;
+                j += 2;
+                continue;
+            }
+            const next = tokens[j + 2];
+            const isCall = next?.kind === 'punct' && next.value === '(';
+            if (isCall) {
+                const callEnd = skipBalanced(tokens, j + 2, '(', ')');
+                ref = resolveTypeReference(member.returns ?? 'any', env);
+                j = callEnd;
+                continue;
+            }
+            if (member.kind === 'function') {
+                ref = { kind: 'primitive', name: 'function' };
+            } else {
+                ref = resolveTypeReference(member.type ?? 'any', env);
+            }
+            j += 2;
+            continue;
+        }
+
+        /* Direct call `name(args)`. */
+        if (tok.kind === 'punct' && tok.value === '(') {
+            /* If the current ref is a function value we don't know its return
+             * type. Best we can do is mark it unknown and skip past the call. */
+            const end = skipBalanced(tokens, j, '(', ')');
+            ref = UNKNOWN;
+            j = end;
+            continue;
+        }
+
+        /* Index `name[expr]` -- element type unknown. */
+        if (tok.kind === 'punct' && tok.value === '[') {
+            j = skipBalanced(tokens, j, '[', ']');
+            ref = UNKNOWN;
+            continue;
+        }
+
+        break;
+    }
+
+    return { ref, next: j };
+}
+
+function readObjectLiteral(
+    tokens: Token[],
+    i: number,
+    env: TypeEnv,
+    workspaceRoots: string[]
+): { ref: TypeRef; next: number } {
+    /* tokens[i] is `{`. */
+    const members = new Map<string, MemberSpec>();
+    let indexParent: TypeRef | undefined;
+
+    let j = i + 1;
+    let depth = 1;
+    while (j < tokens.length && depth > 0) {
+        const tok = tokens[j];
+        if (tok.kind === 'punct') {
+            if (tok.value === '{') { depth++; j++; continue; }
+            if (tok.value === '}') { depth--; j++; continue; }
+            if (tok.value === '[') { j = skipBalanced(tokens, j, '[', ']'); continue; }
+            if (tok.value === '(') { j = skipBalanced(tokens, j, '(', ')'); continue; }
+        }
+        if (depth === 1 && (tok.kind === 'ident' || tok.kind === 'keyword' || tok.kind === 'string')) {
+            const colon = tokens[j + 1];
+            if (colon?.kind === 'op' && colon.value === ':') {
+                const key = tok.kind === 'string' ? unquote(tok.value) : tok.value;
+                if (key === '__index') {
+                    /* The value of `__index` becomes the prototype parent. */
+                    const inner = inferExpression(tokens, j + 2, env, workspaceRoots);
+                    indexParent = inner.ref;
+                    j = inner.next;
+                    continue;
+                }
+                if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+                    /* Best-effort: peek at the value to decide if the slot is
+                     * a function or a plain value. */
+                    const value = tokens[j + 2];
+                    const isFn = value?.kind === 'keyword' && matches(value.value, 'FUNCTION');
+                    members.set(key, isFn ? { kind: 'function' } : { kind: 'value' });
+                }
+            }
+        }
+        j++;
+    }
+
+    return { ref: { kind: 'record', members, indexParent }, next: j };
+}
+
+/* -------------------------------------------------------------------------
+ * Member lookup (the engine behind `name.` completion)
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Return every member visible on `ref`, walking inheritance / __index
+ * chains as appropriate. Closer definitions win.
+ */
+export function listMembers(ref: TypeRef, env: TypeEnv): Map<string, MemberSpec> {
+    const out = new Map<string, MemberSpec>();
+    const seen = new Set<string>();
+
+    const visit = (current: TypeRef): void => {
+        const key = describe(current);
+        if (seen.has(key)) return;
+        seen.add(key);
+
+        switch (current.kind) {
+            case 'manifest-exports': {
+                const m = resolveExportMembers(current.manifest);
+                m.forEach((spec, name) => { if (!out.has(name)) out.set(name, spec); });
+                return;
+            }
+            case 'manifest-type': {
+                const m = resolveTypeMembers(current.manifest, current.typeName);
+                m.forEach((spec, name) => { if (!out.has(name)) out.set(name, spec); });
+                return;
+            }
+            case 'record': {
+                current.members.forEach((spec, name) => { if (!out.has(name)) out.set(name, spec); });
+                if (current.indexParent) visit(current.indexParent);
+                return;
+            }
+            case 'in-file-class': {
+                const cls = env.classes.get(current.className);
+                if (!cls) return;
+                for (const child of cls.children ?? []) {
+                    if (out.has(child.name)) continue;
+                    out.set(child.name, {
+                        kind: child.kind === 'method' ? 'function' : 'value',
+                        doc: child.detail
+                    });
+                }
+                /* CLASS Foo EXTENDS Bar -- follow the chain. */
+                const parentName = cls.detail?.match(/EXTENDS\s+(\w+)/)?.[1];
+                if (parentName) visit({ kind: 'in-file-class', className: parentName });
+                return;
+            }
+            case 'primitive':
+            case 'unknown':
+                return;
+        }
+    };
+
+    visit(ref);
+    return out;
+}
+
+function lookupMemberSpec(ref: TypeRef, name: string, env: TypeEnv): MemberSpec | null {
+    const all = listMembers(ref, env);
+    return all.get(name) ?? null;
+}
+
+/* -------------------------------------------------------------------------
+ * Type-string resolution (manifest "type" / "returns" -> TypeRef)
+ * ----------------------------------------------------------------------- */
+
+function resolveTypeReference(typeStr: string, env: TypeEnv): TypeRef {
+    if (!typeStr) return ANY;
+    const t = typeStr.trim();
+    switch (t) {
+        case 'string':         return { kind: 'primitive', name: 'string' };
+        case 'number':         return { kind: 'primitive', name: 'number' };
+        case 'bool':
+        case 'boolean':        return { kind: 'primitive', name: 'bool' };
+        case 'null':           return { kind: 'primitive', name: 'null' };
+        case 'array':          return { kind: 'primitive', name: 'array' };
+        case 'function':       return { kind: 'primitive', name: 'function' };
+        case 'void':           return { kind: 'primitive', name: 'void' };
+        case 'any':            return ANY;
+        case 'object':         return { kind: 'record', members: new Map() };
+    }
+
+    /* Cross-manifest reference: `forms.TextBox`. Search every manifest
+     * we've seen for the named type. */
+    const dot = t.indexOf('.');
+    if (dot > 0) {
+        const ns = t.slice(0, dot);
+        const ty = t.slice(dot + 1);
+        for (const m of env.manifests.values()) {
+            if (m.name === ns && m.types?.[ty]) {
+                return { kind: 'manifest-type', manifest: m, typeName: ty };
+            }
+        }
+    }
+
+    /* Otherwise look it up in any manifest currently loaded for this env. */
+    for (const m of env.manifests.values()) {
+        if (m.types?.[t]) return { kind: 'manifest-type', manifest: m, typeName: t };
+    }
+
+    /* Fallback: in-file class. */
+    if (env.classes.has(t)) return { kind: 'in-file-class', className: t };
+
+    return UNKNOWN;
+}
+
+function resolveIncludeType(rawPath: string, env: TypeEnv, workspaceRoots: string[]): TypeRef {
+    /* First try the runtime-equivalent resolution: file must exist on disk. */
+    const abs = resolveIncludePath(rawPath, env.documentUri, workspaceRoots);
+    if (abs) {
+        const manifest = findManifestFor(abs);
+        if (manifest) {
+            env.manifests.set(abs, manifest);
+            return { kind: 'manifest-exports', manifest };
+        }
+    }
+
+    /* Fallback: a manifest can exist alongside a binary that hasn't been
+     * built yet. Probe the directory the include path *would* resolve to
+     * and look for the manifest there. */
+    const speculative = speculativeManifestPath(rawPath, env.documentUri, workspaceRoots);
+    if (speculative) {
+        const manifest = findManifestFor(speculative);
+        if (manifest) {
+            env.manifests.set(speculative, manifest);
+            return { kind: 'manifest-exports', manifest };
+        }
+    }
+
+    /* No manifest -- defer to crossfile-derived members. The completion
+     * layer falls back to `getIncludeExports` for this case. */
+    return UNKNOWN;
+}
+
+/**
+ * Compute the absolute path that `rawPath` would resolve to (relative to the
+ * document) without requiring the file to exist. Used to find manifests
+ * that ship alongside an unbuilt binary.
+ */
+function speculativeManifestPath(
+    rawPath: string,
+    documentUri: string,
+    workspaceRoots: string[]
+): string | null {
+    const docPath = uriToFsPath(documentUri);
+    if (!docPath) return null;
+    const docDir = path.dirname(docPath);
+    if (path.isAbsolute(rawPath)) return rawPath;
+    /* Walk up from the document's directory, mirroring the runtime's
+     * search order, and stop at the first ancestor that contains a
+     * directory matching the relative include head. */
+    let cur = docDir;
+    const stop = workspaceRoots.map(r => path.resolve(r));
+    for (let i = 0; i < 16; i++) {
+        const candidate = path.resolve(cur, rawPath);
+        if (findManifestFor(candidate)) return candidate;
+        if (stop.includes(path.resolve(cur))) break;
+        const parent = path.dirname(cur);
+        if (parent === cur) break;
+        cur = parent;
+    }
+    /* No ancestor turned up a manifest -- fall back to the document's own
+     * directory so the caller can still ask for one. */
+    return path.resolve(docDir, rawPath);
+}
+
+function uriToFsPath(uri: string): string | null {
+    if (!uri.startsWith('file://')) return null;
+    let p = uri.slice('file://'.length);
+    const slash = p.indexOf('/');
+    if (slash > 0) p = p.slice(slash);
+    try { p = decodeURIComponent(p); } catch { /* keep raw */ }
+    if (/^\/[A-Za-z]:/.test(p)) p = p.slice(1);
+    return p;
+}
+
+/* -------------------------------------------------------------------------
+ * Reverse helpers (used by completion at a cursor position)
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Given a token array and a cursor position (the index of the token right
+ * after the trailing `.` or `:`), walk backwards to find the start of the
+ * receiver expression and return its inferred type. Used to make
+ * `forms.createTextBox(parent).` complete `TextBox`'s members.
+ */
+export function inferReceiverAt(
+    tokens: Token[],
+    dotIndex: number,
+    env: TypeEnv,
+    workspaceRoots: string[]
+): TypeRef {
+    /* Walk back, skipping balanced `()` / `[]` groups, to find the start of
+     * the chain. Anything other than ident / `.` / `:` / `(` / `[` ends the
+     * receiver. */
+    let start = dotIndex - 1;
+    while (start >= 0) {
+        const tok = tokens[start];
+        if (tok.kind === 'punct' && (tok.value === ')' || tok.value === ']')) {
+            const open = tok.value === ')' ? '(' : '[';
+            const close = tok.value;
+            start = skipBalancedBackwards(tokens, start, open, close) - 1;
+            continue;
+        }
+        if (tok.kind === 'ident') { start--; continue; }
+        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':')) { start--; continue; }
+        break;
+    }
+    start++;
+    if (start >= dotIndex) return UNKNOWN;
+    const { ref } = inferExpression(tokens, start, env, workspaceRoots, dotIndex);
+    return ref;
+}
+
+/* -------------------------------------------------------------------------
+ * Tiny utilities
+ * ----------------------------------------------------------------------- */
+
+function isOneOf(v: string, ...names: string[]): boolean {
+    return names.some(n => v === n || v === n.toLowerCase());
+}
+
+function matches(v: string, ...names: string[]): boolean {
+    return names.some(n => v === n || v === n.toLowerCase());
+}
+
+function unquote(raw: string): string {
+    if (raw.length >= 2) {
+        const a = raw[0], b = raw[raw.length - 1];
+        if ((a === '"' || a === '\'' || a === '`') && a === b) return raw.slice(1, -1);
+    }
+    return raw;
+}
+
+function skipBalanced(tokens: Token[], from: number, open: string, close: string): number {
+    let depth = 0;
+    let j = from;
+    while (j < tokens.length) {
+        const tok = tokens[j];
+        if (tok.kind === 'punct' && tok.value === open) depth++;
+        else if (tok.kind === 'punct' && tok.value === close) {
+            depth--;
+            if (depth === 0) return j + 1;
+        }
+        j++;
+    }
+    return j;
+}
+
+function skipBalancedBackwards(tokens: Token[], from: number, open: string, close: string): number {
+    let depth = 0;
+    let j = from;
+    while (j >= 0) {
+        const tok = tokens[j];
+        if (tok.kind === 'punct' && tok.value === close) depth++;
+        else if (tok.kind === 'punct' && tok.value === open) {
+            depth--;
+            if (depth === 0) return j;
+        }
+        j--;
+    }
+    return j;
+}
+
+function namespaceAsRecord(ns: { name: string; members: string[]; memberDetails?: Record<string, string> }): TypeRef {
+    const members = new Map<string, MemberSpec>();
+    for (const m of ns.members) {
+        members.set(m, {
+            kind: 'function',
+            doc: ns.memberDetails?.[m] ?? `${ns.name}.${m}`
+        });
+    }
+    return { kind: 'record', members };
+}
+
+function describe(ref: TypeRef): string {
+    switch (ref.kind) {
+        case 'primitive':         return `prim:${ref.name}`;
+        case 'unknown':           return 'unknown';
+        case 'manifest-exports':  return `mfst:${ref.manifest.name}:exports`;
+        case 'manifest-type':     return `mfst:${ref.manifest.name}:${ref.typeName}`;
+        case 'in-file-class':     return `cls:${ref.className}`;
+        case 'record': {
+            const keys = [...ref.members.keys()].sort().join(',');
+            return `rec:[${keys}]:${ref.indexParent ? describe(ref.indexParent) : ''}`;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Public hover / display helpers
+ * ----------------------------------------------------------------------- */
+
+export function describeTypeForHover(ref: TypeRef): string {
+    switch (ref.kind) {
+        case 'primitive':         return ref.name;
+        case 'unknown':           return 'any';
+        case 'manifest-exports':  return `${ref.manifest.name} (module)`;
+        case 'manifest-type':     return `${ref.manifest.name}.${ref.typeName}`;
+        case 'in-file-class':     return ref.className;
+        case 'record': {
+            const keys = [...ref.members.keys()].slice(0, 4).join(', ');
+            const more = ref.members.size > 4 ? ', …' : '';
+            return `{ ${keys}${more} }`;
+        }
+    }
+}
+
+export function formatMemberDetail(spec: MemberSpec, name: string): string {
+    if (spec.kind === 'function') {
+        const params = (spec.params ?? []).map(p => {
+            const t = p.type ? `: ${p.type}` : '';
+            const opt = p.optional ? '?' : '';
+            const rest = p.rest ? '...' : '';
+            return `${rest}${p.name}${opt}${t}`;
+        }).join(', ');
+        const ret = spec.returns ? ` -> ${spec.returns}` : '';
+        return `${name}(${params})${ret}`;
+    }
+    if (spec.kind === 'event') {
+        return `${name} ${spec.signature ?? '(event)'}`;
+    }
+    if (spec.type) return `${name}: ${spec.type}`;
+    return name;
+}
+
+/* Exports a synthetic path lookup module so server.ts can stay tidy. */
+export const _internal_for_tests = {
+    skipBalanced,
+    inferPrimary
+};

--- a/editors/vscode-cando/server/test/edge_cases.js
+++ b/editors/vscode-cando/server/test/edge_cases.js
@@ -67,22 +67,15 @@ function membersAt(source) {
     const result = analyze(tokens);
     const env = buildTypeEnv(tokens, result.symbols, DOC_URI, ROOTS);
 
-    /* Find the dot/colon immediately before the cursor. We scan filtered
-     * tokens for `.` or `:` whose end-of-token is at-or-before the cursor
-     * and there is no token in between. To do that, we map filtered token
-     * positions back to character offsets via the lexer's range. */
-    const offsets = filtered.map(t => offsetOf(stripped, t.range.end));
+    /* Find the dot/colon/double-colon immediately before the cursor. */
     let dotIdx = -1;
     for (let i = filtered.length - 1; i >= 0; i--) {
         const tok = filtered[i];
-        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':')) {
+        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':' || tok.value === '::')) {
             const o = offsetOf(stripped, tok.range.start);
-            if (o < idx) { dotIdx = i; break; }
+            const e = offsetOf(stripped, tok.range.end);
+            if (e <= idx) { dotIdx = i; break; }
         }
-        const o = offsets[i];
-        if (o > idx) continue;
-        /* If the token after our cursor is a non-ident token it shouldn't
-         * gate the dot search. */
     }
     if (dotIdx < 0) return { type: 'no-dot', members: [] };
     const ref = inferReceiverAt(filtered, dotIdx, env, ROOTS);
@@ -136,6 +129,60 @@ test('newline between dot and member', () => {
 test('colon (method) syntax', () => {
     const r = membersAt('VAR forms = include("./forms.so"); VAR f = forms.Form();\nf:|');
     return r.members.includes('center') || 'expected center, members=' + r.members.slice(0, 5);
+});
+
+test('double-colon (chain) syntax: t::method', () => {
+    /* `::` is the fluent-chain operator. `f::method(args)` is equivalent
+     * to a `:` call but the runtime always returns the receiver, so the
+     * type tracker should treat completion the same as `f:`. */
+    const r = membersAt('VAR forms = include("./forms.so"); VAR f = forms.Form();\nf::|');
+    return r.members.includes('center') || 'expected center, members=' + r.members.slice(0, 5);
+});
+
+test('::-chain preserves receiver type even when method returns something else', () => {
+    /* User-defined object whose method has a non-self return; chaining via
+     * `::` should keep the result on the original receiver. */
+    const src = `
+        VAR t = { v: 100 };
+        t.meth = FUNCTION(self) { RETURN self.v; };
+        t::meth().|
+    `;
+    const r = membersAt(src);
+    /* The chain ends back on `t`; available members are t's own keys. */
+    return r.members.includes('v') && r.members.includes('meth');
+});
+
+test('::-chain on manifest type preserves the receiver', () => {
+    const src = `
+        VAR forms = include("./forms.so");
+        VAR f = forms.Form();
+        f::setText("hi")::|
+    `;
+    /* setText nominally returns Form (or self). After ::, we're guaranteed
+     * to still be on Form regardless of declaration. */
+    const r = membersAt(src);
+    return r.members.includes('center');
+});
+
+test('mixed :- and ::-chain', () => {
+    const src = `
+        VAR forms = include("./forms.so");
+        VAR f = forms.Form();
+        f:setSize(100, 100)::|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('center');
+});
+
+test('::-chain with two consecutive chains', () => {
+    /* From metamethods.cdo: t::set_v(200)::set_v(300) */
+    const src = `
+        VAR t = { };
+        t.set_v = FUNCTION(self, v) { self.v = v; };
+        t::set_v(200)::|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('set_v');
 });
 
 test('do not complete inside string literal', () => {

--- a/editors/vscode-cando/server/test/edge_cases.js
+++ b/editors/vscode-cando/server/test/edge_cases.js
@@ -1,0 +1,662 @@
+/* Edge-case harness for the CanDo language server's completion path.
+ *
+ * Each test inserts a `|` to mark the cursor, strips it, then asks the
+ * type tracker what receiver type the cursor sits on (when in a member
+ * position) plus what the path detector reports (when in an include
+ * string). Run with `node server/test/edge_cases.js` from the extension
+ * directory after `npx tsc -b`.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+const OUT = path.resolve(__dirname, '..', 'out');
+const { Lexer } = require(path.join(OUT, 'lexer.js'));
+const { analyze } = require(path.join(OUT, 'analyzer.js'));
+const {
+    buildTypeEnv,
+    inferReceiverAt,
+    listMembers,
+    describeTypeForHover
+} = require(path.join(OUT, 'types.js'));
+const { detectIncludeString } = require(path.join(OUT, 'paths.js'));
+
+const REPO = path.resolve(__dirname, '..', '..', '..', '..');
+const DOC_PATH = path.join(REPO, 'modules', 'forms', '_harness.cdo');
+const DOC_URI = 'file://' + DOC_PATH;
+const ROOTS = [REPO];
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+function test(name, body) {
+    try {
+        const result = body();
+        if (result === true) {
+            pass++;
+            return;
+        }
+        fail++;
+        failures.push({ name, reason: result || 'returned false' });
+    } catch (e) {
+        fail++;
+        failures.push({ name, reason: 'threw: ' + e.message + '\n' + e.stack });
+    }
+}
+
+function tokenize(source) {
+    return new Lexer(source).tokenize();
+}
+
+function envFor(source) {
+    const tokens = tokenize(source);
+    const result = analyze(tokens);
+    const env = buildTypeEnv(tokens, result.symbols, DOC_URI, ROOTS);
+    return { tokens, env, symbols: result.symbols };
+}
+
+/** Resolve the receiver type at the `|` marker. Returns the inferred type
+ *  description and member names. */
+function membersAt(source) {
+    const idx = source.indexOf('|');
+    if (idx < 0) throw new Error('no | marker');
+    const stripped = source.slice(0, idx) + source.slice(idx + 1);
+    const tokens = tokenize(stripped);
+    const filtered = tokens.filter(t => t.kind !== 'comment' && t.kind !== 'newline');
+    const result = analyze(tokens);
+    const env = buildTypeEnv(tokens, result.symbols, DOC_URI, ROOTS);
+
+    /* Find the dot/colon immediately before the cursor. We scan filtered
+     * tokens for `.` or `:` whose end-of-token is at-or-before the cursor
+     * and there is no token in between. To do that, we map filtered token
+     * positions back to character offsets via the lexer's range. */
+    const offsets = filtered.map(t => offsetOf(stripped, t.range.end));
+    let dotIdx = -1;
+    for (let i = filtered.length - 1; i >= 0; i--) {
+        const tok = filtered[i];
+        if (tok.kind === 'op' && (tok.value === '.' || tok.value === ':')) {
+            const o = offsetOf(stripped, tok.range.start);
+            if (o < idx) { dotIdx = i; break; }
+        }
+        const o = offsets[i];
+        if (o > idx) continue;
+        /* If the token after our cursor is a non-ident token it shouldn't
+         * gate the dot search. */
+    }
+    if (dotIdx < 0) return { type: 'no-dot', members: [] };
+    const ref = inferReceiverAt(filtered, dotIdx, env, ROOTS);
+    return { type: describeTypeForHover(ref), members: [...listMembers(ref, env).keys()] };
+}
+
+function offsetOf(text, pos) {
+    let line = 0;
+    let col = 0;
+    for (let i = 0; i < text.length; i++) {
+        if (line === pos.line && col === pos.character) return i;
+        if (text[i] === '\n') { line++; col = 0; } else col++;
+    }
+    return text.length;
+}
+
+function detectInclude(source) {
+    const idx = source.indexOf('|');
+    if (idx < 0) throw new Error('no | marker');
+    const stripped = source.slice(0, idx) + source.slice(idx + 1);
+    return detectIncludeString(stripped, idx);
+}
+
+/* =========================================================================
+ *  Receiver detection
+ * ======================================================================= */
+
+test('plain receiver', () =>
+    membersAt('VAR forms = include("./forms.so");\nforms.|').members.includes('Form')
+);
+
+test('chained call result', () =>
+    membersAt('VAR forms = include("./forms.so");\nforms.Form().|').members.includes('center')
+);
+
+test('partial member typed', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.Form().cen|ter');
+    return r.members.includes('center') || ('expected center, got ' + r.members.length + ' members');
+});
+
+test('whitespace between dot and member', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.   |');
+    return r.members.includes('Form') || 'expected Form, members=' + r.members.slice(0, 5);
+});
+
+test('newline between dot and member', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.\n  |');
+    return r.members.includes('Form') || 'expected Form, members=' + r.members.slice(0, 5);
+});
+
+test('colon (method) syntax', () => {
+    const r = membersAt('VAR forms = include("./forms.so"); VAR f = forms.Form();\nf:|');
+    return r.members.includes('center') || 'expected center, members=' + r.members.slice(0, 5);
+});
+
+test('do not complete inside string literal', () => {
+    const r = membersAt('VAR s = "forms.|";');
+    return r.type === 'no-dot' || r.members.length === 0
+        || ('inside string should not have members, got ' + r.type + ': ' + r.members.length);
+});
+
+test('chained constants: forms.Color.cornflowerblue', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.Color.|');
+    return r.members.includes('cornflowerblue') || 'expected cornflowerblue, members=' + r.members.slice(0, 5);
+});
+
+test('parenthesized receiver: (forms.Form()).', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\n(forms.Form()).|');
+    return r.members.includes('center') || 'expected center, members=' + r.members.slice(0, 5);
+});
+
+test('receiver is index access: arr[0].', () => {
+    /* We don't track element types yet, but the receiver detector should
+     * not crash and should bail to unknown. */
+    const r = membersAt('VAR arr = [1,2,3];\narr[0].|');
+    return r.type === 'any' || true;
+});
+
+/* =========================================================================
+ *  Type tracker
+ * ======================================================================= */
+
+test('reassignment refines type', () => {
+    /* Currently we keep the first inference -- document this behaviour. */
+    const { env } = envFor(
+        'VAR forms = include("./forms.so");\nVAR x = forms.Form();\nx = forms.Button(x);'
+    );
+    return describeTypeForHover(env.bindings.get('x')) === 'forms.Form';
+});
+
+test('VAR x = method ref (not call) -> function', () => {
+    const { env } = envFor(
+        'VAR forms = include("./forms.so"); VAR f = forms.Form();\nVAR setT = f.setText;'
+    );
+    return describeTypeForHover(env.bindings.get('setT')) === 'function';
+});
+
+test('VAR x = forms.Color (constant table)', () => {
+    const r = membersAt(
+        'VAR forms = include("./forms.so"); VAR c = forms.Color;\nc.|'
+    );
+    return r.members.includes('cornflowerblue') || 'got members=' + r.members.slice(0, 5);
+});
+
+test('class with EXTENDS chain (CanDo syntax)', () => {
+    const src = `
+        CLASS Animal = (self) { }
+        Animal.speak = FUNCTION(self) { };
+        CLASS Dog EXTENDS Animal = (self) { }
+        Dog.bark = FUNCTION(self) { };
+        VAR d = Dog();
+        d.|
+    `;
+    const r = membersAt(src);
+    return (r.members.includes('bark') && r.members.includes('speak'))
+        || ('expected bark+speak, got ' + r.members);
+});
+
+test('object literal with __index inheritance', () => {
+    const src = `
+        VAR base = { hello: FUNCTION() { } };
+        VAR derived = { __index: base, world: FUNCTION() { } };
+        derived.|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('hello') && r.members.includes('world')
+        || ('expected hello+world, got ' + r.members);
+});
+
+test('class instance method completion via colon', () => {
+    const src = `
+        CLASS Foo = (self) {
+            self.bar = FUNCTION(self) { };
+        }
+        Foo.greet = FUNCTION(self) { };
+        VAR f = Foo();
+        f:|
+    `;
+    const r = membersAt(src);
+    return (r.members.includes('bar') && r.members.includes('greet'))
+        || ('expected bar+greet, got ' + r.members);
+});
+
+test('class declared with empty body (CLASS Name = { })', () => {
+    const src = `
+        CLASS MathUtil = { }
+        MathUtil.square = FUNCTION(n) { };
+        MathUtil.cube   = FUNCTION(n) { };
+        MathUtil.|
+    `;
+    const r = membersAt(src);
+    return (r.members.includes('square') && r.members.includes('cube'))
+        || ('expected square+cube, got ' + r.members);
+});
+
+test('FUNCTION body declarations are tracked', () => {
+    const src = `
+        VAR forms = include("./forms.so");
+        FUNCTION makeForm() {
+            VAR f = forms.Form();
+            f.|
+            RETURN f;
+        }
+    `;
+    const r = membersAt(src);
+    return r.members.includes('center') || 'expected center, got ' + r.members.length;
+});
+
+/* =========================================================================
+ *  Include / path detection
+ * ======================================================================= */
+
+test('detect double-quoted include', () => {
+    const ctx = detectInclude('VAR x = include("./fo|");');
+    return ctx && ctx.typed === './fo' && ctx.quote === '"';
+});
+
+test('detect single-quoted include', () => {
+    const ctx = detectInclude("VAR x = include('./fo|');");
+    return ctx && ctx.typed === './fo' && ctx.quote === '\'';
+});
+
+test('include with whitespace before paren', () => {
+    const ctx = detectInclude('VAR x = include ("./fo|");');
+    return ctx !== null;
+});
+
+test('non-include string returns null', () => {
+    const ctx = detectInclude('VAR x = print("./fo|");');
+    return ctx === null;
+});
+
+test('cursor inside template-string is not include', () => {
+    const ctx = detectInclude('VAR x = `forms.|`;');
+    return ctx === null;
+});
+
+/* =========================================================================
+ *  Manifest pathological cases
+ * ======================================================================= */
+
+test('manifest with circular extends does not infinite-loop', () => {
+    /* Synthesize: write a manifest in a tmp dir with a cycle. */
+    const tmpDir = path.join(require('os').tmpdir(), 'cando-circ-' + process.pid);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'cando.api.json'), JSON.stringify({
+        name: 'circ',
+        exports: { make: { kind: 'function', returns: 'A' } },
+        types: {
+            A: { extends: 'B', members: { ax: { kind: 'value', type: 'string' } } },
+            B: { extends: 'A', members: { bx: { kind: 'value', type: 'string' } } }
+        }
+    }));
+    fs.writeFileSync(path.join(tmpDir, 'circ.so'), '');
+
+    const src = 'VAR m = include("' + tmpDir + '/circ.so");\nVAR a = m.make();\na.|';
+    const r = membersAt(src);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    return r.members.includes('ax') && r.members.includes('bx');
+});
+
+test('reference to missing type degrades gracefully', () => {
+    const tmpDir = path.join(require('os').tmpdir(), 'cando-miss-' + process.pid);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'cando.api.json'), JSON.stringify({
+        name: 'miss',
+        exports: { make: { kind: 'function', returns: 'NotDefined' } },
+        types: {}
+    }));
+
+    const src = 'VAR m = include("' + tmpDir + '/miss.so");\nVAR a = m.make();\na.|';
+    const r = membersAt(src);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    return r.members.length === 0;
+});
+
+test('malformed manifest does not crash', () => {
+    const tmpDir = path.join(require('os').tmpdir(), 'cando-bad-' + process.pid);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'cando.api.json'), '{ this is not json }');
+
+    const src = 'VAR m = include("' + tmpDir + '/x.so");\nm.|';
+    const r = membersAt(src);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    return r.type === 'any' || r.type === 'no-dot';
+});
+
+/* =========================================================================
+ *  Std-library namespaces
+ * ======================================================================= */
+
+test('std namespace member completion: math.', () => {
+    const r = membersAt('math.|');
+    return r.members.includes('pi') && r.members.includes('sqrt');
+});
+
+test('std namespace from variable: VAR m = math; m.', () => {
+    const r = membersAt('VAR m = math;\nm.|');
+    return r.members.includes('sqrt');
+});
+
+/* =========================================================================
+ *  More pathological / edge cases
+ * ======================================================================= */
+
+test('unterminated string in source does not crash completion', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nVAR s = "oops\nforms.|');
+    /* The lexer flags the unterminated string as an error token but
+     * subsequent tokens still parse. The receiver should still resolve. */
+    return r.members.length > 0 || ('expected resilience, type=' + r.type);
+});
+
+test('unmatched paren in source does not crash', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nVAR x = forms.Form(\nforms.|');
+    /* Very forgiving: we just need to not throw. */
+    return Array.isArray(r.members);
+});
+
+test('cursor inside template-string interpolation', () => {
+    /* `${...}` is captured as `interpolations` ranges by the lexer; we don't
+     * try to complete inside it. */
+    const r = membersAt('VAR forms = include("./forms.so");\nVAR s = `hi ${forms.|}`;');
+    /* Template strings are a single token, so the dot-detector should not
+     * find a dot before the cursor. Either no-dot or empty members is OK. */
+    return r.type === 'no-dot' || r.members.length === 0;
+});
+
+test('nested method chain across newlines', () => {
+    const r = membersAt(`
+        VAR forms = include("./forms.so");
+        forms
+            .Form()
+            .|
+    `);
+    return r.members.includes('center') || ('got members=' + r.members.slice(0, 5));
+});
+
+test('chained constants three levels deep', () => {
+    /* forms.Color is a manifest-typed constant table. */
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.Color.cornflower|');
+    return r.members.includes('cornflowerblue') || ('got members=' + r.members.slice(0, 5));
+});
+
+test('variable bound to a manifest type member function', () => {
+    const r = membersAt(
+        'VAR forms = include("./forms.so"); VAR ctor = forms.Form;\n' +
+        'ctor.|'
+    );
+    /* `ctor` aliases a function; functions don't have manifest members,
+     * so the result is empty -- but it must not crash. */
+    return Array.isArray(r.members);
+});
+
+test('VAR x = <complex chain>; x. resolves', () => {
+    const r = membersAt(
+        'VAR forms = include("./forms.so");\n' +
+        'VAR f = forms.Form(); VAR f2 = f;\n' +
+        'f2.|'
+    );
+    return r.members.includes('center') || ('got members=' + r.members.slice(0, 5));
+});
+
+test('manifest exported as VAR; module.member call', () => {
+    const r = membersAt(
+        'VAR forms = include("./forms.so");\n' +
+        'forms.Form():setText("hi"):|'
+    );
+    /* setText returns Form, so we should still be on a Form. */
+    return r.members.includes('center') || ('got members=' + r.members.slice(0, 5));
+});
+
+test('string method completion via colon', () => {
+    /* `"hi":` should offer string namespace methods. We don't currently
+     * track string-literal types, so this is expected to bail (acceptable). */
+    const r = membersAt('VAR x = "hi":|');
+    return r.type === 'string' ? r.members.includes('toUpper') || true : true;
+});
+
+test('large-ish file: 200 VAR decls + chain', () => {
+    let src = 'VAR forms = include("./forms.so");\n';
+    for (let n = 0; n < 200; n++) src += `VAR x${n} = ${n};\n`;
+    src += 'VAR f = forms.Form();\nf.|';
+    const r = membersAt(src);
+    return r.members.includes('center');
+});
+
+test('object literal with trailing comma', () => {
+    const r = membersAt('VAR cfg = { host: "x", port: 80, };\ncfg.|');
+    return r.members.includes('host') && r.members.includes('port');
+});
+
+test('object literal with quoted-string key', () => {
+    const r = membersAt('VAR cfg = { "host": "x", "port": 80 };\ncfg.|');
+    return r.members.includes('host') && r.members.includes('port');
+});
+
+test('object literal: nested object, only top-level keys', () => {
+    const r = membersAt('VAR cfg = { tls: { verify: TRUE }, port: 80 };\ncfg.|');
+    return r.members.includes('tls') && r.members.includes('port') && !r.members.includes('verify');
+});
+
+test('include with a leading ./ that no manifest matches', () => {
+    /* Synthesises a relative include that points at nothing. Should bail
+     * cleanly without crashing. */
+    const r = membersAt('VAR x = include("./does-not-exist.so");\nx.|');
+    return Array.isArray(r.members);
+});
+
+test('include() with non-string arg', () => {
+    /* The parser only treats `include` as special when followed by a
+     * string. Non-string args should just leave the binding unknown. */
+    const r = membersAt('VAR p = "./forms.so"; VAR x = include(p);\nx.|');
+    return r.members.length === 0;
+});
+
+test('chained call inside an argument list', () => {
+    /* Make sure findEnclosingCall doesn't get confused by inner `()`. */
+    const r = membersAt(
+        'VAR forms = include("./forms.so");\n' +
+        'print(forms.Form().|);'
+    );
+    return r.members.includes('center');
+});
+
+test('multi-level __index chain', () => {
+    const src = `
+        VAR a = { ax: 1 };
+        VAR b = { __index: a, bx: 2 };
+        VAR c = { __index: b, cx: 3 };
+        c.|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('ax') && r.members.includes('bx') && r.members.includes('cx');
+});
+
+test('cycle in __index chain does not infinite-loop', () => {
+    /* User-code cycles can\'t actually exist (the field is captured at
+     * parse time, no mutation during inference), but two records that
+     * mention each other should still terminate. */
+    const src = `
+        VAR a = { ax: 1, __index: b };
+        VAR b = { bx: 2, __index: a };
+        a.|
+    `;
+    const r = membersAt(src);
+    return Array.isArray(r.members);
+});
+
+test('CLASS without body still recognised as class', () => {
+    /* `CLASS Foo` (no `=`) is technically incomplete but the analyzer
+     * should not crash. */
+    const r = membersAt('CLASS Foo\nFoo.|');
+    return Array.isArray(r.members);
+});
+
+test('manifest hover on a member shows its details', () => {
+    /* Sanity-check that completion items contain a detail we can format. */
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.Form().setT|');
+    return r.members.includes('setText');
+});
+
+/* =========================================================================
+ *  Real-world idioms (from tests/scripts/metamethods.cdo etc.)
+ * ======================================================================= */
+
+test('canonical Animal/Dog from metamethods.cdo', () => {
+    const src = `
+        CLASS Animal = (self, name) {
+            self.name = name;
+        }
+        Animal.greet = FUNCTION(self) { RETURN "hi " + self.name; };
+        VAR a = Animal("Rex");
+        a.|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('greet') && r.members.includes('name');
+});
+
+test('Counter constructor with self.count', () => {
+    const src = `
+        CLASS Counter = (self, start) { self.count = start; }
+        Counter.inc = FUNCTION(self) { self.count = self.count + 1; };
+        Counter.get = FUNCTION(self) { RETURN self.count; };
+        VAR c = Counter(0);
+        c.|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('inc') && r.members.includes('get') && r.members.includes('count');
+});
+
+test('Base/Derived chain with EXTENDS', () => {
+    const src = `
+        CLASS Base = (self) { }
+        Base.greet = FUNCTION(self) { RETURN "base"; };
+        CLASS Derived EXTENDS Base = (self) { }
+        Derived.bark = FUNCTION(self) { };
+        VAR d = Derived();
+        d.|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('greet') && r.members.includes('bark');
+});
+
+test('object.setPrototype-style runtime chain', () => {
+    /* This pattern uses runtime mutation; the static analyser can\'t see
+     * past it, but should still surface the literal\'s own keys. */
+    const src = `
+        VAR proto = { x: 10, greet: "hello" };
+        VAR child = { y: 20 };
+        object.setPrototype(child, proto);
+        child.|
+    `;
+    const r = membersAt(src);
+    return r.members.includes('y');
+});
+
+/* =========================================================================
+ *  Stress / performance
+ * ======================================================================= */
+
+test('deep manifest hierarchy: forms.Button() inherits from Control', () => {
+    const r = membersAt(
+        'VAR forms = include("./forms.so");\n' +
+        'VAR f = forms.Form(); VAR b = forms.Button(f);\n' +
+        'b.|'
+    );
+    /* setText (Control), onClick (Button), Derma alias SetText (Control). */
+    return r.members.includes('setText')
+        && r.members.includes('onClick')
+        && r.members.includes('SetText');
+});
+
+test('1k-line file completes in under 500ms', () => {
+    let src = 'VAR forms = include("./forms.so");\n';
+    for (let n = 0; n < 1000; n++) src += `VAR x${n} = ${n};\n`;
+    src += 'VAR f = forms.Form();\nf.|';
+    const start = Date.now();
+    const r = membersAt(src);
+    const ms = Date.now() - start;
+    if (!r.members.includes('center')) return 'missing center, members=' + r.members.length;
+    if (ms > 500) return `too slow: ${ms}ms`;
+    return true;
+});
+
+test('repeated completion does not leak memory: 100 cycles', () => {
+    let src = 'VAR forms = include("./forms.so");\nVAR f = forms.Form();\nf.|';
+    const start = process.memoryUsage().heapUsed;
+    for (let n = 0; n < 100; n++) membersAt(src);
+    const after = process.memoryUsage().heapUsed;
+    /* Allow 50MB drift for JIT warmup; assert no runaway. */
+    return (after - start) < 50 * 1024 * 1024;
+});
+
+/* =========================================================================
+ *  General (non-member) completion
+ * ======================================================================= */
+
+test('top-level completion includes user VARs', () => {
+    /* Simulated by feeding the analyser; we can\'t hit the real connection. */
+    const { symbols } = envFor('VAR myVar = 1;\nVAR myFn = FUNCTION() { };\nmy|');
+    return symbols.some(s => s.name === 'myVar') && symbols.some(s => s.name === 'myFn');
+});
+
+/* =========================================================================
+ *  Document & cursor edge cases
+ * ======================================================================= */
+
+test('completion at end of empty document does not crash', () => {
+    const { env } = envFor('');
+    return env.bindings.size === 0;
+});
+
+test('completion on a document with only comments', () => {
+    const { env } = envFor('// just comments\n/* and a block */');
+    return env.bindings.size === 0;
+});
+
+test('CRLF line endings work', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\r\nVAR f = forms.Form();\r\nf.|');
+    return r.members.includes('center');
+});
+
+test('tabs in source are tolerated', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\n\tVAR f = forms.Form();\n\tf.|');
+    return r.members.includes('center');
+});
+
+test('cursor at end of file (no trailing whitespace)', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.|');
+    return r.members.includes('Form');
+});
+
+test('chained call with no arguments', () => {
+    const r = membersAt('VAR forms = include("./forms.so");\nforms.Form().show().|');
+    return r.members.includes('center') || ('got members=' + r.members.slice(0, 5));
+});
+
+test('chained call with multiple args', () => {
+    const r = membersAt('VAR forms = include("./forms.so"); VAR f = forms.Form();\nf:setSize(800, 600):|');
+    return r.members.includes('center');
+});
+
+/* =========================================================================
+ *  Run + report
+ * ======================================================================= */
+
+console.log('\n=== Edge-case harness ===');
+console.log(`PASS: ${pass}`);
+console.log(`FAIL: ${fail}`);
+if (failures.length) {
+    console.log('\n--- Failures ---');
+    for (const f of failures) {
+        console.log('\n* ' + f.name);
+        console.log('    ' + (typeof f.reason === 'string' ? f.reason : JSON.stringify(f.reason)).split('\n').join('\n    '));
+    }
+    process.exit(1);
+}

--- a/editors/vscode-cando/snippets/cando.code-snippets
+++ b/editors/vscode-cando/snippets/cando.code-snippets
@@ -162,6 +162,36 @@
     "body": ["print(${0:value});"],
     "description": "Print to stdout."
   },
+  "Include module": {
+    "prefix": ["include", "import", "require"],
+    "body": ["VAR ${1:name} = include(\"${2:./module.cdo}\");"],
+    "description": "Load a module via include() and bind it to a variable."
+  },
+  "Include binary module (cross-platform)": {
+    "prefix": ["includeso", "includebin"],
+    "body": [
+      "VAR ${1:mod};",
+      "TRY {",
+      "\t${1:mod} = include(\"./${2:module}.so\");",
+      "} CATCH e {",
+      "\tTRY {",
+      "\t\t${1:mod} = include(\"./${2:module}.dylib\");",
+      "\t} CATCH e2 {",
+      "\t\t${1:mod} = include(\"./${2:module}.dll\");",
+      "\t}",
+      "}"
+    ],
+    "description": "Load a binary module, falling back across platform extensions."
+  },
+  "Module export object": {
+    "prefix": ["return", "export"],
+    "body": [
+      "RETURN {",
+      "\t${1:name}: ${0:value}",
+      "};"
+    ],
+    "description": "Return an object literal as the module's exports."
+  },
   "Thread spawn": {
     "prefix": ["thread", "THREAD"],
     "body": ["THREAD ${0:expr};"],

--- a/modules/draw/cando.api.json
+++ b/modules/draw/cando.api.json
@@ -1,0 +1,58 @@
+{
+    "$comment": "API manifest for the draw module (immediate-mode 2D drawing). Read by the vscode-cando language server.",
+    "name": "draw",
+    "doc": "Immediate-mode 2D drawing on top of a window's GL context. Image / font instances inherit methods from `_meta.draw_image` and `_meta.draw_font` via `__index`.",
+    "exports": {
+        "clear":         { "kind": "function", "params": [{ "name": "r", "type": "number" }, { "name": "g", "type": "number" }, { "name": "b", "type": "number" }, { "name": "a", "type": "number", "optional": true }] },
+        "setColor":      { "kind": "function", "params": [{ "name": "r", "type": "number" }, { "name": "g", "type": "number" }, { "name": "b", "type": "number" }, { "name": "a", "type": "number", "optional": true }] },
+        "getColor":      { "kind": "function", "returns": "number", "doc": "Multi-return current `r, g, b, a`." },
+        "setLineWidth":  { "kind": "function", "params": [{ "name": "px", "type": "number" }] },
+        "getLineWidth":  { "kind": "function", "returns": "number" },
+        "setScissor":    { "kind": "function", "params": [{ "name": "x", "type": "number", "optional": true }, { "name": "y", "type": "number", "optional": true }, { "name": "w", "type": "number", "optional": true }, { "name": "h", "type": "number", "optional": true }], "doc": "Pass no arguments to disable." },
+        "setFont":       { "kind": "function", "params": [{ "name": "font", "type": "Font" }] },
+
+        "push":          { "kind": "function" },
+        "pop":           { "kind": "function" },
+        "translate":     { "kind": "function", "params": [{ "name": "x", "type": "number" }, { "name": "y", "type": "number" }] },
+        "scale":         { "kind": "function", "params": [{ "name": "sx", "type": "number" }, { "name": "sy", "type": "number", "optional": true }] },
+        "rotate":        { "kind": "function", "params": [{ "name": "rad", "type": "number" }] },
+        "origin":        { "kind": "function" },
+
+        "rectangle":     { "kind": "function", "params": [{ "name": "mode", "type": "string", "doc": "\"fill\" or \"line\"" }, { "name": "x", "type": "number" }, { "name": "y", "type": "number" }, { "name": "w", "type": "number" }, { "name": "h", "type": "number" }] },
+        "circle":        { "kind": "function", "params": [{ "name": "mode", "type": "string" }, { "name": "cx", "type": "number" }, { "name": "cy", "type": "number" }, { "name": "r", "type": "number" }, { "name": "segments", "type": "number", "optional": true }] },
+        "line":          { "kind": "function", "params": [{ "name": "coords", "type": "number", "rest": true }], "doc": "Variadic `x, y` pairs." },
+
+        "newImage":      { "kind": "function", "params": [{ "name": "path", "type": "string" }], "returns": "Image" },
+        "draw":          { "kind": "function", "params": [{ "name": "image", "type": "Image" }, { "name": "x", "type": "number" }, { "name": "y", "type": "number" }, { "name": "r", "type": "number", "optional": true }, { "name": "sx", "type": "number", "optional": true }, { "name": "sy", "type": "number", "optional": true }, { "name": "ox", "type": "number", "optional": true }, { "name": "oy", "type": "number", "optional": true }] },
+
+        "newFont":       { "kind": "function", "params": [{ "name": "path", "type": "string" }, { "name": "pixelHeight", "type": "number" }], "returns": "Font" },
+        "print":         { "kind": "function", "params": [{ "name": "text", "type": "string" }, { "name": "x", "type": "number" }, { "name": "y", "type": "number" }, { "name": "r", "type": "number", "optional": true }, { "name": "sx", "type": "number", "optional": true }, { "name": "sy", "type": "number", "optional": true }] }
+    },
+
+    "types": {
+        "Image": {
+            "indexes": "_meta.draw_image",
+            "members": {}
+        },
+        "Font": {
+            "indexes": "_meta.draw_font",
+            "members": {}
+        },
+        "_meta.draw_image": {
+            "members": {
+                "getWidth":      { "kind": "function", "returns": "number" },
+                "getHeight":     { "kind": "function", "returns": "number" },
+                "getDimensions": { "kind": "function", "returns": "number", "doc": "Multi-return `w, h`." },
+                "setFilter":     { "kind": "function", "params": [{ "name": "filter", "type": "string", "doc": "\"nearest\" or \"linear\"" }] },
+                "release":       { "kind": "function" }
+            }
+        },
+        "_meta.draw_font": {
+            "members": {
+                "getWidth":  { "kind": "function", "params": [{ "name": "text", "type": "string" }], "returns": "number" },
+                "getHeight": { "kind": "function", "returns": "number" },
+                "release":   { "kind": "function" }
+            }
+        }
+    }
+}

--- a/modules/forms/cando.api.json
+++ b/modules/forms/cando.api.json
@@ -1,0 +1,355 @@
+{
+    "$comment": "API manifest for the forms module (CanDo Windows Forms binding). Read by the vscode-cando language server to power autocompletion, hover, and signature help. Match modules/forms/README.md and modules/forms/forms_module.c when extending.",
+    "name": "forms",
+    "version": "1.0.0",
+    "doc": "Native UI toolkit. Mirrors System.Windows.Forms; method-style calls (`f:setText(...)`) pass the receiver as the first argument. On non-Windows platforms `forms.supported` is FALSE and constructors throw.",
+    "exports": {
+        "VERSION":   { "kind": "value", "type": "string", "doc": "Module version, e.g. \"1.0.0\"." },
+        "platform":  { "kind": "value", "type": "string", "doc": "\"windows\" or \"stub\"." },
+        "supported": { "kind": "value", "type": "bool",   "doc": "TRUE on Windows, FALSE everywhere else." },
+
+        "Color":         { "kind": "value", "type": "ColorPalette", "doc": "CSS-style colour palette (`forms.Color.cornflowerblue` etc.)." },
+        "Dock":          { "kind": "value", "type": "DockEnum",     "doc": "Dock side constants." },
+        "Anchor":        { "kind": "value", "type": "AnchorEnum",   "doc": "Anchor edge bitmask constants." },
+        "AutoSizeMode":  { "kind": "value", "type": "AutoSizeEnum", "doc": "Auto-size growth modes." },
+        "BorderStyle":   { "kind": "value", "type": "BorderEnum",   "doc": "Border styles for `setBorderStyle`." },
+        "Cursor":        { "kind": "value", "type": "CursorEnum",   "doc": "String aliases for `setCursor`." },
+
+        "Form":            { "kind": "function", "params": [],                                                "returns": "Form",            "doc": "Top-level form. No parent argument." },
+        "Button":          { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Button",        "doc": "Standard `BUTTON` push-button." },
+        "Label":           { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Label",         "doc": "Static text label." },
+        "LinkLabel":       { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "LinkLabel",     "doc": "Clickable hyperlink label (SysLink)." },
+        "TextBox":         { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "TextBox",       "doc": "Single- or multi-line text input." },
+        "CheckBox":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "CheckBox",      "doc": "Auto-toggle check box." },
+        "RadioButton":     { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "RadioButton",   "doc": "Auto-radio button." },
+        "ComboBox":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "ComboBox",      "doc": "Drop-down list of items." },
+        "ListBox":         { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "ListBox",       "doc": "Scrolling list of items." },
+        "Panel":           { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Panel",         "doc": "Plain container." },
+        "GroupBox":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "GroupBox",      "doc": "Captioned container with a frame." },
+        "ProgressBar":     { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "ProgressBar",   "doc": "Horizontal progress bar." },
+        "TrackBar":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "TrackBar",      "doc": "Slider with optional ticks." },
+        "NumericUpDown":   { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "NumericUpDown", "doc": "Numeric edit + spin buttons." },
+        "PictureBox":      { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "PictureBox",    "doc": "Static bitmap container." },
+        "DateTimePicker":  { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "DateTimePicker","doc": "Drop-down date / time selector." },
+        "MonthCalendar":   { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "MonthCalendar", "doc": "Month-grid calendar." },
+        "StatusBar":       { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "StatusBar",     "doc": "Bottom-of-form status bar." },
+        "Spinner":         { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Spinner",       "doc": "Standalone up/down spinner." }
+    },
+
+    "types": {
+        "Control": {
+            "doc": "Base class for every widget. All getter/setter methods that don't apply to a given control kind are silent no-ops, so script code can stay untyped.",
+            "members": {
+                "setText":           { "kind": "function", "params": [{ "name": "s", "type": "string" }],                              "returns": "Control", "aliases": ["SetText"], "doc": "Set the caption / value." },
+                "getText":           { "kind": "function", "returns": "string", "aliases": ["GetText"], "doc": "Get the current caption / value." },
+                "setLocation":       { "kind": "function", "params": [{ "name": "x", "type": "number" }, { "name": "y", "type": "number" }], "returns": "Control", "aliases": ["setPosition", "SetPos"] },
+                "getLocation":       { "kind": "function", "returns": "number", "aliases": ["getPosition", "GetPos"], "doc": "Returns `x, y` (multi-return)." },
+                "setSize":           { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Control", "aliases": ["SetSize"] },
+                "getSize":           { "kind": "function", "returns": "number", "doc": "Returns `w, h` (multi-return)." },
+                "setWidth":          { "kind": "function", "params": [{ "name": "w", "type": "number" }], "returns": "Control" },
+                "setHeight":         { "kind": "function", "params": [{ "name": "h", "type": "number" }], "returns": "Control" },
+                "getWidth":          { "kind": "function", "returns": "number" },
+                "getHeight":         { "kind": "function", "returns": "number" },
+
+                "sizeToContent":        { "kind": "function", "returns": "Control", "aliases": ["SizeToContents"], "doc": "Resize to the control's natural size." },
+                "sizeToContentWidth":   { "kind": "function", "returns": "Control" },
+                "sizeToContentHeight":  { "kind": "function", "returns": "Control" },
+                "getPreferredSize":     { "kind": "function", "returns": "number", "doc": "Returns `w, h` without resizing." },
+                "setAutoSize":          { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control" },
+                "getAutoSize":          { "kind": "function", "returns": "bool" },
+                "setAutoSizeMode":      { "kind": "function", "params": [{ "name": "mode", "type": "string", "doc": "\"grow\" or \"growShrink\"" }], "returns": "Control" },
+
+                "setPadding":   { "kind": "function", "params": [{ "name": "values", "type": "any", "rest": true }], "returns": "Control", "aliases": ["DockPadding"] },
+                "getPadding":   { "kind": "function", "returns": "number", "doc": "Returns `l, t, r, b`." },
+                "setMargin":    { "kind": "function", "params": [{ "name": "values", "type": "any", "rest": true }], "returns": "Control", "aliases": ["DockMargin"] },
+                "getMargin":    { "kind": "function", "returns": "number", "doc": "Returns `l, t, r, b`." },
+
+                "setAnchor":    { "kind": "function", "params": [{ "name": "spec", "type": "any", "doc": "string list, mask integer, or AnchorEnum value" }], "returns": "Control" },
+                "getAnchor":    { "kind": "function", "returns": "number" },
+
+                "show":         { "kind": "function", "returns": "Control" },
+                "hide":         { "kind": "function", "returns": "Control" },
+                "setVisible":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control", "aliases": ["SetVisible"] },
+                "getVisible":   { "kind": "function", "returns": "bool", "aliases": ["isVisible"] },
+
+                "setEnabled":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control", "aliases": ["SetEnabled"] },
+                "getEnabled":   { "kind": "function", "returns": "bool", "aliases": ["isEnabled"] },
+                "focus":        { "kind": "function", "returns": "Control", "doc": "Give the control keyboard focus." },
+                "hasFocus":     { "kind": "function", "returns": "bool" },
+
+                "setParent":    { "kind": "function", "params": [{ "name": "other", "type": "Control" }], "returns": "Control" },
+                "bringToFront": { "kind": "function", "returns": "Control", "aliases": ["MoveToFront"] },
+                "sendToBack":   { "kind": "function", "returns": "Control", "aliases": ["MoveToBack"] },
+                "refresh":      { "kind": "function", "returns": "Control", "aliases": ["invalidate"] },
+                "destroy":      { "kind": "function", "returns": "bool", "aliases": ["remove", "Remove"] },
+                "isOpen":       { "kind": "function", "returns": "bool" },
+
+                "setFont":         { "kind": "function", "params": [{ "name": "spec", "type": "any", "doc": "(face), (face,size), (face,size,style) or {face,size,bold,italic,underline,strikeout}" }, { "name": "rest", "type": "any", "rest": true, "optional": true }], "returns": "Control" },
+                "setFontSize":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "Control" },
+                "setBold":         { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
+                "setItalic":       { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
+                "setUnderline":    { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
+                "setStrikeout":    { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
+                "clearFont":       { "kind": "function", "returns": "Control" },
+                "getFont":         { "kind": "function", "returns": "object", "doc": "Returns `{face, size, bold, italic, underline, strikeout}` or NULL." },
+
+                "setForeColor":    { "kind": "function", "params": [{ "name": "spec", "type": "any", "rest": true }], "returns": "Control", "aliases": ["setColor"] },
+                "setBackColor":    { "kind": "function", "params": [{ "name": "spec", "type": "any", "rest": true }], "returns": "Control", "aliases": ["setBackground"] },
+                "getForeColor":    { "kind": "function", "returns": "number" },
+                "getBackColor":    { "kind": "function", "returns": "number" },
+                "clearForeColor":  { "kind": "function", "returns": "Control" },
+                "clearBackColor":  { "kind": "function", "returns": "Control" },
+
+                "setDock":         { "kind": "function", "params": [{ "name": "side", "type": "string" }], "returns": "Control", "aliases": ["Dock"] },
+                "getDock":         { "kind": "function", "returns": "number" },
+                "relayout":        { "kind": "function", "returns": "Control", "aliases": ["InvalidateLayout"] },
+
+                "setToolTip":      { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "Control" },
+                "setCursor":       { "kind": "function", "params": [{ "name": "name", "type": "string" }], "returns": "Control" },
+
+                "getParent":       { "kind": "function", "returns": "Control" },
+                "getChildren":     { "kind": "function", "returns": "array" },
+                "contains":        { "kind": "function", "params": [{ "name": "other", "type": "Control" }], "returns": "bool" },
+
+                "setTabIndex":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "Control" },
+                "getTabIndex":     { "kind": "function", "returns": "number" },
+                "setTabStop":      { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control" },
+
+                "onClick":         { "kind": "event", "signature": "function(self, button, x, y)" },
+                "onTextChanged":   { "kind": "event", "signature": "function(self)" },
+                "onValueChanged":  { "kind": "event", "signature": "function(self)" },
+                "onSelectionChanged": { "kind": "event", "signature": "function(self)" },
+                "onKeyDown":       { "kind": "event", "signature": "function(self, vk)" },
+                "onKeyUp":         { "kind": "event", "signature": "function(self, vk)" },
+                "onMouseDown":     { "kind": "event", "signature": "function(self, button, x, y)" },
+                "onMouseUp":       { "kind": "event", "signature": "function(self, button, x, y)" },
+                "onMouseMove":     { "kind": "event", "signature": "function(self, x, y)" },
+                "onFocus":         { "kind": "event", "signature": "function(self)" },
+                "onBlur":          { "kind": "event", "signature": "function(self)" }
+            }
+        },
+
+        "Form": {
+            "doc": "Top-level window. The script keeps running while forms are open; each form holds a VM lifeline until destroyed.",
+            "extends": "Control",
+            "members": {
+                "setTitle":         { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "Form", "doc": "Alias of setText." },
+                "center":           { "kind": "function", "returns": "Form", "aliases": ["centre", "Center"] },
+                "setOpacity":       { "kind": "function", "params": [{ "name": "alpha", "type": "number" }], "returns": "Form" },
+                "getOpacity":       { "kind": "function", "returns": "number" },
+                "setTopMost":       { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
+                "setMinSize":       { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Form" },
+                "setMaxSize":       { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Form" },
+                "setBorderStyle":   { "kind": "function", "params": [{ "name": "style", "type": "string", "doc": "\"none\", \"single\", or \"3d\"" }], "returns": "Form" },
+
+                "setIcon":          { "kind": "function", "params": [{ "name": "path", "type": "string" }], "returns": "Form" },
+                "flash":            { "kind": "function", "params": [{ "name": "n", "type": "number", "optional": true }], "returns": "Form" },
+                "maximize":         { "kind": "function", "returns": "Form" },
+                "minimize":         { "kind": "function", "returns": "Form" },
+                "restore":          { "kind": "function", "returns": "Form" },
+                "setWindowState":   { "kind": "function", "params": [{ "name": "state", "type": "string" }], "returns": "Form" },
+                "getWindowState":   { "kind": "function", "returns": "string" },
+                "setResizable":     { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
+                "setMinimizeBox":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
+                "setMaximizeBox":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
+                "setShowInTaskbar": { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
+                "setAcceptButton":  { "kind": "function", "params": [{ "name": "btn", "type": "Button" }], "returns": "Form" },
+                "setCancelButton":  { "kind": "function", "params": [{ "name": "btn", "type": "Button" }], "returns": "Form" },
+
+                "onClose":  { "kind": "event", "signature": "function(self)" },
+                "onShown":  { "kind": "event", "signature": "function(self)" },
+                "onResize": { "kind": "event", "signature": "function(self, w, h)" }
+            }
+        },
+
+        "Button": {
+            "extends": "Control",
+            "indexes": "Control",
+            "members": {
+                "onClick": { "kind": "event", "signature": "function(self)" }
+            }
+        },
+
+        "Label": {
+            "extends": "Control",
+            "members": {
+                "setTextAlign": { "kind": "function", "params": [{ "name": "align", "type": "string", "doc": "\"left\", \"center\", or \"right\"" }], "returns": "Label" }
+            }
+        },
+
+        "LinkLabel": {
+            "extends": "Control",
+            "doc": "Clickable hyperlink. Activations fire `onClick`.",
+            "members": {}
+        },
+
+        "TextBox": {
+            "extends": "Control",
+            "members": {
+                "setMultiline":     { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "TextBox" },
+                "setReadOnly":      { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "TextBox" },
+                "setPlaceholder":   { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "TextBox", "aliases": ["setHint"] },
+                "setPasswordChar":  { "kind": "function", "params": [{ "name": "c", "type": "string" }], "returns": "TextBox" },
+                "setMaxLength":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TextBox" },
+                "setTextAlign":     { "kind": "function", "params": [{ "name": "align", "type": "string" }], "returns": "TextBox" },
+                "selectAll":        { "kind": "function", "returns": "TextBox" },
+                "appendText":       { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "TextBox" },
+                "clear":            { "kind": "function", "returns": "TextBox" },
+                "setValue":         { "kind": "function", "params": [{ "name": "v", "type": "any" }], "returns": "TextBox" },
+                "getValue":         { "kind": "function", "returns": "any" }
+            }
+        },
+
+        "CheckBox": {
+            "extends": "Control",
+            "members": {
+                "setChecked": { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "CheckBox" },
+                "getChecked": { "kind": "function", "returns": "bool" }
+            }
+        },
+
+        "RadioButton": {
+            "extends": "Control",
+            "members": {
+                "setChecked": { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "RadioButton" },
+                "getChecked": { "kind": "function", "returns": "bool" }
+            }
+        },
+
+        "ListLike": {
+            "doc": "Common ListBox + ComboBox surface.",
+            "extends": "Control",
+            "members": {
+                "addItem":           { "kind": "function", "params": [{ "name": "text", "type": "string" }], "returns": "Control" },
+                "removeItem":        { "kind": "function", "params": [{ "name": "index", "type": "number" }], "returns": "Control" },
+                "clearItems":        { "kind": "function", "returns": "Control" },
+                "getItem":           { "kind": "function", "params": [{ "name": "index", "type": "number" }], "returns": "string" },
+                "getItems":          { "kind": "function", "returns": "array" },
+                "getItemCount":      { "kind": "function", "returns": "number" },
+                "getSelectedIndex":  { "kind": "function", "returns": "number" },
+                "setSelectedIndex":  { "kind": "function", "params": [{ "name": "i", "type": "number" }], "returns": "Control" },
+                "clear":             { "kind": "function", "returns": "Control" }
+            }
+        },
+        "ComboBox": { "extends": "ListLike", "members": {} },
+        "ListBox":  { "extends": "ListLike", "members": {} },
+
+        "Panel":    { "extends": "Control", "members": {} },
+        "GroupBox": { "extends": "Control", "members": {} },
+
+        "ProgressBar": {
+            "extends": "Control",
+            "members": {
+                "setValue":   { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "ProgressBar" },
+                "getValue":   { "kind": "function", "returns": "number" },
+                "setRange":   { "kind": "function", "params": [{ "name": "lo", "type": "number" }, { "name": "hi", "type": "number" }], "returns": "ProgressBar" },
+                "setMarquee": { "kind": "function", "params": [{ "name": "active", "type": "bool" }, { "name": "speed", "type": "number", "optional": true }], "returns": "ProgressBar" },
+                "setState":   { "kind": "function", "params": [{ "name": "state", "type": "string" }], "returns": "ProgressBar" },
+                "setStep":    { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "ProgressBar" },
+                "stepIt":     { "kind": "function", "returns": "ProgressBar" }
+            }
+        },
+
+        "TrackBar": {
+            "extends": "Control",
+            "members": {
+                "setValue":         { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" },
+                "getValue":         { "kind": "function", "returns": "number" },
+                "setRange":         { "kind": "function", "params": [{ "name": "lo", "type": "number" }, { "name": "hi", "type": "number" }], "returns": "TrackBar" },
+                "setTickFrequency": { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" },
+                "setSmallStep":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" },
+                "setLargeStep":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" }
+            }
+        },
+
+        "NumericUpDown": {
+            "extends": "Control",
+            "members": {
+                "setValue":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "NumericUpDown" },
+                "getValue":     { "kind": "function", "returns": "number" },
+                "setIncrement": { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "NumericUpDown" }
+            }
+        },
+
+        "PictureBox":     { "extends": "Control", "members": {} },
+        "DateTimePicker": { "extends": "Control", "members": {} },
+        "MonthCalendar":  { "extends": "Control", "members": {} },
+        "StatusBar":      { "extends": "Control", "members": {} },
+        "Spinner":        { "extends": "Control", "members": {} },
+
+        "ColorPalette": {
+            "doc": "0xRRGGBB packed colour constants. The same names are accepted as strings by setForeColor / setBackColor.",
+            "members": {
+                "red":             { "kind": "constant", "type": "number" },
+                "green":           { "kind": "constant", "type": "number" },
+                "blue":            { "kind": "constant", "type": "number" },
+                "white":           { "kind": "constant", "type": "number" },
+                "black":           { "kind": "constant", "type": "number" },
+                "yellow":          { "kind": "constant", "type": "number" },
+                "magenta":         { "kind": "constant", "type": "number" },
+                "cyan":            { "kind": "constant", "type": "number" },
+                "cornflowerblue":  { "kind": "constant", "type": "number" },
+                "steelblue":       { "kind": "constant", "type": "number" },
+                "darkgreen":       { "kind": "constant", "type": "number" },
+                "darkred":         { "kind": "constant", "type": "number" },
+                "darkblue":        { "kind": "constant", "type": "number" },
+                "lightgray":       { "kind": "constant", "type": "number" },
+                "darkgray":        { "kind": "constant", "type": "number" },
+                "orange":          { "kind": "constant", "type": "number" },
+                "purple":          { "kind": "constant", "type": "number" },
+                "pink":            { "kind": "constant", "type": "number" },
+                "brown":           { "kind": "constant", "type": "number" }
+            }
+        },
+        "DockEnum": {
+            "members": {
+                "none":   { "kind": "constant", "type": "number" },
+                "top":    { "kind": "constant", "type": "number" },
+                "bottom": { "kind": "constant", "type": "number" },
+                "left":   { "kind": "constant", "type": "number" },
+                "right":  { "kind": "constant", "type": "number" },
+                "fill":   { "kind": "constant", "type": "number" }
+            }
+        },
+        "AnchorEnum": {
+            "members": {
+                "none":   { "kind": "constant", "type": "number" },
+                "left":   { "kind": "constant", "type": "number" },
+                "top":    { "kind": "constant", "type": "number" },
+                "right":  { "kind": "constant", "type": "number" },
+                "bottom": { "kind": "constant", "type": "number" },
+                "all":    { "kind": "constant", "type": "number" }
+            }
+        },
+        "AutoSizeEnum": {
+            "members": {
+                "grow":       { "kind": "constant", "type": "string" },
+                "growShrink": { "kind": "constant", "type": "string" }
+            }
+        },
+        "BorderEnum": {
+            "members": {
+                "none":    { "kind": "constant", "type": "string" },
+                "single":  { "kind": "constant", "type": "string" },
+                "fixed3D": { "kind": "constant", "type": "string" }
+            }
+        },
+        "CursorEnum": {
+            "members": {
+                "arrow":       { "kind": "constant", "type": "string" },
+                "hand":        { "kind": "constant", "type": "string" },
+                "ibeam":       { "kind": "constant", "type": "string" },
+                "wait":        { "kind": "constant", "type": "string" },
+                "cross":       { "kind": "constant", "type": "string" },
+                "sizeNS":      { "kind": "constant", "type": "string" },
+                "sizeWE":      { "kind": "constant", "type": "string" },
+                "sizeNWSE":    { "kind": "constant", "type": "string" },
+                "sizeNESW":    { "kind": "constant", "type": "string" },
+                "sizeAll":     { "kind": "constant", "type": "string" },
+                "no":          { "kind": "constant", "type": "string" },
+                "help":        { "kind": "constant", "type": "string" },
+                "appStarting": { "kind": "constant", "type": "string" }
+            }
+        }
+    }
+}

--- a/modules/forms/cando.api.json
+++ b/modules/forms/cando.api.json
@@ -4,351 +4,1761 @@
     "version": "1.0.0",
     "doc": "Native UI toolkit. Mirrors System.Windows.Forms; method-style calls (`f:setText(...)`) pass the receiver as the first argument. On non-Windows platforms `forms.supported` is FALSE and constructors throw.",
     "exports": {
-        "VERSION":   { "kind": "value", "type": "string", "doc": "Module version, e.g. \"1.0.0\"." },
-        "platform":  { "kind": "value", "type": "string", "doc": "\"windows\" or \"stub\"." },
-        "supported": { "kind": "value", "type": "bool",   "doc": "TRUE on Windows, FALSE everywhere else." },
-
-        "Color":         { "kind": "value", "type": "ColorPalette", "doc": "CSS-style colour palette (`forms.Color.cornflowerblue` etc.)." },
-        "Dock":          { "kind": "value", "type": "DockEnum",     "doc": "Dock side constants." },
-        "Anchor":        { "kind": "value", "type": "AnchorEnum",   "doc": "Anchor edge bitmask constants." },
-        "AutoSizeMode":  { "kind": "value", "type": "AutoSizeEnum", "doc": "Auto-size growth modes." },
-        "BorderStyle":   { "kind": "value", "type": "BorderEnum",   "doc": "Border styles for `setBorderStyle`." },
-        "Cursor":        { "kind": "value", "type": "CursorEnum",   "doc": "String aliases for `setCursor`." },
-
-        "Form":            { "kind": "function", "params": [],                                                "returns": "Form",            "doc": "Top-level form. No parent argument." },
-        "Button":          { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Button",        "doc": "Standard `BUTTON` push-button." },
-        "Label":           { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Label",         "doc": "Static text label." },
-        "LinkLabel":       { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "LinkLabel",     "doc": "Clickable hyperlink label (SysLink)." },
-        "TextBox":         { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "TextBox",       "doc": "Single- or multi-line text input." },
-        "CheckBox":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "CheckBox",      "doc": "Auto-toggle check box." },
-        "RadioButton":     { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "RadioButton",   "doc": "Auto-radio button." },
-        "ComboBox":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "ComboBox",      "doc": "Drop-down list of items." },
-        "ListBox":         { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "ListBox",       "doc": "Scrolling list of items." },
-        "Panel":           { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Panel",         "doc": "Plain container." },
-        "GroupBox":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "GroupBox",      "doc": "Captioned container with a frame." },
-        "ProgressBar":     { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "ProgressBar",   "doc": "Horizontal progress bar." },
-        "TrackBar":        { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "TrackBar",      "doc": "Slider with optional ticks." },
-        "NumericUpDown":   { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "NumericUpDown", "doc": "Numeric edit + spin buttons." },
-        "PictureBox":      { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "PictureBox",    "doc": "Static bitmap container." },
-        "DateTimePicker":  { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "DateTimePicker","doc": "Drop-down date / time selector." },
-        "MonthCalendar":   { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "MonthCalendar", "doc": "Month-grid calendar." },
-        "StatusBar":       { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "StatusBar",     "doc": "Bottom-of-form status bar." },
-        "Spinner":         { "kind": "function", "params": [{ "name": "parent", "type": "Control" }, { "name": "options", "type": "any", "optional": true }], "returns": "Spinner",       "doc": "Standalone up/down spinner." }
+        "VERSION": {
+            "kind": "value",
+            "type": "string",
+            "doc": "Module version, e.g. \"1.0.0\"."
+        },
+        "platform": {
+            "kind": "value",
+            "type": "string",
+            "doc": "\"windows\" or \"stub\"."
+        },
+        "supported": {
+            "kind": "value",
+            "type": "bool",
+            "doc": "TRUE on Windows, FALSE everywhere else."
+        },
+        "Color": {
+            "kind": "value",
+            "type": "ColorPalette",
+            "doc": "CSS-style colour palette (`forms.Color.cornflowerblue` etc.)."
+        },
+        "Dock": {
+            "kind": "value",
+            "type": "DockEnum",
+            "doc": "Dock side constants."
+        },
+        "Anchor": {
+            "kind": "value",
+            "type": "AnchorEnum",
+            "doc": "Anchor edge bitmask constants."
+        },
+        "AutoSizeMode": {
+            "kind": "value",
+            "type": "AutoSizeEnum",
+            "doc": "Auto-size growth modes."
+        },
+        "BorderStyle": {
+            "kind": "value",
+            "type": "BorderEnum",
+            "doc": "Border styles for `setBorderStyle`."
+        },
+        "Cursor": {
+            "kind": "value",
+            "type": "CursorEnum",
+            "doc": "String aliases for `setCursor`."
+        },
+        "Form": {
+            "kind": "function",
+            "params": [],
+            "returns": "Form",
+            "doc": "Top-level form. No parent argument."
+        },
+        "Button": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "Button",
+            "doc": "Standard `BUTTON` push-button."
+        },
+        "Label": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "Label",
+            "doc": "Static text label."
+        },
+        "LinkLabel": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "LinkLabel",
+            "doc": "Clickable hyperlink label (SysLink)."
+        },
+        "TextBox": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "TextBox",
+            "doc": "Single- or multi-line text input."
+        },
+        "CheckBox": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "CheckBox",
+            "doc": "Auto-toggle check box."
+        },
+        "RadioButton": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "RadioButton",
+            "doc": "Auto-radio button."
+        },
+        "ComboBox": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "ComboBox",
+            "doc": "Drop-down list of items."
+        },
+        "ListBox": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "ListBox",
+            "doc": "Scrolling list of items."
+        },
+        "Panel": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "Panel",
+            "doc": "Plain container."
+        },
+        "GroupBox": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "GroupBox",
+            "doc": "Captioned container with a frame."
+        },
+        "ProgressBar": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "ProgressBar",
+            "doc": "Horizontal progress bar."
+        },
+        "TrackBar": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "TrackBar",
+            "doc": "Slider with optional ticks."
+        },
+        "NumericUpDown": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "NumericUpDown",
+            "doc": "Numeric edit + spin buttons."
+        },
+        "PictureBox": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "PictureBox",
+            "doc": "Static bitmap container."
+        },
+        "DateTimePicker": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "DateTimePicker",
+            "doc": "Drop-down date / time selector."
+        },
+        "MonthCalendar": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "MonthCalendar",
+            "doc": "Month-grid calendar."
+        },
+        "StatusBar": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "StatusBar",
+            "doc": "Bottom-of-form status bar."
+        },
+        "Spinner": {
+            "kind": "function",
+            "params": [
+                {
+                    "name": "parent",
+                    "type": "Control"
+                },
+                {
+                    "name": "options",
+                    "type": "any",
+                    "optional": true
+                }
+            ],
+            "returns": "Spinner",
+            "doc": "Standalone up/down spinner."
+        }
     },
-
     "types": {
         "Control": {
             "doc": "Base class for every widget. All getter/setter methods that don't apply to a given control kind are silent no-ops, so script code can stay untyped.",
             "members": {
-                "setText":           { "kind": "function", "params": [{ "name": "s", "type": "string" }],                              "returns": "Control", "aliases": ["SetText"], "doc": "Set the caption / value." },
-                "getText":           { "kind": "function", "returns": "string", "aliases": ["GetText"], "doc": "Get the current caption / value." },
-                "setLocation":       { "kind": "function", "params": [{ "name": "x", "type": "number" }, { "name": "y", "type": "number" }], "returns": "Control", "aliases": ["setPosition", "SetPos"] },
-                "getLocation":       { "kind": "function", "returns": "number", "aliases": ["getPosition", "GetPos"], "doc": "Returns `x, y` (multi-return)." },
-                "setSize":           { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Control", "aliases": ["SetSize"] },
-                "getSize":           { "kind": "function", "returns": "number", "doc": "Returns `w, h` (multi-return)." },
-                "setWidth":          { "kind": "function", "params": [{ "name": "w", "type": "number" }], "returns": "Control" },
-                "setHeight":         { "kind": "function", "params": [{ "name": "h", "type": "number" }], "returns": "Control" },
-                "getWidth":          { "kind": "function", "returns": "number" },
-                "getHeight":         { "kind": "function", "returns": "number" },
-
-                "sizeToContent":        { "kind": "function", "returns": "Control", "aliases": ["SizeToContents"], "doc": "Resize to the control's natural size." },
-                "sizeToContentWidth":   { "kind": "function", "returns": "Control" },
-                "sizeToContentHeight":  { "kind": "function", "returns": "Control" },
-                "getPreferredSize":     { "kind": "function", "returns": "number", "doc": "Returns `w, h` without resizing." },
-                "setAutoSize":          { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control" },
-                "getAutoSize":          { "kind": "function", "returns": "bool" },
-                "setAutoSizeMode":      { "kind": "function", "params": [{ "name": "mode", "type": "string", "doc": "\"grow\" or \"growShrink\"" }], "returns": "Control" },
-
-                "setPadding":   { "kind": "function", "params": [{ "name": "values", "type": "any", "rest": true }], "returns": "Control", "aliases": ["DockPadding"] },
-                "getPadding":   { "kind": "function", "returns": "number", "doc": "Returns `l, t, r, b`." },
-                "setMargin":    { "kind": "function", "params": [{ "name": "values", "type": "any", "rest": true }], "returns": "Control", "aliases": ["DockMargin"] },
-                "getMargin":    { "kind": "function", "returns": "number", "doc": "Returns `l, t, r, b`." },
-
-                "setAnchor":    { "kind": "function", "params": [{ "name": "spec", "type": "any", "doc": "string list, mask integer, or AnchorEnum value" }], "returns": "Control" },
-                "getAnchor":    { "kind": "function", "returns": "number" },
-
-                "show":         { "kind": "function", "returns": "Control" },
-                "hide":         { "kind": "function", "returns": "Control" },
-                "setVisible":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control", "aliases": ["SetVisible"] },
-                "getVisible":   { "kind": "function", "returns": "bool", "aliases": ["isVisible"] },
-
-                "setEnabled":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control", "aliases": ["SetEnabled"] },
-                "getEnabled":   { "kind": "function", "returns": "bool", "aliases": ["isEnabled"] },
-                "focus":        { "kind": "function", "returns": "Control", "doc": "Give the control keyboard focus." },
-                "hasFocus":     { "kind": "function", "returns": "bool" },
-
-                "setParent":    { "kind": "function", "params": [{ "name": "other", "type": "Control" }], "returns": "Control" },
-                "bringToFront": { "kind": "function", "returns": "Control", "aliases": ["MoveToFront"] },
-                "sendToBack":   { "kind": "function", "returns": "Control", "aliases": ["MoveToBack"] },
-                "refresh":      { "kind": "function", "returns": "Control", "aliases": ["invalidate"] },
-                "destroy":      { "kind": "function", "returns": "bool", "aliases": ["remove", "Remove"] },
-                "isOpen":       { "kind": "function", "returns": "bool" },
-
-                "setFont":         { "kind": "function", "params": [{ "name": "spec", "type": "any", "doc": "(face), (face,size), (face,size,style) or {face,size,bold,italic,underline,strikeout}" }, { "name": "rest", "type": "any", "rest": true, "optional": true }], "returns": "Control" },
-                "setFontSize":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "Control" },
-                "setBold":         { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
-                "setItalic":       { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
-                "setUnderline":    { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
-                "setStrikeout":    { "kind": "function", "params": [{ "name": "b", "type": "bool"   }], "returns": "Control" },
-                "clearFont":       { "kind": "function", "returns": "Control" },
-                "getFont":         { "kind": "function", "returns": "object", "doc": "Returns `{face, size, bold, italic, underline, strikeout}` or NULL." },
-
-                "setForeColor":    { "kind": "function", "params": [{ "name": "spec", "type": "any", "rest": true }], "returns": "Control", "aliases": ["setColor"] },
-                "setBackColor":    { "kind": "function", "params": [{ "name": "spec", "type": "any", "rest": true }], "returns": "Control", "aliases": ["setBackground"] },
-                "getForeColor":    { "kind": "function", "returns": "number" },
-                "getBackColor":    { "kind": "function", "returns": "number" },
-                "clearForeColor":  { "kind": "function", "returns": "Control" },
-                "clearBackColor":  { "kind": "function", "returns": "Control" },
-
-                "setDock":         { "kind": "function", "params": [{ "name": "side", "type": "string" }], "returns": "Control", "aliases": ["Dock"] },
-                "getDock":         { "kind": "function", "returns": "number" },
-                "relayout":        { "kind": "function", "returns": "Control", "aliases": ["InvalidateLayout"] },
-
-                "setToolTip":      { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "Control" },
-                "setCursor":       { "kind": "function", "params": [{ "name": "name", "type": "string" }], "returns": "Control" },
-
-                "getParent":       { "kind": "function", "returns": "Control" },
-                "getChildren":     { "kind": "function", "returns": "array" },
-                "contains":        { "kind": "function", "params": [{ "name": "other", "type": "Control" }], "returns": "bool" },
-
-                "setTabIndex":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "Control" },
-                "getTabIndex":     { "kind": "function", "returns": "number" },
-                "setTabStop":      { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Control" },
-
-                "onClick":         { "kind": "event", "signature": "function(self, button, x, y)" },
-                "onTextChanged":   { "kind": "event", "signature": "function(self)" },
-                "onValueChanged":  { "kind": "event", "signature": "function(self)" },
-                "onSelectionChanged": { "kind": "event", "signature": "function(self)" },
-                "onKeyDown":       { "kind": "event", "signature": "function(self, vk)" },
-                "onKeyUp":         { "kind": "event", "signature": "function(self, vk)" },
-                "onMouseDown":     { "kind": "event", "signature": "function(self, button, x, y)" },
-                "onMouseUp":       { "kind": "event", "signature": "function(self, button, x, y)" },
-                "onMouseMove":     { "kind": "event", "signature": "function(self, x, y)" },
-                "onFocus":         { "kind": "event", "signature": "function(self)" },
-                "onBlur":          { "kind": "event", "signature": "function(self)" }
+                "setText": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "s",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "SetText"
+                    ],
+                    "doc": "Set the caption / value."
+                },
+                "getText": {
+                    "kind": "function",
+                    "returns": "string",
+                    "aliases": [
+                        "GetText"
+                    ],
+                    "doc": "Get the current caption / value."
+                },
+                "setLocation": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "x",
+                            "type": "number"
+                        },
+                        {
+                            "name": "y",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "setPosition",
+                        "SetPos"
+                    ]
+                },
+                "getLocation": {
+                    "kind": "function",
+                    "returns": "number",
+                    "aliases": [
+                        "getPosition",
+                        "GetPos"
+                    ],
+                    "doc": "Returns `x, y` (multi-return)."
+                },
+                "setSize": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "w",
+                            "type": "number"
+                        },
+                        {
+                            "name": "h",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "SetSize"
+                    ]
+                },
+                "getSize": {
+                    "kind": "function",
+                    "returns": "number",
+                    "doc": "Returns `w, h` (multi-return)."
+                },
+                "setWidth": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "w",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setHeight": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "h",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getWidth": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "getHeight": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "sizeToContent": {
+                    "kind": "function",
+                    "returns": "self",
+                    "aliases": [
+                        "SizeToContents"
+                    ],
+                    "doc": "Resize to the control's natural size."
+                },
+                "sizeToContentWidth": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "sizeToContentHeight": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "getPreferredSize": {
+                    "kind": "function",
+                    "returns": "number",
+                    "doc": "Returns `w, h` without resizing."
+                },
+                "setAutoSize": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getAutoSize": {
+                    "kind": "function",
+                    "returns": "bool"
+                },
+                "setAutoSizeMode": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "mode",
+                            "type": "string",
+                            "doc": "\"grow\" or \"growShrink\""
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setPadding": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "values",
+                            "type": "any",
+                            "rest": true
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "DockPadding"
+                    ]
+                },
+                "getPadding": {
+                    "kind": "function",
+                    "returns": "number",
+                    "doc": "Returns `l, t, r, b`."
+                },
+                "setMargin": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "values",
+                            "type": "any",
+                            "rest": true
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "DockMargin"
+                    ]
+                },
+                "getMargin": {
+                    "kind": "function",
+                    "returns": "number",
+                    "doc": "Returns `l, t, r, b`."
+                },
+                "setAnchor": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "spec",
+                            "type": "any",
+                            "doc": "string list, mask integer, or AnchorEnum value"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getAnchor": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "show": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "hide": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "setVisible": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "SetVisible"
+                    ]
+                },
+                "getVisible": {
+                    "kind": "function",
+                    "returns": "bool",
+                    "aliases": [
+                        "isVisible"
+                    ]
+                },
+                "setEnabled": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "SetEnabled"
+                    ]
+                },
+                "getEnabled": {
+                    "kind": "function",
+                    "returns": "bool",
+                    "aliases": [
+                        "isEnabled"
+                    ]
+                },
+                "focus": {
+                    "kind": "function",
+                    "returns": "self",
+                    "doc": "Give the control keyboard focus."
+                },
+                "hasFocus": {
+                    "kind": "function",
+                    "returns": "bool"
+                },
+                "setParent": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "other",
+                            "type": "Control"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "bringToFront": {
+                    "kind": "function",
+                    "returns": "self",
+                    "aliases": [
+                        "MoveToFront"
+                    ]
+                },
+                "sendToBack": {
+                    "kind": "function",
+                    "returns": "self",
+                    "aliases": [
+                        "MoveToBack"
+                    ]
+                },
+                "refresh": {
+                    "kind": "function",
+                    "returns": "self",
+                    "aliases": [
+                        "invalidate"
+                    ]
+                },
+                "destroy": {
+                    "kind": "function",
+                    "returns": "bool",
+                    "aliases": [
+                        "remove",
+                        "Remove"
+                    ]
+                },
+                "isOpen": {
+                    "kind": "function",
+                    "returns": "bool"
+                },
+                "setFont": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "spec",
+                            "type": "any",
+                            "doc": "(face), (face,size), (face,size,style) or {face,size,bold,italic,underline,strikeout}"
+                        },
+                        {
+                            "name": "rest",
+                            "type": "any",
+                            "rest": true,
+                            "optional": true
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setFontSize": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setBold": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setItalic": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setUnderline": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setStrikeout": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "clearFont": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "getFont": {
+                    "kind": "function",
+                    "returns": "object",
+                    "doc": "Returns `{face, size, bold, italic, underline, strikeout}` or NULL."
+                },
+                "setForeColor": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "spec",
+                            "type": "any",
+                            "rest": true
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "setColor"
+                    ]
+                },
+                "setBackColor": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "spec",
+                            "type": "any",
+                            "rest": true
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "setBackground"
+                    ]
+                },
+                "getForeColor": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "getBackColor": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "clearForeColor": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "clearBackColor": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "setDock": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "side",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "Dock"
+                    ]
+                },
+                "getDock": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "relayout": {
+                    "kind": "function",
+                    "returns": "self",
+                    "aliases": [
+                        "InvalidateLayout"
+                    ]
+                },
+                "setToolTip": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "s",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setCursor": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getParent": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "getChildren": {
+                    "kind": "function",
+                    "returns": "array"
+                },
+                "contains": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "other",
+                            "type": "Control"
+                        }
+                    ],
+                    "returns": "bool"
+                },
+                "setTabIndex": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getTabIndex": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "setTabStop": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "onClick": {
+                    "kind": "event",
+                    "signature": "function(self, button, x, y)"
+                },
+                "onTextChanged": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                },
+                "onValueChanged": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                },
+                "onSelectionChanged": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                },
+                "onKeyDown": {
+                    "kind": "event",
+                    "signature": "function(self, vk)"
+                },
+                "onKeyUp": {
+                    "kind": "event",
+                    "signature": "function(self, vk)"
+                },
+                "onMouseDown": {
+                    "kind": "event",
+                    "signature": "function(self, button, x, y)"
+                },
+                "onMouseUp": {
+                    "kind": "event",
+                    "signature": "function(self, button, x, y)"
+                },
+                "onMouseMove": {
+                    "kind": "event",
+                    "signature": "function(self, x, y)"
+                },
+                "onFocus": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                },
+                "onBlur": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                }
             }
         },
-
         "Form": {
             "doc": "Top-level window. The script keeps running while forms are open; each form holds a VM lifeline until destroyed.",
             "extends": "Control",
             "members": {
-                "setTitle":         { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "Form", "doc": "Alias of setText." },
-                "center":           { "kind": "function", "returns": "Form", "aliases": ["centre", "Center"] },
-                "setOpacity":       { "kind": "function", "params": [{ "name": "alpha", "type": "number" }], "returns": "Form" },
-                "getOpacity":       { "kind": "function", "returns": "number" },
-                "setTopMost":       { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
-                "setMinSize":       { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Form" },
-                "setMaxSize":       { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Form" },
-                "setBorderStyle":   { "kind": "function", "params": [{ "name": "style", "type": "string", "doc": "\"none\", \"single\", or \"3d\"" }], "returns": "Form" },
-
-                "setIcon":          { "kind": "function", "params": [{ "name": "path", "type": "string" }], "returns": "Form" },
-                "flash":            { "kind": "function", "params": [{ "name": "n", "type": "number", "optional": true }], "returns": "Form" },
-                "maximize":         { "kind": "function", "returns": "Form" },
-                "minimize":         { "kind": "function", "returns": "Form" },
-                "restore":          { "kind": "function", "returns": "Form" },
-                "setWindowState":   { "kind": "function", "params": [{ "name": "state", "type": "string" }], "returns": "Form" },
-                "getWindowState":   { "kind": "function", "returns": "string" },
-                "setResizable":     { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
-                "setMinimizeBox":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
-                "setMaximizeBox":   { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
-                "setShowInTaskbar": { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Form" },
-                "setAcceptButton":  { "kind": "function", "params": [{ "name": "btn", "type": "Button" }], "returns": "Form" },
-                "setCancelButton":  { "kind": "function", "params": [{ "name": "btn", "type": "Button" }], "returns": "Form" },
-
-                "onClose":  { "kind": "event", "signature": "function(self)" },
-                "onShown":  { "kind": "event", "signature": "function(self)" },
-                "onResize": { "kind": "event", "signature": "function(self, w, h)" }
+                "setTitle": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "s",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self",
+                    "doc": "Alias of setText."
+                },
+                "center": {
+                    "kind": "function",
+                    "returns": "self",
+                    "aliases": [
+                        "centre",
+                        "Center"
+                    ]
+                },
+                "setOpacity": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "alpha",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getOpacity": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "setTopMost": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setMinSize": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "w",
+                            "type": "number"
+                        },
+                        {
+                            "name": "h",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setMaxSize": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "w",
+                            "type": "number"
+                        },
+                        {
+                            "name": "h",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setBorderStyle": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "style",
+                            "type": "string",
+                            "doc": "\"none\", \"single\", or \"3d\""
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setIcon": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "path",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "flash": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number",
+                            "optional": true
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "maximize": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "minimize": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "restore": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "setWindowState": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "state",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getWindowState": {
+                    "kind": "function",
+                    "returns": "string"
+                },
+                "setResizable": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setMinimizeBox": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setMaximizeBox": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setShowInTaskbar": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setAcceptButton": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "btn",
+                            "type": "Button"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setCancelButton": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "btn",
+                            "type": "Button"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "onClose": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                },
+                "onShown": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                },
+                "onResize": {
+                    "kind": "event",
+                    "signature": "function(self, w, h)"
+                }
             }
         },
-
         "Button": {
             "extends": "Control",
             "indexes": "Control",
             "members": {
-                "onClick": { "kind": "event", "signature": "function(self)" }
+                "onClick": {
+                    "kind": "event",
+                    "signature": "function(self)"
+                }
             }
         },
-
         "Label": {
             "extends": "Control",
             "members": {
-                "setTextAlign": { "kind": "function", "params": [{ "name": "align", "type": "string", "doc": "\"left\", \"center\", or \"right\"" }], "returns": "Label" }
+                "setTextAlign": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "align",
+                            "type": "string",
+                            "doc": "\"left\", \"center\", or \"right\""
+                        }
+                    ],
+                    "returns": "self"
+                }
             }
         },
-
         "LinkLabel": {
             "extends": "Control",
             "doc": "Clickable hyperlink. Activations fire `onClick`.",
             "members": {}
         },
-
         "TextBox": {
             "extends": "Control",
             "members": {
-                "setMultiline":     { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "TextBox" },
-                "setReadOnly":      { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "TextBox" },
-                "setPlaceholder":   { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "TextBox", "aliases": ["setHint"] },
-                "setPasswordChar":  { "kind": "function", "params": [{ "name": "c", "type": "string" }], "returns": "TextBox" },
-                "setMaxLength":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TextBox" },
-                "setTextAlign":     { "kind": "function", "params": [{ "name": "align", "type": "string" }], "returns": "TextBox" },
-                "selectAll":        { "kind": "function", "returns": "TextBox" },
-                "appendText":       { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "TextBox" },
-                "clear":            { "kind": "function", "returns": "TextBox" },
-                "setValue":         { "kind": "function", "params": [{ "name": "v", "type": "any" }], "returns": "TextBox" },
-                "getValue":         { "kind": "function", "returns": "any" }
+                "setMultiline": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setReadOnly": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setPlaceholder": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "s",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self",
+                    "aliases": [
+                        "setHint"
+                    ]
+                },
+                "setPasswordChar": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "c",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setMaxLength": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setTextAlign": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "align",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "selectAll": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "appendText": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "s",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "clear": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "setValue": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "v",
+                            "type": "any"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getValue": {
+                    "kind": "function",
+                    "returns": "any"
+                }
             }
         },
-
         "CheckBox": {
             "extends": "Control",
             "members": {
-                "setChecked": { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "CheckBox" },
-                "getChecked": { "kind": "function", "returns": "bool" }
+                "setChecked": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getChecked": {
+                    "kind": "function",
+                    "returns": "bool"
+                }
             }
         },
-
         "RadioButton": {
             "extends": "Control",
             "members": {
-                "setChecked": { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "RadioButton" },
-                "getChecked": { "kind": "function", "returns": "bool" }
+                "setChecked": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "b",
+                            "type": "bool"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getChecked": {
+                    "kind": "function",
+                    "returns": "bool"
+                }
             }
         },
-
         "ListLike": {
             "doc": "Common ListBox + ComboBox surface.",
             "extends": "Control",
             "members": {
-                "addItem":           { "kind": "function", "params": [{ "name": "text", "type": "string" }], "returns": "Control" },
-                "removeItem":        { "kind": "function", "params": [{ "name": "index", "type": "number" }], "returns": "Control" },
-                "clearItems":        { "kind": "function", "returns": "Control" },
-                "getItem":           { "kind": "function", "params": [{ "name": "index", "type": "number" }], "returns": "string" },
-                "getItems":          { "kind": "function", "returns": "array" },
-                "getItemCount":      { "kind": "function", "returns": "number" },
-                "getSelectedIndex":  { "kind": "function", "returns": "number" },
-                "setSelectedIndex":  { "kind": "function", "params": [{ "name": "i", "type": "number" }], "returns": "Control" },
-                "clear":             { "kind": "function", "returns": "Control" }
+                "addItem": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "text",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "removeItem": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "index",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "clearItems": {
+                    "kind": "function",
+                    "returns": "self"
+                },
+                "getItem": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "index",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "string"
+                },
+                "getItems": {
+                    "kind": "function",
+                    "returns": "array"
+                },
+                "getItemCount": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "getSelectedIndex": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "setSelectedIndex": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "i",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "clear": {
+                    "kind": "function",
+                    "returns": "self"
+                }
             }
         },
-        "ComboBox": { "extends": "ListLike", "members": {} },
-        "ListBox":  { "extends": "ListLike", "members": {} },
-
-        "Panel":    { "extends": "Control", "members": {} },
-        "GroupBox": { "extends": "Control", "members": {} },
-
+        "ComboBox": {
+            "extends": "ListLike",
+            "members": {}
+        },
+        "ListBox": {
+            "extends": "ListLike",
+            "members": {}
+        },
+        "Panel": {
+            "extends": "Control",
+            "members": {}
+        },
+        "GroupBox": {
+            "extends": "Control",
+            "members": {}
+        },
         "ProgressBar": {
             "extends": "Control",
             "members": {
-                "setValue":   { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "ProgressBar" },
-                "getValue":   { "kind": "function", "returns": "number" },
-                "setRange":   { "kind": "function", "params": [{ "name": "lo", "type": "number" }, { "name": "hi", "type": "number" }], "returns": "ProgressBar" },
-                "setMarquee": { "kind": "function", "params": [{ "name": "active", "type": "bool" }, { "name": "speed", "type": "number", "optional": true }], "returns": "ProgressBar" },
-                "setState":   { "kind": "function", "params": [{ "name": "state", "type": "string" }], "returns": "ProgressBar" },
-                "setStep":    { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "ProgressBar" },
-                "stepIt":     { "kind": "function", "returns": "ProgressBar" }
+                "setValue": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getValue": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "setRange": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "lo",
+                            "type": "number"
+                        },
+                        {
+                            "name": "hi",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setMarquee": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "active",
+                            "type": "bool"
+                        },
+                        {
+                            "name": "speed",
+                            "type": "number",
+                            "optional": true
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setState": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "state",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setStep": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "stepIt": {
+                    "kind": "function",
+                    "returns": "self"
+                }
             }
         },
-
         "TrackBar": {
             "extends": "Control",
             "members": {
-                "setValue":         { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" },
-                "getValue":         { "kind": "function", "returns": "number" },
-                "setRange":         { "kind": "function", "params": [{ "name": "lo", "type": "number" }, { "name": "hi", "type": "number" }], "returns": "TrackBar" },
-                "setTickFrequency": { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" },
-                "setSmallStep":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" },
-                "setLargeStep":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "TrackBar" }
+                "setValue": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getValue": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "setRange": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "lo",
+                            "type": "number"
+                        },
+                        {
+                            "name": "hi",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setTickFrequency": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setSmallStep": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "setLargeStep": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                }
             }
         },
-
         "NumericUpDown": {
             "extends": "Control",
             "members": {
-                "setValue":     { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "NumericUpDown" },
-                "getValue":     { "kind": "function", "returns": "number" },
-                "setIncrement": { "kind": "function", "params": [{ "name": "n", "type": "number" }], "returns": "NumericUpDown" }
+                "setValue": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                },
+                "getValue": {
+                    "kind": "function",
+                    "returns": "number"
+                },
+                "setIncrement": {
+                    "kind": "function",
+                    "params": [
+                        {
+                            "name": "n",
+                            "type": "number"
+                        }
+                    ],
+                    "returns": "self"
+                }
             }
         },
-
-        "PictureBox":     { "extends": "Control", "members": {} },
-        "DateTimePicker": { "extends": "Control", "members": {} },
-        "MonthCalendar":  { "extends": "Control", "members": {} },
-        "StatusBar":      { "extends": "Control", "members": {} },
-        "Spinner":        { "extends": "Control", "members": {} },
-
+        "PictureBox": {
+            "extends": "Control",
+            "members": {}
+        },
+        "DateTimePicker": {
+            "extends": "Control",
+            "members": {}
+        },
+        "MonthCalendar": {
+            "extends": "Control",
+            "members": {}
+        },
+        "StatusBar": {
+            "extends": "Control",
+            "members": {}
+        },
+        "Spinner": {
+            "extends": "Control",
+            "members": {}
+        },
         "ColorPalette": {
             "doc": "0xRRGGBB packed colour constants. The same names are accepted as strings by setForeColor / setBackColor.",
             "members": {
-                "red":             { "kind": "constant", "type": "number" },
-                "green":           { "kind": "constant", "type": "number" },
-                "blue":            { "kind": "constant", "type": "number" },
-                "white":           { "kind": "constant", "type": "number" },
-                "black":           { "kind": "constant", "type": "number" },
-                "yellow":          { "kind": "constant", "type": "number" },
-                "magenta":         { "kind": "constant", "type": "number" },
-                "cyan":            { "kind": "constant", "type": "number" },
-                "cornflowerblue":  { "kind": "constant", "type": "number" },
-                "steelblue":       { "kind": "constant", "type": "number" },
-                "darkgreen":       { "kind": "constant", "type": "number" },
-                "darkred":         { "kind": "constant", "type": "number" },
-                "darkblue":        { "kind": "constant", "type": "number" },
-                "lightgray":       { "kind": "constant", "type": "number" },
-                "darkgray":        { "kind": "constant", "type": "number" },
-                "orange":          { "kind": "constant", "type": "number" },
-                "purple":          { "kind": "constant", "type": "number" },
-                "pink":            { "kind": "constant", "type": "number" },
-                "brown":           { "kind": "constant", "type": "number" }
+                "red": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "green": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "blue": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "white": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "black": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "yellow": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "magenta": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "cyan": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "cornflowerblue": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "steelblue": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "darkgreen": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "darkred": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "darkblue": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "lightgray": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "darkgray": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "orange": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "purple": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "pink": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "brown": {
+                    "kind": "constant",
+                    "type": "number"
+                }
             }
         },
         "DockEnum": {
             "members": {
-                "none":   { "kind": "constant", "type": "number" },
-                "top":    { "kind": "constant", "type": "number" },
-                "bottom": { "kind": "constant", "type": "number" },
-                "left":   { "kind": "constant", "type": "number" },
-                "right":  { "kind": "constant", "type": "number" },
-                "fill":   { "kind": "constant", "type": "number" }
+                "none": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "top": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "bottom": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "left": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "right": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "fill": {
+                    "kind": "constant",
+                    "type": "number"
+                }
             }
         },
         "AnchorEnum": {
             "members": {
-                "none":   { "kind": "constant", "type": "number" },
-                "left":   { "kind": "constant", "type": "number" },
-                "top":    { "kind": "constant", "type": "number" },
-                "right":  { "kind": "constant", "type": "number" },
-                "bottom": { "kind": "constant", "type": "number" },
-                "all":    { "kind": "constant", "type": "number" }
+                "none": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "left": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "top": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "right": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "bottom": {
+                    "kind": "constant",
+                    "type": "number"
+                },
+                "all": {
+                    "kind": "constant",
+                    "type": "number"
+                }
             }
         },
         "AutoSizeEnum": {
             "members": {
-                "grow":       { "kind": "constant", "type": "string" },
-                "growShrink": { "kind": "constant", "type": "string" }
+                "grow": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "growShrink": {
+                    "kind": "constant",
+                    "type": "string"
+                }
             }
         },
         "BorderEnum": {
             "members": {
-                "none":    { "kind": "constant", "type": "string" },
-                "single":  { "kind": "constant", "type": "string" },
-                "fixed3D": { "kind": "constant", "type": "string" }
+                "none": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "single": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "fixed3D": {
+                    "kind": "constant",
+                    "type": "string"
+                }
             }
         },
         "CursorEnum": {
             "members": {
-                "arrow":       { "kind": "constant", "type": "string" },
-                "hand":        { "kind": "constant", "type": "string" },
-                "ibeam":       { "kind": "constant", "type": "string" },
-                "wait":        { "kind": "constant", "type": "string" },
-                "cross":       { "kind": "constant", "type": "string" },
-                "sizeNS":      { "kind": "constant", "type": "string" },
-                "sizeWE":      { "kind": "constant", "type": "string" },
-                "sizeNWSE":    { "kind": "constant", "type": "string" },
-                "sizeNESW":    { "kind": "constant", "type": "string" },
-                "sizeAll":     { "kind": "constant", "type": "string" },
-                "no":          { "kind": "constant", "type": "string" },
-                "help":        { "kind": "constant", "type": "string" },
-                "appStarting": { "kind": "constant", "type": "string" }
+                "arrow": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "hand": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "ibeam": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "wait": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "cross": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "sizeNS": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "sizeWE": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "sizeNWSE": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "sizeNESW": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "sizeAll": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "no": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "help": {
+                    "kind": "constant",
+                    "type": "string"
+                },
+                "appStarting": {
+                    "kind": "constant",
+                    "type": "string"
+                }
             }
         }
     }

--- a/modules/ldap/cando.api.json
+++ b/modules/ldap/cando.api.json
@@ -1,0 +1,45 @@
+{
+    "$comment": "API manifest for the ldap module. Read by the vscode-cando language server.",
+    "name": "ldap",
+    "version": "1.0.0",
+    "doc": "OpenLDAP / Active Directory client. Calls are function-style; the connection handle is passed as the first argument.",
+    "exports": {
+        "VERSION":    { "kind": "value", "type": "string" },
+        "SCOPE_BASE": { "kind": "constant", "type": "number", "doc": "LDAP_SCOPE_BASE." },
+        "SCOPE_ONE":  { "kind": "constant", "type": "number", "doc": "LDAP_SCOPE_ONELEVEL." },
+        "SCOPE_SUB":  { "kind": "constant", "type": "number", "doc": "LDAP_SCOPE_SUBTREE." },
+
+        "connect":          { "kind": "function", "params": [{ "name": "uri", "type": "string", "doc": "ldap:// or ldaps:// URI" }], "returns": "Connection" },
+        "bind":             { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "password", "type": "string" }], "returns": "bool" },
+        "bind_anonymous":   { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }], "returns": "bool" },
+        "start_tls":        { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }], "returns": "bool" },
+        "set_option":       { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "name", "type": "string" }, { "name": "value", "type": "any" }], "returns": "bool" },
+        "search":           { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "options", "type": "object", "doc": "{ base, scope, filter, attrs }" }], "returns": "array" },
+        "add":              { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "attrs", "type": "object" }], "returns": "bool" },
+        "modify":           { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "mods", "type": "object" }], "returns": "bool" },
+        "compare":          { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "attr", "type": "string" }, { "name": "value", "type": "any" }], "returns": "bool" },
+        "delete":           { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }], "returns": "bool" },
+        "rename":           { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "new_rdn", "type": "string" }, { "name": "delete_old", "type": "bool", "optional": true }], "returns": "bool" },
+        "move":             { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "new_parent_dn", "type": "string" }, { "name": "new_rdn", "type": "string", "optional": true }, { "name": "delete_old", "type": "bool", "optional": true }], "returns": "bool" },
+        "unbind":           { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }], "returns": "bool" },
+        "rootdse":          { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "attrs", "type": "array", "optional": true }], "returns": "object" },
+        "test_credentials": { "kind": "function", "params": [{ "name": "uri", "type": "string" }, { "name": "dn", "type": "string" }, { "name": "password", "type": "string" }], "returns": "bool" },
+        "password_modify":  { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "dn", "type": "string" }, { "name": "old_password", "type": "string" }, { "name": "new_password", "type": "string" }, { "name": "format", "type": "string", "optional": true, "doc": "\"auto\" | \"ad\" | \"rfc3062\"" }], "returns": "bool" },
+        "members":          { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "group_dn", "type": "string" }, { "name": "options", "type": "object", "optional": true }], "returns": "array" },
+        "member_of":        { "kind": "function", "params": [{ "name": "conn", "type": "Connection" }, { "name": "user_dn",  "type": "string" }, { "name": "options", "type": "object", "optional": true }], "returns": "array" },
+
+        "escape_filter":    { "kind": "function", "params": [{ "name": "value", "type": "string" }], "returns": "string", "doc": "RFC 4515 search-filter escape." },
+        "escape_dn":        { "kind": "function", "params": [{ "name": "value", "type": "string" }], "returns": "string", "doc": "RFC 4514 DN escape." },
+
+        "rc4":                          { "kind": "function", "params": [{ "name": "key", "type": "string" }, { "name": "data", "type": "string" }], "returns": "string", "doc": "Generic RC4 stream cipher." },
+        "md5":                          { "kind": "function", "params": [{ "name": "data", "type": "string" }], "returns": "string", "doc": "MD5 digest as a 16-byte binary string." },
+        "decode_reversible_password":   { "kind": "function", "params": [{ "name": "blob", "type": "string" }, { "name": "key", "type": "string" }], "returns": "string" }
+    },
+
+    "types": {
+        "Connection": {
+            "doc": "Open LDAP connection. The runtime exposes only function-style calls (`ldap.bind(conn, ...)`); there is no method-style surface here.",
+            "members": {}
+        }
+    }
+}

--- a/modules/sql/cando.api.json
+++ b/modules/sql/cando.api.json
@@ -1,0 +1,57 @@
+{
+    "$comment": "API manifest for the sql module (PostgreSQL + MySQL/MariaDB). Read by the vscode-cando language server.",
+    "name": "sql",
+    "version": "0.1.0",
+    "doc": "PostgreSQL and MySQL/MariaDB client. Both function-style (`sql.exec(db, ...)`) and method-style (`db:exec(...)`) calls are supported on every handle.",
+    "exports": {
+        "VERSION":          { "kind": "value", "type": "string" },
+        "DRIVER_POSTGRES":  { "kind": "constant", "type": "string", "doc": "Constant \"postgres\"." },
+        "DRIVER_MYSQL":     { "kind": "constant", "type": "string", "doc": "Constant \"mysql\"." },
+
+        "open":         { "kind": "function", "params": [{ "name": "driver", "type": "string", "doc": "\"postgres\" or \"mysql\"" }, { "name": "options", "type": "object" }], "returns": "Connection", "doc": "Generic open." },
+        "openPostgres": { "kind": "function", "params": [{ "name": "options", "type": "object" }], "returns": "Connection", "doc": "Open a PostgreSQL connection." },
+        "openMySQL":    { "kind": "function", "params": [{ "name": "options", "type": "object" }], "returns": "Connection", "doc": "Open a MySQL/MariaDB connection." },
+
+        "close":            { "kind": "function", "params": [{ "name": "db", "type": "Connection" }],                                                                       "returns": "bool" },
+        "exec":             { "kind": "function", "params": [{ "name": "db", "type": "Connection" }, { "name": "sql", "type": "string" }],                                  "returns": "object" },
+        "prepare":          { "kind": "function", "params": [{ "name": "db", "type": "Connection" }, { "name": "sql", "type": "string" }],                                  "returns": "Statement" },
+        "begin":            { "kind": "function", "params": [{ "name": "db", "type": "Connection" }],                                                                       "returns": "bool" },
+        "commit":           { "kind": "function", "params": [{ "name": "db", "type": "Connection" }],                                                                       "returns": "bool" },
+        "rollback":         { "kind": "function", "params": [{ "name": "db", "type": "Connection" }],                                                                       "returns": "bool" },
+        "inTransaction":    { "kind": "function", "params": [{ "name": "db", "type": "Connection" }],                                                                       "returns": "bool" },
+        "transaction":      { "kind": "function", "params": [{ "name": "db", "type": "Connection" }, { "name": "fn", "type": "function" }, { "name": "args", "type": "any", "rest": true, "optional": true }], "returns": "any" },
+        "ping":             { "kind": "function", "params": [{ "name": "db", "type": "Connection" }],                                                                       "returns": "bool" },
+        "escape":           { "kind": "function", "params": [{ "name": "db", "type": "Connection" }, { "name": "value", "type": "any" }],                                   "returns": "string" },
+        "escapeIdentifier": { "kind": "function", "params": [{ "name": "db", "type": "Connection" }, { "name": "name",  "type": "string" }],                                "returns": "string" }
+    },
+
+    "types": {
+        "Connection": {
+            "doc": "Open SQL connection. All methods accept either function-style (with `db` first) or method-style (`db:foo(...)`) calls.",
+            "members": {
+                "close":            { "kind": "function", "returns": "bool" },
+                "exec":             { "kind": "function", "params": [{ "name": "sql", "type": "string" }], "returns": "object", "doc": "Returns `{ affected, insertId, tag }`." },
+                "prepare":          { "kind": "function", "params": [{ "name": "sql", "type": "string" }], "returns": "Statement" },
+                "begin":            { "kind": "function", "returns": "bool" },
+                "commit":           { "kind": "function", "returns": "bool" },
+                "rollback":         { "kind": "function", "returns": "bool" },
+                "inTransaction":    { "kind": "function", "returns": "bool" },
+                "transaction":      { "kind": "function", "params": [{ "name": "fn", "type": "function" }, { "name": "args", "type": "any", "rest": true, "optional": true }], "returns": "any" },
+                "bigintMode":       { "kind": "function", "params": [{ "name": "mode", "type": "string", "optional": true, "doc": "\"number\" or \"string\"" }], "returns": "string" },
+                "ping":             { "kind": "function", "returns": "bool" },
+                "escape":           { "kind": "function", "params": [{ "name": "value", "type": "any" }], "returns": "string" },
+                "escapeIdentifier": { "kind": "function", "params": [{ "name": "name", "type": "string" }], "returns": "string" }
+            }
+        },
+        "Statement": {
+            "doc": "Compiled SQL statement. Always finalize with `:finalize()` once done.",
+            "members": {
+                "run":      { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "object", "doc": "Returns `{ affected, insertId }`." },
+                "get":      { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "object", "doc": "First row, or NULL." },
+                "all":      { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "array",  "doc": "Every row as an object." },
+                "finalize": { "kind": "function", "returns": "bool" },
+                "sourceSQL":{ "kind": "value",    "type": "string" }
+            }
+        }
+    }
+}

--- a/modules/sqlite/cando.api.json
+++ b/modules/sqlite/cando.api.json
@@ -1,0 +1,66 @@
+{
+    "$comment": "API manifest for the sqlite module (embedded SQLite). Read by the vscode-cando language server.",
+    "name": "sqlite",
+    "version": "0.5.0",
+    "doc": "Embedded SQLite database, API on par with Node.js's node:sqlite. Both function-style and method-style calls are supported on every handle.",
+    "exports": {
+        "VERSION":         { "kind": "value", "type": "string" },
+        "SQLITE_VERSION":  { "kind": "value", "type": "string", "doc": "Vendored SQLite library version." },
+        "OPEN_READONLY":   { "kind": "constant", "type": "number" },
+        "OPEN_READWRITE":  { "kind": "constant", "type": "number" },
+        "OPEN_CREATE":     { "kind": "constant", "type": "number" },
+        "OPEN_URI":        { "kind": "constant", "type": "number" },
+        "OPEN_MEMORY":     { "kind": "constant", "type": "number" },
+
+        "open":             { "kind": "function", "params": [{ "name": "path", "type": "string" }, { "name": "options", "type": "object", "optional": true }], "returns": "Database" },
+        "escape":           { "kind": "function", "params": [{ "name": "value", "type": "any" }], "returns": "string" },
+        "escapeIdentifier": { "kind": "function", "params": [{ "name": "name",  "type": "string" }], "returns": "string" },
+
+        "close":            { "kind": "function", "params": [{ "name": "db", "type": "Database" }],                                          "returns": "bool" },
+        "exec":             { "kind": "function", "params": [{ "name": "db", "type": "Database" }, { "name": "sql", "type": "string" }],     "returns": "bool" },
+        "prepare":          { "kind": "function", "params": [{ "name": "db", "type": "Database" }, { "name": "sql", "type": "string" }],     "returns": "Statement" }
+    },
+
+    "types": {
+        "Database": {
+            "doc": "Open SQLite database. Wrap multi-step work in `:transaction(fn)` for ACID + savepoint nesting.",
+            "members": {
+                "close":             { "kind": "function", "returns": "bool" },
+                "exec":              { "kind": "function", "params": [{ "name": "sql", "type": "string" }], "returns": "bool" },
+                "prepare":           { "kind": "function", "params": [{ "name": "sql", "type": "string" }], "returns": "Statement" },
+                "begin":             { "kind": "function", "returns": "bool" },
+                "commit":            { "kind": "function", "returns": "bool" },
+                "rollback":          { "kind": "function", "returns": "bool" },
+                "inTransaction":     { "kind": "function", "returns": "bool" },
+                "transaction":       { "kind": "function", "params": [{ "name": "fn", "type": "function" }, { "name": "args", "type": "any", "rest": true, "optional": true }], "returns": "any" },
+                "pragma":            { "kind": "function", "params": [{ "name": "name", "type": "string" }, { "name": "value", "type": "any", "optional": true }], "returns": "array" },
+                "bigintMode":        { "kind": "function", "params": [{ "name": "mode", "type": "string", "optional": true }], "returns": "string" },
+                "setReadBigInts":    { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "bool", "doc": "node:sqlite-compat alias for bigintMode." },
+                "defineFunction":    { "kind": "function", "params": [{ "name": "name", "type": "string" }, { "name": "fn", "type": "function" }], "returns": "bool" },
+                "defineAggregate":   { "kind": "function", "params": [{ "name": "name", "type": "string" }, { "name": "opts", "type": "object" }], "returns": "bool" },
+                "loadExtension":     { "kind": "function", "params": [{ "name": "path", "type": "string" }, { "name": "entryPoint", "type": "string", "optional": true }], "returns": "bool" },
+                "backup":            { "kind": "function", "params": [{ "name": "destPath", "type": "string" }, { "name": "options", "type": "object", "optional": true }], "returns": "object" }
+            }
+        },
+        "Statement": {
+            "members": {
+                "run":         { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "object", "doc": "Returns `{ lastInsertRowid, changes }`." },
+                "get":         { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "object" },
+                "all":         { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "array" },
+                "iterate":     { "kind": "function", "params": [{ "name": "params", "type": "any", "rest": true, "optional": true }], "returns": "Iterator" },
+                "bind":        { "kind": "function", "params": [{ "name": "params", "type": "any" }], "returns": "bool" },
+                "reset":       { "kind": "function", "returns": "bool" },
+                "finalize":    { "kind": "function", "returns": "bool" },
+                "expandedSQL": { "kind": "function", "returns": "string" },
+                "columns":     { "kind": "function", "returns": "array", "doc": "Array of `{ name, type, table, column, database }`." },
+                "sourceSQL":   { "kind": "value", "type": "string" }
+            }
+        },
+        "Iterator": {
+            "members": {
+                "next": { "kind": "function", "returns": "object", "doc": "Next row, or NULL once drained." },
+                "done": { "kind": "value", "type": "bool" }
+            }
+        }
+    }
+}

--- a/modules/window/cando.api.json
+++ b/modules/window/cando.api.json
@@ -1,0 +1,87 @@
+{
+    "$comment": "API manifest for the window module (GLFW). Read by the vscode-cando language server.",
+    "name": "window",
+    "version": "1.0.0",
+    "doc": "GLFW-based window. Each window instance chains `__index` to `_meta.window`, so every accessor is a method on the instance.",
+    "exports": {
+        "VERSION":     { "kind": "value", "type": "string" },
+        "glfwVersion": { "kind": "value", "type": "string" },
+        "keys":        { "kind": "value", "type": "KeyMap",   "doc": "Key constants (escape, a..z, _0.._9, f1..f12, space, return, tab, arrows, modifiers, punctuation)." },
+        "mouse":       { "kind": "value", "type": "MouseMap", "doc": "Mouse button constants (left, middle, right)." },
+
+        "create": {
+            "kind": "function",
+            "params": [
+                { "name": "title", "type": "any", "doc": "string title or { title=, width=, height= } options table" },
+                { "name": "width",  "type": "number", "optional": true },
+                { "name": "height", "type": "number", "optional": true }
+            ],
+            "returns": "Window"
+        }
+    },
+
+    "types": {
+        "Window": {
+            "doc": "Open window. Methods inherit from `_meta.window` via `__index`.",
+            "indexes": "_meta.window",
+            "members": {
+                "update":         { "kind": "event", "signature": "function(self, dt)" },
+                "draw":           { "kind": "event", "signature": "function(self)" },
+                "keypressed":     { "kind": "event", "signature": "function(self, key, isrepeat)" },
+                "keyreleased":    { "kind": "event", "signature": "function(self, key)" },
+                "textinput":      { "kind": "event", "signature": "function(self, text)" },
+                "mousepressed":   { "kind": "event", "signature": "function(self, x, y, button)" },
+                "mousereleased":  { "kind": "event", "signature": "function(self, x, y, button)" },
+                "mousemoved":     { "kind": "event", "signature": "function(self, x, y)" },
+                "wheelmoved":     { "kind": "event", "signature": "function(self, dx, dy)" },
+                "resize":         { "kind": "event", "signature": "function(self, width, height)" },
+                "focus":          { "kind": "event", "signature": "function(self, focused)" },
+                "onClose":        { "kind": "event", "signature": "function(self)" },
+                "quit":           { "kind": "event", "signature": "function(self)", "doc": "Back-compat alias for onClose." }
+            }
+        },
+        "_meta.window": {
+            "doc": "Prototype shared by every window instance. User code can install default handlers here.",
+            "members": {
+                "close":              { "kind": "function", "returns": "bool" },
+                "isOpen":             { "kind": "function", "returns": "bool" },
+                "setTitle":           { "kind": "function", "params": [{ "name": "s", "type": "string" }], "returns": "Window" },
+                "getTitle":           { "kind": "function", "returns": "string" },
+                "setSize":            { "kind": "function", "params": [{ "name": "w", "type": "number" }, { "name": "h", "type": "number" }], "returns": "Window" },
+                "getSize":            { "kind": "function", "returns": "number", "doc": "Returns `w, h` (multi-return)." },
+                "setPosition":        { "kind": "function", "params": [{ "name": "x", "type": "number" }, { "name": "y", "type": "number" }], "returns": "Window" },
+                "getPosition":        { "kind": "function", "returns": "number", "doc": "Returns `x, y` (multi-return)." },
+                "setVisible":         { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Window" },
+                "isVisible":          { "kind": "function", "returns": "bool" },
+                "focus":              { "kind": "function", "returns": "Window" },
+                "hasFocus":           { "kind": "function", "returns": "bool" },
+                "setVSync":           { "kind": "function", "params": [{ "name": "b", "type": "bool" }], "returns": "Window" },
+                "getMouse":           { "kind": "function", "returns": "number", "doc": "Returns `x, y` relative to the client area." },
+                "getDPIScale":        { "kind": "function", "returns": "number", "doc": "Returns `sx, sy`." },
+                "getFramebufferSize": { "kind": "function", "returns": "number", "doc": "DPI-aware pixel size, multi-return `w, h`." }
+            }
+        },
+        "KeyMap": {
+            "doc": "Open-ended namespace of key constants. Common members shown; arrow / modifier / punctuation members exist too.",
+            "members": {
+                "escape": { "kind": "constant", "type": "number" },
+                "space":  { "kind": "constant", "type": "number" },
+                "return": { "kind": "constant", "type": "number" },
+                "tab":    { "kind": "constant", "type": "number" },
+                "left":   { "kind": "constant", "type": "number" },
+                "right":  { "kind": "constant", "type": "number" },
+                "up":     { "kind": "constant", "type": "number" },
+                "down":   { "kind": "constant", "type": "number" },
+                "f1":     { "kind": "constant", "type": "number" },
+                "f12":    { "kind": "constant", "type": "number" }
+            }
+        },
+        "MouseMap": {
+            "members": {
+                "left":   { "kind": "constant", "type": "number" },
+                "middle": { "kind": "constant", "type": "number" },
+                "right":  { "kind": "constant", "type": "number" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR significantly enhances the CanDo VS Code language server with intelligent cross-file member completion, filesystem path completion for `include()` calls, and comprehensive type tracking. The server can now resolve `include("...")` bindings to their exported members, offer completion on object literals and manifest-defined types, and provide detailed hover information and signature help.

## Key Changes

### New Type Tracking System (`types.ts`)
- Implemented a lightweight type inference engine that walks the token stream and builds a `TypeEnv` mapping names to `TypeRef` types
- Supports three sources of truth: in-file information (classes, object literals, includes), module manifests (`cando.api.json`), and built-in namespaces
- Handles inheritance chains through `extends` and `__index` mechanisms
- Provides `inferReceiverAt()` to determine the type at a member access position and `listMembers()` to enumerate available completions
- Correctly handles the `::` fluent-chain operator (preserves receiver type) vs `:` method calls (uses declared return type)
- Augments record-typed bindings with runtime member attachments (e.g., `t.meth = FUNCTION(self) { ... }`)

### Module Manifests (`cando.api.json`)
- Added API manifest files for all built-in modules: `forms`, `window`, `sqlite`, `draw`, `sql`, `ldap`
- Manifests describe exported values, types, members, and their signatures
- Enables completion and hover on binary modules (`.so`, `.dll`) where source introspection isn't possible
- Manifest loader (`manifest.ts`) resolves type hierarchies and member inheritance

### Cross-File Resolution (`crossfile.ts`)
- Resolves `include("path")` arguments to actual files on disk
- Harvests exported member names from included modules:
  - `.cdo` files: keys from top-level `RETURN { ... }` or fallback to VAR/CONST/GLOBAL/FUNCTION names
  - `.json` files: top-level object keys
  - Binary modules: members from their manifest
- Caches results per absolute path with mtime-based invalidation

### Filesystem Path Completion (`paths.ts`)
- Detects when cursor is inside an `include("...")` string argument
- Provides filesystem completion for includable file types (`.cdo`, `.json`, `.csv`, `.yaml`, `.so`, `.dylib`, `.dll`)
- Mirrors CanDo's runtime resolution: searches in document directory and ancestors up to workspace root
- Supports both quoted and unquoted path editing

### Enhanced Analyzer (`analyzer.ts`)
- Extended to capture `include("path")` bindings for cross-file completion
- Tracks object literal keys bound to top-level variables
- Captures module exports via top-level `RETURN { ... }` statements
- Records function parameters for signature help

### Language Server Improvements (`server.ts`)
- Integrated type tracking into completion, hover, and new signature help handlers
- Completion now offers:
  - Cross-file members from `include()` bindings
  - Object literal members
  - Manifest-defined type members
  - Filesystem paths inside `include("...")`
- Hover now shows:
  - Resolved include paths with file details
  - Type descriptions and member documentation
  - Manifest member signatures
- Added signature help for function calls (in-file and namespace methods)
- Goto-definition now jumps to included files

### Built-in Definitions (`builtins.ts`)
- Added `snippet` field to `BuiltinInfo` for snippet-based completion
- Added `memberDetails` to `NamespaceInfo` for per-member signature display
- Enhanced namespace definitions with detailed member information

### Test Coverage (`edge_cases.js`)
- Comprehensive 63-case test harness for type tracking edge cases
- Tests receiver detection, chaining, method calls, manifest types, and more
- All tests passing

## Notable Implementation Details

- **Conservative type inference**: Returns `unknown` when confidence is low rather than guessing, preventing misleading completions
- **No flow-sensitive narrowing**: Keeps the implementation lightweight and predictable
- **Manifest-first design**: Manifests are the source of

https://claude.ai/code/session_01WBQbec6qnUMt7xPsHiLEBu