### PR TITLE
Fix latent bugs surfaced by code review + ASan/UBSan/LSan/TSan

### DIFF
--- a/modules/forms/forms_module.c
+++ b/modules/forms/forms_module.c
@@ -40,6 +40,13 @@
  * Must compile with gcc / clang / MinGW-w64 -std=c11.
  */
 
+/* Pull in nanosleep / clock_gettime from <time.h> on POSIX. */
+#if !defined(_WIN32) && !defined(_WIN64)
+#  ifndef _POSIX_C_SOURCE
+#    define _POSIX_C_SOURCE 200809L
+#  endif
+#endif
+
 #ifndef FORMS_MODULE_TEST_BUILD
 #  include <cando.h>
 #  include "vm/bridge.h"

--- a/source/core/memory.c
+++ b/source/core/memory.c
@@ -27,7 +27,9 @@ static void live_grow(CandoMemCtrl *mc) {
 static bool live_remove_by_obj(CandoMemCtrl *mc, void *obj) {
     for (u32 i = 0; i < mc->live_count; i++) {
         if (mc->live[i].obj == obj) {
-            mc->live[i] = mc->live[--mc->live_count];
+            u32 new_count = mc->live_count - 1;
+            mc->live[i] = mc->live[new_count];
+            __atomic_store_n(&mc->live_count, new_count, __ATOMIC_RELAXED);
             return true;
         }
     }
@@ -80,7 +82,9 @@ void cando_memctrl_track(CandoMemCtrl *mc, void *obj,
     mc->live[mc->live_count].obj     = obj;
     mc->live[mc->live_count].destroy = destroy;
     mc->live[mc->live_count].marked  = false;
-    mc->live_count++;
+    /* Relaxed atomic store: the unsynchronised reader in
+     * vm_gc_maybe_collect uses __atomic_load_n on the same field. */
+    __atomic_store_n(&mc->live_count, mc->live_count + 1, __ATOMIC_RELAXED);
     cando_lock_write_release(&mc->gc_lock);
 }
 
@@ -142,7 +146,9 @@ void cando_memctrl_sweep(CandoMemCtrl *mc,
         void (*destroy)(void *) = e->destroy;
         /* Remove from the registry first so the destroy hook can safely
          * re-enter (e.g. a finalizer that allocates new objects).      */
-        mc->live[i] = mc->live[--mc->live_count];
+        u32 new_count = mc->live_count - 1;
+        mc->live[i] = mc->live[new_count];
+        __atomic_store_n(&mc->live_count, new_count, __ATOMIC_RELAXED);
         if (free_handle) free_handle(handle_user, obj);
         if (destroy)     destroy(obj);
         /* Don't increment i -- a different entry now sits at this slot. */

--- a/source/lib/crypto.c
+++ b/source/lib/crypto.c
@@ -1,8 +1,8 @@
 /*
  * lib/crypto.c -- Cryptography and hashing standard library for Cando.
  *
- * For now, this is a placeholder/mock implementation to demonstrate the API
- * since real MD5/SHA256 implementations are large.
+ * Backed by OpenSSL (-lcrypto), which the rest of the runtime already
+ * links for the secure socket and HTTPS modules.
  *
  * Must compile with gcc -std=c11.
  */
@@ -14,6 +14,8 @@
 
 #include <stdio.h>
 #include <string.h>
+
+#include <openssl/evp.h>
 
 /* =========================================================================
  * Base64 Encoding
@@ -64,21 +66,59 @@ static int crypto_base64Encode(CandoVM *vm, int argc, CandoValue *args)
 }
 
 /* =========================================================================
- * Placeholder MD5 and SHA256 (returns mocked values)
+ * MD5 and SHA256, backed by OpenSSL EVP
  * ======================================================================= */
+
+static int crypto_hash_evp(CandoVM *vm, int argc, CandoValue *args,
+                            const EVP_MD *md, const char *name)
+{
+    /* Default to the empty-string digest if the caller passes anything
+     * non-stringy -- matches the previous placeholder's "always succeed"
+     * shape so existing scripts keep working. */
+    const char *data = "";
+    u32         len  = 0;
+    CandoString *s = libutil_arg_str_at(args, argc, 0);
+    if (s) { data = s->data; len = s->length; }
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int  digest_len = 0;
+
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        cando_vm_error(vm, "crypto.%s: out of memory", name);
+        return -1;
+    }
+    if (EVP_DigestInit_ex(ctx, md, NULL) != 1 ||
+        EVP_DigestUpdate(ctx, data, len) != 1 ||
+        EVP_DigestFinal_ex(ctx, digest, &digest_len) != 1) {
+        EVP_MD_CTX_free(ctx);
+        cando_vm_error(vm, "crypto.%s: digest computation failed", name);
+        return -1;
+    }
+    EVP_MD_CTX_free(ctx);
+
+    /* Hex-encode into a stack buffer.  EVP_MAX_MD_SIZE is 64, so the
+     * encoded form is at most 128 bytes plus the trailing NUL. */
+    char hex[EVP_MAX_MD_SIZE * 2 + 1];
+    static const char digits[] = "0123456789abcdef";
+    for (unsigned int i = 0; i < digest_len; i++) {
+        hex[i * 2]     = digits[(digest[i] >> 4) & 0xF];
+        hex[i * 2 + 1] = digits[ digest[i]       & 0xF];
+    }
+    hex[digest_len * 2] = '\0';
+
+    libutil_push_str(vm, hex, digest_len * 2);
+    return 1;
+}
 
 static int crypto_md5(CandoVM *vm, int argc, CandoValue *args)
 {
-    (void)argc; (void)args;
-    libutil_push_cstr(vm, "d41d8cd98f00b204e9800998ecf8427e"); /* MD5 of empty string */
-    return 1;
+    return crypto_hash_evp(vm, argc, args, EVP_md5(), "md5");
 }
 
 static int crypto_sha256(CandoVM *vm, int argc, CandoValue *args)
 {
-    (void)argc; (void)args;
-    libutil_push_cstr(vm, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); /* SHA256 of empty */
-    return 1;
+    return crypto_hash_evp(vm, argc, args, EVP_sha256(), "sha256");
 }
 
 static int crypto_base64Decode(CandoVM *vm, int argc, CandoValue *args)

--- a/source/lib/http.c
+++ b/source/lib/http.c
@@ -1368,18 +1368,31 @@ static int server_close_fn(CandoVM *vm, int argc, CandoValue *args)
     if (!server) { cando_vm_push(vm, cando_null()); return 1; }
 
     atomic_store(&server->running, false);
+    /* Shutdown unblocks any in-flight accept() so the worker exits its
+     * loop, but we must not close the fd yet -- the accept thread may
+     * still be reading server->listen_fd.  Join first, then close. */
     if (server->listen_fd >= 0) {
 #if defined(CANDO_PLATFORM_WINDOWS)
         shutdown(server->listen_fd, SD_BOTH);
 #else
         shutdown(server->listen_fd, SHUT_RDWR);
 #endif
-        HTTP_CLOSE(server->listen_fd);
-        server->listen_fd = -1;
     }
     if (server->has_thread) {
         cando_os_thread_join(server->accept_thread);
         server->has_thread = false;
+    }
+    if (server->listen_fd >= 0) {
+        HTTP_CLOSE(server->listen_fd);
+        server->listen_fd = -1;
+    }
+    /* Connection workers are detached from the accept loop, so we must
+     * drain them by hand before letting the slot be reused.  Otherwise a
+     * worker can still be running through the script's bytecode while
+     * the host scope tears down (see TSan races against cando_chunk_free
+     * and against memset() of a freshly-allocated server slot). */
+    while (atomic_load(&server->active_conns) > 0) {
+        cando_os_thread_sleep_ms(1);
     }
     if (server->ssl_ctx) {
         SSL_CTX_free(server->ssl_ctx);

--- a/source/lib/include.c
+++ b/source/lib/include.c
@@ -297,7 +297,12 @@ static CandoModuleEntry *cache_insert(CandoVM *vm, const char *canonical_path,
     }
 
     CandoModuleEntry *e = &vm->module_cache[vm->module_cache_count++];
-    e->path      = strdup(canonical_path); /* owned by the cache */
+    /* Use cando_alloc so OOM aborts uniformly; strdup returns NULL on
+     * failure and the cached entry is later strcmp'd, which would then
+     * crash on the NULL path. */
+    usize path_len = strlen(canonical_path) + 1;
+    e->path = (char *)cando_alloc(path_len);
+    memcpy(e->path, canonical_path, path_len);
     e->value_count = value_count;
     if (value_count > 0) {
         e->values = (CandoValue *)cando_alloc(value_count * sizeof(CandoValue));

--- a/source/lib/json.c
+++ b/source/lib/json.c
@@ -64,12 +64,19 @@ static void jbuf_free(JBuf *b)
  * JSON parser
  * ======================================================================= */
 
+/* Cap nesting to keep deeply nested adversarial input from blowing the
+ * native stack via the recursive descent.  256 is comfortably below the
+ * default 8 MiB pthread stack for the typical ~100 bytes per frame and
+ * well above any practical document. */
+#define JSON_MAX_DEPTH 256
+
 typedef struct {
     const char *src;
     usize       len;
     usize       pos;
     CandoVM    *vm;
     bool        has_error;
+    int         depth;
     char        error[256];
 } JParser;
 
@@ -220,6 +227,8 @@ str_done:;
     if (!p->has_error) {
         if (buf.oom) {
             jp_error(p, "out of memory building string");
+        } else if (buf.len > UINT32_MAX) {
+            jp_error(p, "string too long");
         } else {
             const char *raw = buf.data ? buf.data : "";
             CandoString *s = cando_string_new(raw, (u32)buf.len);
@@ -406,8 +415,16 @@ static CandoValue jp_parse_value(JParser *p)
 
     char c = p->src[p->pos];
     if (c == '"')                           return jp_parse_string(p);
-    if (c == '[')                           return jp_parse_array(p);
-    if (c == '{')                           return jp_parse_object(p);
+    if (c == '[' || c == '{') {
+        if (p->depth >= JSON_MAX_DEPTH) {
+            jp_error(p, "nesting too deep");
+            return cando_null();
+        }
+        p->depth++;
+        CandoValue v = (c == '[') ? jp_parse_array(p) : jp_parse_object(p);
+        p->depth--;
+        return v;
+    }
     if (c == 't') {
         if (jp_match(p, "true",  4))        return cando_bool(true);
         jp_error(p, "invalid token"); return cando_null();
@@ -441,6 +458,7 @@ bool cando_lib_json_parse_buffer(CandoVM *vm,
     p.pos       = 0;
     p.vm        = vm;
     p.has_error = false;
+    p.depth     = 0;
     p.error[0]  = '\0';
 
     CandoValue result = jp_parse_value(&p);

--- a/source/lib/yaml.c
+++ b/source/lib/yaml.c
@@ -88,6 +88,11 @@ typedef struct {
     bool has_tab_indent; /* tab found in indent — error for block ctx    */
 } YLine;
 
+/* Caps recursion in both block and flow parsing -- adversarial input
+ * like "[[[[[...]]]]]" or deeply nested mappings would otherwise blow
+ * the native stack. */
+#define YAML_MAX_DEPTH 256
+
 typedef struct {
     const char *src;
     u32         len;
@@ -96,6 +101,7 @@ typedef struct {
     u32         pos;        /* current line index                        */
     CandoVM    *vm;
     bool        has_error;
+    int         depth;
     char        error[256];
 } YParser;
 
@@ -704,8 +710,17 @@ static CandoValue yp_parse_flow_value(YParser *p, const char *s, u32 *i, u32 n)
     yp_skip_flow_ws(s, i, n);
     if (*i >= n) { yp_error(p, "expected flow value"); return cando_null(); }
     char c = s[*i];
-    if (c == '[') return yp_parse_flow_seq(p, s, i, n);
-    if (c == '{') return yp_parse_flow_map(p, s, i, n);
+    if (c == '[' || c == '{') {
+        if (p->depth >= YAML_MAX_DEPTH) {
+            yp_error(p, "nesting too deep");
+            return cando_null();
+        }
+        p->depth++;
+        CandoValue v = (c == '[') ? yp_parse_flow_seq(p, s, i, n)
+                                  : yp_parse_flow_map(p, s, i, n);
+        p->depth--;
+        return v;
+    }
     if (c == '"') return yp_decode_dquoted(p, s, i, n);
     if (c == '\'') return yp_decode_squoted(p, s, i, n);
 
@@ -1129,7 +1144,7 @@ static CandoValue yp_parse_block_map(YParser *p, u32 indent)
  * first non-blank line's content.
  * ======================================================================= */
 
-static CandoValue yp_parse_node(YParser *p, u32 min_indent)
+static CandoValue yp_parse_node_inner(YParser *p, u32 min_indent)
 {
     yp_skip_blanks(p);
     if (p->pos >= p->n_lines) return cando_null();
@@ -1176,6 +1191,18 @@ static CandoValue yp_parse_node(YParser *p, u32 min_indent)
     return v;
 }
 
+static CandoValue yp_parse_node(YParser *p, u32 min_indent)
+{
+    if (p->depth >= YAML_MAX_DEPTH) {
+        yp_error(p, "nesting too deep");
+        return cando_null();
+    }
+    p->depth++;
+    CandoValue v = yp_parse_node_inner(p, min_indent);
+    p->depth--;
+    return v;
+}
+
 /* =========================================================================
  * Public parse entry point
  * ======================================================================= */
@@ -1193,6 +1220,7 @@ bool cando_lib_yaml_parse_buffer(CandoVM *vm,
     p.pos       = 0;
     p.vm        = vm;
     p.has_error = false;
+    p.depth     = 0;
     p.error[0]  = '\0';
 
     yl_tokenise(&p);

--- a/source/object/array.c
+++ b/source/object/array.c
@@ -89,7 +89,10 @@ bool cdo_array_rawset_idx(CdoObject *arr, u32 idx, CdoValue val) {
 
 u32 cdo_array_len(const CdoObject *arr) {
     CANDO_ASSERT(arr != NULL && arr->kind == OBJ_ARRAY);
-    return arr->items_len;
+    cando_lock_read_acquire((CandoLockHeader *)&arr->lock);
+    u32 len = arr->items_len;
+    cando_lock_read_release((CandoLockHeader *)&arr->lock);
+    return len;
 }
 
 bool cdo_array_insert(CdoObject *arr, u32 idx, CdoValue val) {

--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -579,7 +579,10 @@ u32 cando_vm_gc_collect(CandoVM *vm) {
      * Floor at 256 so very small programs don't ping-pong.            */
     u32 next = after * 2;
     if (next < 256) next = 256;
-    vm->mem->next_collect_threshold = next;
+    /* Relaxed atomic store -- pairs with the unsynchronised relaxed
+     * load in vm_gc_maybe_collect's hot path. */
+    __atomic_store_n(&vm->mem->next_collect_threshold, next,
+                     __ATOMIC_RELAXED);
     return before - after;
 }
 
@@ -589,11 +592,19 @@ u32 cando_vm_gc_collect(CandoVM *vm) {
  * object has already been pushed onto the value stack so it counts as
  * a root.                                                              */
 static inline void vm_gc_maybe_collect(CandoVM *vm) {
-    if (CANDO_UNLIKELY(vm->mem &&
-                       vm->mem->next_collect_threshold > 0 &&
-                       vm->mem->live_count >=
-                           vm->mem->next_collect_threshold)) {
-        cando_vm_gc_collect(vm);
+    if (CANDO_UNLIKELY(vm->mem)) {
+        /* Use relaxed atomic loads here; the matching writes in
+         * memory.c are made under gc_lock, but this hot path
+         * intentionally reads without taking the lock and the values
+         * are only used as a heuristic to decide whether to run a
+         * full collect.  Stale reads are acceptable -- a true torn
+         * read is not, hence the explicit atomic load. */
+        u32 threshold = __atomic_load_n(&vm->mem->next_collect_threshold,
+                                        __ATOMIC_RELAXED);
+        u32 live      = __atomic_load_n(&vm->mem->live_count,
+                                        __ATOMIC_RELAXED);
+        if (CANDO_UNLIKELY(threshold > 0 && live >= threshold))
+            cando_vm_gc_collect(vm);
     }
 }
 


### PR DESCRIPTION
Long sweep across the codebase looking for bugs.  Each commit is
focused; the categories are summarised below.  The whole branch is
verified by:

- 54 unit + integration tests pass
- Every script in `tests/scripts/` (55 of them) runs clean under
  ASan + UBSan
- Every script runs clean under LSan (was 3 exit-time leaks before)
- Every script runs clean under TSan (was several races before),
  even under heavy concurrent eval / thread / socket / GC workloads
  re-run multiple times

## Real correctness bugs

- **`crypto.base64Encode`** had wrong padding for any input whose
  length wasn't a multiple of 3, e.g. `base64('A')` → `'QQAA'`
  instead of `'QQ=='`.  Confirmed with a standalone reproducer.
- **`crypto.md5` / `crypto.sha256`** were placeholders that always
  returned the empty-string digest regardless of input.  Replaced
  with real OpenSSL EVP digests.

## Memory-safety / use-after-free

- **`eval()` closure use-after-free**: `eval()` freed its compiled
  chunk immediately after exec, but a returned `FUNCTION` captured
  pointers into chunk bytecode/constants.  Hand the chunk to a
  per-VM-family list freed at VM teardown.
- **`thread + eval` use-after-free**: same shape as above when the
  closure escaped a thread via `thread.join`; share the eval-chunk
  list across the whole VM family with a mutex.
- **`thread.join` double-free**: `thread_join_one` pushed the
  thread's result slot to the caller's stack without copying.  When
  the caller's local went out of scope, the refcount hit zero and
  the thread destroy then double-freed the same allocation.
- **Throw inside `eval()` corruption**: `handle_error` walked the
  outer try-stack from inside the inner `vm_run`, then started
  executing the outer chunk's bytecode inside the nested loop --
  ASan caught the resulting heap-use-after-free in OP_CONST.
  Stop unwinding at `eval_stop_frame` / `thread_stop_frame`.
- **`handle_get` race vs realloc**: `cando_handle_get` /
  `cando_handle_set` ran their `CANDO_ASSERT(t->slots[idx]...)`
  before acquiring the table lock; `handle_table_grow`'s realloc
  could race them and read freed memory.  Validate under the lock.

## Concurrency

- **HTTP / TCP server close**: shut down the listen fd and zeroed
  it before joining the accept thread; reorder to shutdown -> join
  -> close.
- **HTTP / TCP server close**: didn't wait for in-flight connection
  workers, so the chunk could be freed while a worker still
  executed bytecode against it.  Track `active_conns` and drain.
- **`cdo_array_len`** read `items_len` without holding the array
  lock.
- **`vm_gc_maybe_collect` fast-path counter** raced with
  `memctrl_track`; switch reads/writes to relaxed `__atomic_*`.
- **GC across thread VMs**: stage-1 GC walks roots from the
  calling VM only, so an auto-collect on one thread could sweep
  objects another thread had on its stack.  Skip auto-collect
  when sibling thread VMs are alive (manual `gc.collect()` still
  works).
- **`gc.count` / `gc.threshold` natives**: bring them in line with
  the relaxed atomic accessors used by the GC's hot path.
- **`OP_THREAD count++`** used a plain increment under the
  registry mutex; the lock-free reader in `vm_gc_maybe_collect`
  needed an atomic store.
- **6+ pool-init `one_shot` races**: every `ensure_*_inited()` used
  a two-state CAS that let a second thread race through and lock
  an uninitialised mutex.  Replaced with a three-state guard
  (unstarted / in-progress / done) plus a yield-spin on losers.
  Sites: sockutil, socket, stream, http, process, sql, sqlite,
  ldap, window.
- **`datetime.format`** used non-reentrant `localtime()`.

## Memory leaks

- **`thread_results` not released on VM teardown**: scripts that
  ended via a metamethod-driven function call left the final
  return values in `thread_results[]`.
- **String refcount leaks**: `cando_bridge_to_cdo` mints a fresh
  `CdoString`; sites that passed it inline to `cdo_array_push` /
  `_insert` / `cdo_object_rawset` (which retain) dropped the
  caller's ref on the floor.  Tight loop of `array.push("...")`
  was leaking 90 strings (2520 bytes) per 100 calls.
  Sites: `lib/array.c`, `lib/object.c`, `natives.c`,
  `modules/sql/sql_module.c`, `modules/sqlite/sqlite_module.c`.
- **Module-cache GC root miss**: cached module exports were never
  marked, so a GC after the script dropped its reference would
  collect the cached object out from under the next `include()`.
- **`https.get()`** leaked the `url` and `method` strings on every
  call.
- **`include()` strdup OOM**: replaced with `cando_alloc` so the
  cache doesn't store a NULL path.

## Hardening

- **Process spawn pipe `O_CLOEXEC`**: pipes inherited through any
  concurrent `process.spawn` blocked the original process's stdin
  EOF until the sibling exited.
- **JSON / YAML recursion depth**: capped at 256 so adversarial
  input like `[[[[...]]]]` can't blow the native stack.
- **`json.parse` length cast**: guarded the `usize → u32` cast to
  reject 4 GiB+ strings cleanly instead of silently truncating.
- **`string.format`** used `sprintf` into a fixed 4096-byte stack
  buffer; switched to `snprintf` with bounds clamping.
- **`OP_ADD` string concat overflow check**.
- **`array_ensure_cap` / `cdo_array_push` / `_insert`**: guarded
  against `UINT32_MAX` wrap.
- **YAML self-assignment bug** in the block-seq parser's
  "restore L" path -- restore from the saved `YLine` instead.

## Build hygiene

- Removed dead code (unused `meta_call_depth`, stale
  `file_methods[]`).
- `forms_module.c` declared `_POSIX_C_SOURCE` so `nanosleep` has a
  real prototype.
- `function.c` cast `upvalue_count` to `size_t` before `*` with
  `sizeof(CdoValue)`.

24 commits total.  See `git log --oneline` on the branch for the
per-commit breakdown.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xfj8ZRFt51jYbBi8Ms8PEm)_