### PR TITLE
Fix if_stack memory leak when BREAK/CONTINUE inside IF body

### DIFF
--- a/source/vm/vm.c
+++ b/source/vm/vm.c
@@ -3070,6 +3070,10 @@ static CandoVMResult vm_run(CandoVM *vm) {
 
             vm->spread_extra = 0;
             ip = vm->loop_stack[idx].break_ip;
+            /* Restore if-chain depth: BREAK from inside an IF body skips
+             * the chain's OP_IF_END, so without this each iteration leaks
+             * an if_stack frame and eventually corrupts adjacent VM state. */
+            vm->if_depth   = vm->loop_stack[idx].if_save;
             vm->loop_depth = idx;
             DISPATCH();
         }
@@ -3082,6 +3086,9 @@ static CandoVMResult vm_run(CandoVM *vm) {
             }
             u32 idx = vm->loop_depth - 1 - depth;
             ip      = vm->loop_stack[idx].cont_ip;
+            /* Same rationale as OP_BREAK: CONTINUE from inside an IF body
+             * bypasses OP_IF_END and would otherwise leak if_stack frames. */
+            vm->if_depth   = vm->loop_stack[idx].if_save;
             vm->loop_depth = idx; /* pop frame; LOOP_MARK will re-push on next iteration */
             DISPATCH();
         }
@@ -3100,6 +3107,7 @@ static CandoVMResult vm_run(CandoVM *vm) {
             lf->break_ip  = ip + break_fwd;
             lf->cont_ip   = ip - cont_back;
             lf->stack_save = (u32)(vm->stack_top - vm->stack);
+            lf->if_save    = vm->if_depth;
             lf->loop_type  = loop_type;
             vm->loop_depth++;
             DISPATCH();

--- a/source/vm/vm.h
+++ b/source/vm/vm.h
@@ -186,6 +186,9 @@ typedef struct CandoLoopFrame {
     u8  *break_ip;    /* target for OP_BREAK   (end of loop)             */
     u8  *cont_ip;     /* target for OP_CONTINUE (next iteration check)   */
     u32  stack_save;  /* value-stack depth at loop body entry (for BREAK)*/
+    u32  if_save;     /* if-chain depth at loop body entry: BREAK and    *
+                       * CONTINUE bypass OP_IF_END, so they must restore *
+                       * vm->if_depth or the if_stack leaks each iter.   */
     u8   loop_type;   /* one of CANDO_LOOP_* above                       */
 } CandoLoopFrame;
 


### PR DESCRIPTION
## Summary
Fixes a memory leak in the VM where executing BREAK or CONTINUE from inside an IF body would leak if_stack frames on each loop iteration. The issue occurs because these control flow statements bypass the OP_IF_END instruction that normally restores the if_depth.

## Changes
- **vm.h**: Added `if_save` field to `CandoLoopFrame` struct to store the if-chain depth at loop entry
- **vm.c**: 
  - Save `vm->if_depth` when entering a loop (OP_LOOP_MARK)
  - Restore `vm->if_depth` from the saved value when executing OP_BREAK
  - Restore `vm->if_depth` from the saved value when executing OP_CONTINUE

## Implementation Details
When a BREAK or CONTINUE statement executes from within an IF body, it jumps directly to the loop's break_ip or cont_ip, bypassing any OP_IF_END instructions that would normally decrement if_depth. Without restoration, each loop iteration that contains such a statement would leak one if_stack frame, eventually corrupting adjacent VM state.

The fix captures if_depth at loop entry and restores it alongside the loop_depth when control flow jumps occur, ensuring the if_stack remains balanced.

https://claude.ai/code/session_01KTCjrGs9b2Lz1Jrjcb3LBp