### PR TITLE
vscode: cross-file include uses real return shape; surface fn-body locals

### DIFF
--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to the **CanDo Language** VS Code extension are
 documented in this file.
 
+## 0.3.3 -- 2026-05-01
+
+### Fixed
+
+- **Cross-file include now uses the actual return shape, not the file's
+  top-level VARs.** When a `.cdo` module did
+  `VAR exports = { foo, bar }; RETURN exports;` the language server
+  was leaking `helper`, `thing`, `exports` -- every top-level
+  declaration in the file -- as if they were public members. The type
+  tracker now parses the included file and infers the type of its
+  top-level `RETURN <expr>` statement directly. Three shapes are
+  recognised:
+  1. `RETURN { ... }`     -- literal object
+  2. `RETURN ident;`      -- a variable bound to an object literal
+  3. `RETURN <chain>`     -- chained call whose type the tracker can
+                              follow (e.g. another module's exports)
+  The crossfile fallback no longer surfaces top-level VARs at all.
+- **Function-body locals show up in identifier completion.** The
+  analyzer only collects symbols at depth 0 (for the Outline view),
+  so `VAR localFoo = ...` declared inside a `FUNCTION` was invisible
+  to plain identifier completion. The general completion path now
+  also walks the type env's bindings, which includes every
+  `VAR/CONST/GLOBAL` regardless of nesting.
+
 ## 0.3.2 -- 2026-05-01
 
 ### Fixed

--- a/editors/vscode-cando/package.json
+++ b/editors/vscode-cando/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cando",
   "displayName": "CanDo Language",
   "description": "Syntax highlighting, snippets and IntelliSense for the CanDo scripting language (.cdo).",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "CandoProject",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "icons/cando.png",

--- a/editors/vscode-cando/server/src/analyzer.ts
+++ b/editors/vscode-cando/server/src/analyzer.ts
@@ -304,13 +304,26 @@ export function analyze(tokens: Token[]): AnalysisResult {
             }
         }
 
-        /* Top-level `RETURN { ... }` -- capture as module exports. */
+        /* Top-level `RETURN <expr>` -- capture as module exports. We
+         * recognise three shapes:
+         *   - `RETURN { a: ..., b: ... };`        -- literal object
+         *   - `RETURN ident;`                     -- a variable that was
+         *                                            bound earlier to an
+         *                                            object literal
+         *   - other expressions                   -- left for the type
+         *                                            tracker to handle
+         */
         if (depth === 0 && isKw(tok, 'RETURN')) {
             if (isPunct(t[i + 1], '{')) {
                 const { keys, end } = collectObjectKeys(i + 1);
                 if (keys.length) moduleExports = keys;
                 i = end - 1;
                 continue;
+            }
+            const next = t[i + 1];
+            if (next?.kind === 'ident') {
+                const lit = objectLiterals.get(next.value);
+                if (lit && lit.length) moduleExports = [...lit];
             }
         }
     }

--- a/editors/vscode-cando/server/src/crossfile.ts
+++ b/editors/vscode-cando/server/src/crossfile.ts
@@ -71,9 +71,12 @@ function readMembers(abs: string): string[] {
     if (ext === '.cdo') {
         const tokens = new Lexer(text).tokenize();
         const result = analyze(tokens);
-        if (result.moduleExports.length) return dedupe(result.moduleExports);
-        /* Fallback: surface the module's top-level declarations. */
-        return dedupe(result.symbols.map(s => s.name));
+        /* Only surface the module's actual export shape -- the keys of its
+         * top-level `RETURN { ... }` (or `RETURN ident` when ident is a
+         * known object literal). NEVER fall back to top-level VARs/CONSTs
+         * since those are private to the module; surfacing them would
+         * advertise members the caller can't actually access. */
+        return dedupe(result.moduleExports);
     }
 
     if (ext === '.json') {

--- a/editors/vscode-cando/server/src/server.ts
+++ b/editors/vscode-cando/server/src/server.ts
@@ -329,6 +329,7 @@ connection.onCompletion(params => {
 
     const cached = analysisCache.get(params.textDocument.uri);
     if (cached) {
+        const seen = new Set<string>();
         for (const s of cached.symbols) {
             const item: CompletionItem = {
                 label: s.name,
@@ -346,6 +347,21 @@ connection.onCompletion(params => {
                 item.insertTextFormat = InsertTextFormat.Snippet;
             }
             items.push(item);
+            seen.add(s.name);
+        }
+        /* Function-body locals -- the analyzer only records top-level
+         * symbols, but the type tracker walks every VAR / CONST / GLOBAL
+         * declaration in the file. Surface those here so identifier
+         * completion works inside `FUNCTION` bodies and class
+         * constructors. */
+        for (const [name, ref] of cached.typeEnv.bindings) {
+            if (seen.has(name)) continue;
+            items.push({
+                label: name,
+                kind: CompletionItemKind.Variable,
+                detail: describeTypeForHover(ref)
+            });
+            seen.add(name);
         }
     }
 

--- a/editors/vscode-cando/server/src/types.ts
+++ b/editors/vscode-cando/server/src/types.ts
@@ -573,6 +573,14 @@ function resolveIncludeType(rawPath: string, env: TypeEnv, workspaceRoots: strin
             env.manifests.set(abs, manifest);
             return { kind: 'manifest-exports', manifest };
         }
+        /* No manifest, but if the target is a `.cdo` source file we can
+         * actually parse it and infer the type of its `RETURN` expression
+         * directly -- much more accurate than the crossfile harvester's
+         * key-based heuristic. */
+        if (abs.toLowerCase().endsWith('.cdo')) {
+            const sub = resolveCdoReturnType(abs, workspaceRoots);
+            if (sub) return sub;
+        }
     }
 
     /* Fallback: a manifest can exist alongside a binary that hasn't been
@@ -590,6 +598,54 @@ function resolveIncludeType(rawPath: string, env: TypeEnv, workspaceRoots: strin
     /* No manifest -- defer to crossfile-derived members. The completion
      * layer falls back to `getIncludeExports` for this case. */
     return UNKNOWN;
+}
+
+/* Cache by absolute path + mtime so repeated includes don't re-parse. */
+const cdoReturnCache = new Map<string, { mtimeMs: number; ref: TypeRef | null }>();
+
+/**
+ * Parse a `.cdo` file, build a partial type env over it, and return the
+ * type of its top-level `RETURN <expr>` statement -- precisely the value
+ * `include(...)` will yield. Returns `null` when the file has no
+ * recognisable top-level RETURN (the runtime would also yield `null` in
+ * that case but we have no useful members to offer).
+ */
+function resolveCdoReturnType(abs: string, workspaceRoots: string[]): TypeRef | null {
+    let mtimeMs: number;
+    try { mtimeMs = require('fs').statSync(abs).mtimeMs; }
+    catch { return null; }
+
+    const cached = cdoReturnCache.get(abs);
+    if (cached && cached.mtimeMs === mtimeMs) return cached.ref;
+
+    let text: string;
+    try { text = require('fs').readFileSync(abs, 'utf8'); }
+    catch { return null; }
+
+    const tokens = new (require('./lexer').Lexer)(text).tokenize();
+    const analysis = require('./analyzer').analyze(tokens);
+    const subEnv = buildTypeEnv(tokens, analysis.symbols, 'file://' + abs, workspaceRoots);
+
+    /* Find the first top-level RETURN. */
+    const t = tokens.filter((x: Token) => x.kind !== 'comment' && x.kind !== 'newline');
+    let depth = 0;
+    let ref: TypeRef | null = null;
+    for (let i = 0; i < t.length; i++) {
+        const tok = t[i];
+        if (tok.kind === 'punct' && tok.value === '{') { depth++; continue; }
+        if (tok.kind === 'punct' && tok.value === '}') { depth--; continue; }
+        if (depth !== 0) continue;
+        if (tok.kind === 'keyword' && (tok.value === 'RETURN' || tok.value === 'return')) {
+            const inferred = inferExpression(t, i + 1, subEnv, workspaceRoots);
+            if (inferred.ref.kind !== 'unknown') {
+                ref = inferred.ref;
+                break;
+            }
+        }
+    }
+
+    cdoReturnCache.set(abs, { mtimeMs, ref });
+    return ref;
 }
 
 /**

--- a/editors/vscode-cando/server/test/edge_cases.js
+++ b/editors/vscode-cando/server/test/edge_cases.js
@@ -693,6 +693,75 @@ test('chained call with multiple args', () => {
 });
 
 /* =========================================================================
+ *  Cross-file include resolution (regression for the user-reported bugs)
+ * ======================================================================= */
+
+test('include of .cdo: RETURN { ... } literal -> only those keys', () => {
+    const dir = path.join(require('os').tmpdir(), 'cando-cf1-' + process.pid);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'mod.cdo'),
+        'VAR helper = 1;\nCONST private_thing = 2;\n' +
+        'RETURN { foo: helper, bar: private_thing };\n');
+
+    const stripped = `VAR x = include("${dir}/mod.cdo");\nx.|`;
+    const cursor = stripped.indexOf('|');
+    const text = stripped.slice(0, cursor) + stripped.slice(cursor + 1);
+    const tokens = new Lexer(text).tokenize();
+    const filtered = tokens.filter(t => t.kind !== 'comment' && t.kind !== 'newline');
+    const result = analyze(tokens);
+    const env = buildTypeEnv(tokens, result.symbols, 'file://' + dir + '/main.cdo', [dir, REPO]);
+    const dotIdx = filtered.findIndex(t => t.kind === 'op' && t.value === '.' && filtered[filtered.indexOf(t) - 1]?.value === 'x');
+    const ref = require(path.join(OUT, 'types.js')).inferReceiverAt(filtered, dotIdx, env, [dir, REPO]);
+    const members = [...require(path.join(OUT, 'types.js')).listMembers(ref, env).keys()];
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    /* Must have foo + bar; must NOT include helper / private_thing. */
+    return members.includes('foo') && members.includes('bar')
+        && !members.includes('helper') && !members.includes('private_thing')
+        || ('got members=' + members.join(','));
+});
+
+test('include of .cdo: RETURN ident -> follow ident to its object literal', () => {
+    const dir = path.join(require('os').tmpdir(), 'cando-cf2-' + process.pid);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'mod.cdo'),
+        'VAR helper = 1;\nVAR exports = { foo: helper, bar: 2 };\nRETURN exports;\n');
+
+    const r = membersAt(`VAR x = include("${dir}/mod.cdo");\nx.|`);
+    fs.rmSync(dir, { recursive: true, force: true });
+    /* Only the exported keys, never the internal `helper` / `exports`. */
+    return r.members.includes('foo') && r.members.includes('bar')
+        && !r.members.includes('helper') && !r.members.includes('exports');
+});
+
+test('include of .cdo: no RETURN at all -> no false-positive members', () => {
+    const dir = path.join(require('os').tmpdir(), 'cando-cf3-' + process.pid);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'mod.cdo'), 'VAR helper = 1;\nVAR thing = 2;\n');
+
+    const r = membersAt(`VAR x = include("${dir}/mod.cdo");\nx.|`);
+    fs.rmSync(dir, { recursive: true, force: true });
+    /* Top-level VARs are private to the module; they must not appear
+     * as if they were exports. */
+    return r.members.length === 0
+        || ('expected 0 members, got: ' + r.members.join(','));
+});
+
+test('FUNCTION-body local variables are surfaced for general completion', () => {
+    /* Build the env directly and check that bindings include the local. */
+    const { env } = envFor(`
+        VAR topLevel = 1;
+        FUNCTION work() {
+            VAR localOne = 10;
+            CONST localTwo = 20;
+        }
+    `);
+    return env.bindings.has('topLevel')
+        && env.bindings.has('localOne')
+        && env.bindings.has('localTwo');
+});
+
+/* =========================================================================
  *  Run + report
  * ======================================================================= */
 


### PR DESCRIPTION
Fixes two reported autocomplete bugs in the VS Code extension.

## 1. Cross-file include leaked module-private VARs

When a `.cdo` module did the canonical re-export pattern:

```cando
VAR helper = 1;
VAR exports = { foo: helper, bar: 2 };
RETURN exports;
```

`include`-ing it then typing `x.` advertised every top-level
declaration (`helper`, `exports`, `bar`, …) as if it were a public
member. Two layers were wrong:

- The analyzer's `moduleExports` detector only matched `RETURN { … }`
  literals -- it missed `RETURN ident`.
- The crossfile harvester then "helpfully" fell back to surfacing
  every top-level declaration when no exports were detected.

Fixed by making the type tracker parse the included file and run
`inferExpression` on whatever follows `RETURN`. Three shapes are
recognised:

```
RETURN { ... };           # literal object
RETURN ident;             # follow ident to its object literal
RETURN expr.chain         # full chained-call inference
```

The crossfile fallback no longer surfaces top-level VARs at all -- a
module's locals are private and shouldn't be advertised to callers.

## 2. Function-body locals were missing from identifier completion

The analyzer only collects symbols at depth 0 (correct for the
Outline view). But the general (non-member) completion path was
reading from `cached.symbols` only, so a `VAR localFoo = …` declared
inside a `FUNCTION` body never showed up in autocomplete.

The general path now also iterates the type env's bindings, which
include every `VAR / CONST / GLOBAL` regardless of nesting.

## Test plan

Four regression tests added to `server/test/edge_cases.js` (now at 72,
all green):

- [x] include of `.cdo` with `RETURN { ... }` literal -> only those keys
- [x] include of `.cdo` with `RETURN ident` -> follow ident to its literal
- [x] include of `.cdo` with no RETURN -> 0 members (no false positives)
- [x] FUNCTION-body `VAR/CONST` locals are surfaced for general completion

Run with:

```
cd editors/vscode-cando
npm install
npx tsc -b
node server/test/edge_cases.js
```

https://claude.ai/code/session_01WBQbec6qnUMt7xPsHiLEBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBQbec6qnUMt7xPsHiLEBu)_