### PR TITLE
Documentation updates: clarify APIs, fix examples, and correct inaccuracies

### DIFF
--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -133,6 +133,58 @@ pointer as a short-lived temporary.
 
 The full treatment is in [value-system.md](value-system.md).
 
+## Runtime substructures
+
+A handful of runtime structures don't fit neatly into either the
+parser, VM, or library category, but a contributor needs to know they
+exist:
+
+- **IF-chain frames** (`CandoIfFrame` in `source/vm/vm.h`).  Every
+  active `IF` chain pushes a frame recording the post-chain
+  settlement IP and the stack depth at chain entry.  `OP_IF_MARK`
+  (vm.c:3242) pushes one, `OP_IF_END` (vm.c:3257) pops it, and
+  `OP_SETTLE n` (vm.c:3261) walks `n` levels up the stack, restores
+  the saved depth (releasing temporaries), clears `spread_extra`, and
+  jumps to the recorded IP.
+
+- **Module cache** (`CandoModuleEntry` in `source/vm/vm.h`,
+  `source/lib/include.c:277-299`).  `include(path)` canonicalises via
+  `realpath()` and looks up in the cache before parsing.  Entries
+  hold the canonical path, the cached export values, an optional
+  `dlopen` handle (for `.so` / `.dylib` / `.dll` modules), and the
+  chunk + closure keeping a compiled script alive.  Repeated
+  `include()` of the same absolute path returns the cached value.
+
+- **Multi-return spread state** (`spread_extra` / `array_extra` /
+  `last_ret_count` in `CandoVM`, `source/vm/vm.h:367-370`).
+  `OP_SPREAD_RET` (vm.c:4716) accumulates `last_ret_count - 1` into
+  `spread_extra`, used by `OP_CALL` to widen a call site.
+  `OP_ARRAY_SPREAD` (vm.c:4720) uses `array_extra` for
+  array-literal construction so the two spread paths don't interfere.
+  `OP_TRUNCATE_RET` (vm.c:4730) discards all but the first return
+  value when a multi-call is used in a single-value context.
+
+- **Thread registry** (`CandoThreadRegistry` in
+  `source/vm/vm.h:243-250`).  A root-owned struct shared by every
+  spawned thread.  `OP_THREAD` (vm.c:4526) increments `count` under
+  mutex before creating an OS thread; the trampoline decrements and
+  broadcasts on exit.  `cando_vm_request_quit()` sets
+  `quit_requested` to signal cooperative shutdown; running threads
+  poll the flag to drain cleanly.  `cando_vm_wait_all_threads()`
+  blocks the main thread until `count` returns to zero (and the
+  companion `cando_vm_wait_all_lifelines()` also waits on
+  subsystem-owned lifelines such as open HTTP servers).
+
+- **JIT hot-PC table** (`source/jit/hot.c`, `source/jit/hot.h`).  A
+  chained-hash table mapping bytecode PC → hit counter.
+  `cando_hot_hit(pc)` is called from loop back-edges, function
+  entries, and iterator advances; it bumps the counter and returns
+  `true` exactly once when the PC crosses
+  `CANDO_HOT_DEFAULT_THRESHOLD` (56 hits) — that's the signal for the
+  recorder to start a trace.  Triggered PCs are auto-blacklisted; the
+  recorder un-blacklists on successful compile or re-blacklists on
+  abort.
+
 ## File layout cheat-sheet
 
 | Question                                  | Look in |

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -115,10 +115,16 @@ code that knows both.  Any new code that needs to operate on objects
 goes through the bridge:
 
 ```c
-CdoObject *o = bridge_resolve_object(vm, value);
-if (!o) cando_throw(vm, "expected object");
+if (!cando_is_object(value)) {
+    cando_vm_error(vm, "expected object");
+    return -1;
+}
+CdoObject *o = cando_bridge_resolve(vm, cando_as_handle(value));
 
-CandoValue field = cdo_object_get(o, "name");
+CdoString *key = cdo_string_intern("name", 4);
+CdoValue   field;
+bool       found = cdo_object_get(o, key, &field);
+cdo_string_release(key);
 ```
 
 Storing the resolved `CdoObject *` across a call that might trigger

--- a/docs/internals/jit.md
+++ b/docs/internals/jit.md
@@ -15,12 +15,16 @@ IR of every compiled trace.
 
 ```
 source/jit/
-  recorder.c        trace recording
-  ir.c              IR construction and optimization
-  codegen.c         IR → native (x86-64 today)
-  cache.c           trace cache and eviction
-  jit.c, jit.h       public interface; the runtime knobs
+  jit.c, jit.h        public interface, runtime knobs, recorder
+                      driver, and the trace cache
+  hot.c, hot.h        hot-pc counting and threshold detection
+  ir.c, ir.h          IR construction and optimization
+  codegen.c, codegen.h IR → native (x86-64 today)
+  mcode.c, mcode.h    executable code page allocator
 ```
+
+There is no separate `recorder.c` or `cache.c` — both responsibilities
+live inside `jit.c`.
 
 ## Lifecycle of a trace
 

--- a/docs/internals/parser.md
+++ b/docs/internals/parser.md
@@ -59,7 +59,8 @@ parser is responsible for emitting its own opcodes.
 1. Add a token type if needed (in `token.h`) and teach the lexer to
    produce it.
 2. Add a case in `parse_statement()`.
-3. Emit the right opcode sequence using the helpers in `emit.h`.
+3. Emit the right opcode sequence using the `emit_op` / `emit_op_a` /
+   `emit_op_ab` helpers in `parser.c`.
 
 ### Adding a new operator
 
@@ -72,7 +73,9 @@ parser is responsible for emitting its own opcodes.
 
 ## Scope system
 
-`source/parser/scope.c` tracks lexical scopes.  A scope owns:
+Scope tracking lives directly in `parser.c` (in the `CandoParser`
+struct and helpers around it — there is no separate `scope.c`).  A
+scope owns:
 
 - A list of local names → slot indices.
 - A list of captured upvalues for the function it belongs to.

--- a/docs/internals/parser.md
+++ b/docs/internals/parser.md
@@ -11,9 +11,11 @@ want to change it.
 source/parser/
   lexer.c, lexer.h        token stream
   token.h                  TokenType enum, keyword/operator table
-  parser.c, parser.h       Pratt parser; emits bytecode as it parses
-  scope.c, scope.h         block scopes, locals, upvalues, captures
-  emit.c, emit.h           emit_op / emit_op_a / emit_op_ab + helpers
+  parser.c, parser.h       Pratt parser; emits bytecode as it parses.
+                           Scope tracking (locals, upvalues, captures)
+                           and the emit helpers (emit_op / emit_op_a /
+                           emit_op_ab) live here as well — there is no
+                           separate scope.c or emit.c.
 ```
 
 ## Lexer

--- a/docs/internals/value-system.md
+++ b/docs/internals/value-system.md
@@ -33,8 +33,8 @@ object owns:
 - a dense `values[]` array for integer-indexed storage (used by
   arrays),
 - an `ObjectKind` tag — one of `OBJ_OBJECT`, `OBJ_ARRAY`,
-  `OBJ_FUNCTION`, `OBJ_NATIVE`, `OBJ_THREAD` (classes use
-  `OBJ_OBJECT`; there is no dedicated `OBJ_CLASS`),
+  `OBJ_FUNCTION`, `OBJ_NATIVE`, `OBJ_THREAD`.  Classes use
+  `OBJ_OBJECT`; there is no dedicated `OBJ_CLASS`,
 - type-specific metadata (function bytecode, native pointer, thread
   state, …).
 
@@ -153,24 +153,29 @@ The `OP_NEW_CLASS`, `OP_BIND_METHOD`, `OP_INHERIT`, and
 ### Validate then operate
 
 ```c
-if (argc < 2 || !cando_value_is_string(argv[0])) {
-    cando_throw(vm, "first argument must be a string");
+if (argc < 2 || !cando_is_string(args[0])) {
+    cando_vm_error(vm, "first argument must be a string");
+    return -1;
 }
-CdoObject *o = bridge_resolve_object(vm, argv[1]);
-if (!o) cando_throw(vm, "second argument must be an object");
+if (!cando_is_object(args[1])) {
+    cando_vm_error(vm, "second argument must be an object");
+    return -1;
+}
+CdoObject *o = cando_bridge_resolve(vm, cando_as_handle(args[1]));
 ```
 
 ### Loop without holding pointers across calls
 
 ```c
-CdoObject *arr = bridge_resolve_object(vm, argv[0]);
-size_t n = cdo_array_length(arr);
+CdoObject *arr = cando_bridge_resolve(vm, cando_as_handle(args[0]));
+u32 n = cdo_array_len(arr);
 
-for (size_t i = 0; i < n; i++) {
-    CandoValue v = cdo_array_get(arr, i);
+for (u32 i = 0; i < n; i++) {
+    CdoValue v;
+    if (!cdo_array_rawget_idx(arr, i, &v)) continue;
     /* ... operate on v ... */
     /* if you must call back into the VM, re-resolve `arr` afterwards */
-    arr = bridge_resolve_object(vm, argv[0]);
+    arr = cando_bridge_resolve(vm, cando_as_handle(args[0]));
 }
 ```
 

--- a/docs/internals/value-system.md
+++ b/docs/internals/value-system.md
@@ -32,8 +32,9 @@ object owns:
   methods, `__index`, metamethods),
 - a dense `values[]` array for integer-indexed storage (used by
   arrays),
-- an `ObjectKind` tag (plain object, array, function, native, thread,
-  class, …),
+- an `ObjectKind` tag — one of `OBJ_OBJECT`, `OBJ_ARRAY`,
+  `OBJ_FUNCTION`, `OBJ_NATIVE`, `OBJ_THREAD` (classes use
+  `OBJ_OBJECT`; there is no dedicated `OBJ_CLASS`),
 - type-specific metadata (function bytecode, native pointer, thread
   state, …).
 

--- a/docs/internals/vm.md
+++ b/docs/internals/vm.md
@@ -164,7 +164,13 @@ The high two bits of a `OP_LOOP_MARK` operand encode the loop type:
 `OP_RANGE_ASC`, `OP_RANGE_DESC`, `OP_FOR_INIT`, `OP_FOR_NEXT`,
 `OP_FOR_OVER_INIT`, `OP_FOR_OVER_NEXT`,
 `OP_PIPE_INIT`, `OP_PIPE_NEXT`, `OP_FILTER_NEXT`, `OP_PIPE_END`,
-`OP_PIPE_COLLECT`, `OP_FILTER_COLLECT`, `OP_COND_FILTER_COLLECT`
+`OP_PIPE_COLLECT`, `OP_FILTER_COLLECT`, `OP_COND_FILTER_COLLECT`,
+`OP_FOR_RANGE_INIT`, `OP_FOR_RANGE_NEXT`
+
+`OP_FOR_RANGE_INIT` and `OP_FOR_RANGE_NEXT` are physically placed
+after Band 19 in `opcodes.h` (added later in development) but belong
+to Band 13 logically — they specialise `FOR i IN N -> M` so the full
+range never has to be materialised as an array.
 
 ### Band 14 — error handling
 `OP_TRY_BEGIN`, `OP_TRY_END`, `OP_CATCH_BEGIN`, `OP_FINALLY_BEGIN`,

--- a/docs/language/classes.md
+++ b/docs/language/classes.md
@@ -131,8 +131,12 @@ the right-hand operand (left-hand for unary).
 | `a == b`       | `__eq`       | `(a, b) → bool` (only when both sides are objects of the same class) |
 | `a < b`        | `__lt`       | `(a, b) → bool`                |
 | `a <= b`       | `__le`       | `(a, b) → bool`                |
-| `a..b`         | `__concat`   | (string concat fallback)       |
 | `a(args)`      | `__call`     | `(a, ...args) → ...result`     |
+
+String concatenation is performed by `+` when either operand is a
+string; there is no separate `..` operator and no `__concat`
+metamethod.  `__tostring` is consulted when a non-string operand
+participates in string concatenation.
 
 For the binary operators, if the left operand has no metamethod, the
 right operand's metamethod is consulted.
@@ -193,30 +197,26 @@ VAR alwaysFalsy = { __is: FALSE };
 IF alwaysFalsy { /* skipped */ }
 ```
 
-### Field flags (advanced)
+## Shared members
 
-Fields can carry flags that change how they behave under writes and
-serialization.  These are exposed through the `object` and `_meta`
-libraries — see [../libraries/object.md](../libraries/object.md) and
-[../libraries/meta.md](../libraries/meta.md).
-
-## Member modifiers
-
-The reserved words `STATIC` and `PRIVATE` mark class members.
+Any field assigned directly on the class object is shared across all
+instances — instances reach it through `__index`.
 
 ```cdo
 CLASS Counter = (self) { self.n = 0; }
+Counter.kind = "counter";           // shared across all instances
 
-STATIC Counter.kind = "counter";    // shared across all instances
-PRIVATE Counter.tick = FUNCTION(self) { self.n = self.n + 1; };
+VAR a = Counter();
+VAR b = Counter();
+print(a.kind, b.kind);              // counter counter
 ```
 
-- `STATIC` means the field lives on the class object itself, not the
-  instance — every instance reads through `__index` and sees the same
-  value.
-- `PRIVATE` is a soft contract: it suppresses the member from
-  `inspect()` output and from `object.keys()` enumeration.  It does
-  **not** enforce access control.
+`STATIC` and `PRIVATE` are reserved words but are not currently parsed
+as member modifiers.  Field-level flags (immutable / hidden) that
+control write protection and `inspect()` / `object.keys()` visibility
+are available programmatically through the `object` and `_meta`
+libraries — see [../libraries/object.md](../libraries/object.md) and
+[../libraries/meta.md](../libraries/meta.md).
 
 ## Default `__call` for classes
 

--- a/docs/language/error-handling.md
+++ b/docs/language/error-handling.md
@@ -56,21 +56,18 @@ objects.  When the embedder receives an uncaught error, it sees the
 
 ## Re-throwing
 
-Inside a `CATCH`, `RERAISE` rethrows the current error unchanged:
+CanDo has no dedicated re-raise keyword.  To propagate an error from a
+`CATCH`, either omit the `CATCH` clause for the cases you don't want to
+handle, or `THROW` a fresh value (the new error replaces the old one):
 
 ```cdo
 TRY {
     risky();
 } CATCH (e) {
     log(e);
-    RERAISE;
+    THROW e;          // forward the same value
 }
 ```
-
-`RERAISE` outside a `CATCH` body is a runtime error.
-
-You can also `THROW` a fresh error from inside `CATCH`; the new error
-replaces the old one.
 
 ## Runtime errors
 
@@ -99,7 +96,6 @@ different failure modes.
 | `comparison requires numbers`                              | `<`, `<=`, `>`, `>=` between non-numeric values without a `__lt` / `__le` metamethod. |
 | `range requires numbers`                                   | `a -> b` or `a <- b` outside a `FOR` (the range-list form). |
 | `range check requires numbers`                             | A `FOR i IN a -> b { … }` where `a` or `b` isn't a number. |
-| `unary '+' requires a number`                              | `+x` on a non-string non-number. |
 | `unary '-' requires a number`                              | `-x` on a non-numeric value without `__unm`. |
 | `'++' requires a number`, `'--' requires a number`         | Increment/decrement on a non-number. |
 | `# operator requires a string or object`                   | `#x` on `null`, `bool`, or `number` without `__len`. |
@@ -137,7 +133,6 @@ different failure modes.
 | `BREAK outside loop`                     | `BREAK` (or `BREAK n`) used where no loop is active. |
 | `CONTINUE outside loop`                  | `CONTINUE` used where no loop is active. |
 | `SETTLE outside IF`                      | `SETTLE` (or `SETTLE n`) used outside an `IF` chain. |
-| `RERAISE outside of catch block`         | `RERAISE` used outside a `CATCH` body. |
 
 ### Threads and concurrency
 

--- a/docs/language/expressions.md
+++ b/docs/language/expressions.md
@@ -8,10 +8,11 @@ forms.  See [statements.md](statements.md) for control flow.
 | Category   | Operators                                                  |
 |------------|------------------------------------------------------------|
 | Arithmetic | `+  -  *  /  %  ^` (power)                                 |
-| Unary      | `-x  +x  !x  ~x  #x  ++x  --x`                             |
+| Unary      | `-x  !x  #x`                                               |
+| Postfix    | `x++  x--` (identifier targets only)                       |
 | Comparison | `==  !=  <  >  <=  >=`                                     |
 | Logical    | `&&  \|\|  !`                                              |
-| Bitwise    | `&  \|  \|&` (xor)  `~` (not)  `<<  >>`                    |
+| Bitwise    | `&  \|  \|&` (xor)  `<<  >>`                               |
 | Assignment | `=  +=  -=  *=  /=  %=  ^=`                                |
 | Indexing   | `a[i]   obj.field   obj["field"]`                          |
 | Safe       | `obj?.field   obj?[expr]`                                  |
@@ -40,9 +41,9 @@ From lowest to highest (each row binds tighter than the row above it):
 11. Additive `+`, `-`
 12. Multiplicative `*`, `/`, `%`
 13. Power `^` — right-associative
-14. Unary `- + ! ~ # ++ --`
+14. Unary prefix `- ! #`
 15. Postfix call `(...)`, member `.`, index `[…]`, method `:`, fluent
-    `::`, safe `?.` / `?[`
+    `::`, safe `?.` / `?[`, increment/decrement `++` / `--`
 
 This follows C with two adjustments: `^` is power (right-assoc), and
 the pipe operators (`~>`, `~!>`, `~&>`) form their own associativity

--- a/docs/language/functions.md
+++ b/docs/language/functions.md
@@ -32,18 +32,6 @@ value but no name — for example as a callback:
 arr:map(FUNCTION(x) { RETURN x * x; });
 ```
 
-### Lambda arrow
-
-For short one-expression callbacks:
-
-```cdo
-arr:map((x) => x * x);
-arr:filter((x) => x > 10);
-```
-
-The arrow form parses as `FUNCTION(args) { RETURN <expr>; }`.  Single
-parameter with no parens is **not** supported — write `(x)`.
-
 ## Parameters and arguments
 
 ### Default values
@@ -172,15 +160,12 @@ FUNCTION fact(n) {
 }
 ```
 
-For expression-form anonymous functions, name them when you need
-recursion:
-
-```cdo
-VAR fact = FUNCTION fact(n) {
-    IF n <= 1 { RETURN 1; }
-    RETURN n * fact(n - 1);
-};
-```
+Expression-form functions are anonymous — `FUNCTION` must be followed
+immediately by `(`, with no name token in between.  If you need
+recursion, use the statement form (which exposes the function's own
+name inside its body) or wrap the call site so the recursive
+reference resolves at call time rather than via the function's own
+binding.
 
 ## Mask selectors
 

--- a/docs/language/pipes.md
+++ b/docs/language/pipes.md
@@ -106,6 +106,15 @@ Inside a block you can introduce locals, `IF`, etc.  An explicit
 `RETURN` provides the value; otherwise the value is `NULL`, which
 matters for `~!>` and `~&>`.
 
+## The `pipe` binding
+
+Inside the body, `pipe` is the only iteration-state name the runtime
+exposes.  There is **no implicit index binding** (no `pipe_index`,
+`i`, `_idx`, etc.) — the OP_PIPE_* opcodes track the source index
+internally but never push it onto the script stack.  If you need the
+position, walk the array with `FOR i IN 0 -> #arr - 1 { … }`
+instead.
+
 ## Composition
 
 Pipes return arrays, so they chain naturally:

--- a/docs/language/statements.md
+++ b/docs/language/statements.md
@@ -258,7 +258,7 @@ CONTINUE;                        // skip to the next iteration of the innermost 
 CONTINUE 2;                      // continue the loop two levels out
 
 SETTLE;                          // exit the innermost IF chain
-SETTLE 1;                        // exit two nested IF chains
+SETTLE 1;                        // exit two nested IF chains (innermost + one above)
 ```
 
 The optional numeric argument is the depth to skip (where 0 == innermost).

--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -74,12 +74,15 @@ A few notes:
 All numbers are IEEE-754 double-precision floats.
 
 ```cdo
-42         3.14       1e6        1.5e-3
-0xff       0o77       0b1010
+42         3.14
 ```
 
-Integer prefixes `0x` (hex), `0o` (octal), and `0b` (binary) are
-accepted.  Underscores between digits are not currently parsed.
+The lexer accepts a run of decimal digits, optionally followed by a
+single `.` and another run of digits.  Hexadecimal (`0xff`), octal
+(`0o77`), binary (`0b1010`), scientific notation (`1e6`, `1.5e-3`),
+and underscore digit separators are **not** currently recognised — the
+lexer stops at the first non-digit and the rest of the literal would
+be re-lexed as identifier tokens.
 
 ### Boolean literals
 
@@ -95,23 +98,24 @@ NULL
 
 ### String literals
 
-Three quote styles, with different escape and interpolation rules:
+Three quote styles:
 
-| Delimiter | Escapes? | Multiline? | Interpolation? |
+| Delimiter | Multiline? | Interpolation? | Notes                       |
 |---|---|---|---|
-| `"…"`         | yes (`\n \t \" \\ \r \xNN \uNNNN`) | no  | no  |
-| `'…'`         | no                                  | yes | no  |
-| `` `…` ``     | yes                                 | yes | yes (`${expr}`) |
+| `"…"`         | no  | no              | single-line; backslash before a `"` keeps the quote inside the string, but escape sequences such as `\n`, `\t`, `\xNN`, `\uNNNN` are **not** decoded — they are stored as the literal bytes. |
+| `'…'`         | yes | no              | newlines are preserved literally. |
+| `` `…` ``     | yes | yes (`${expr}`) | template strings; interpolated expressions go through `toString`. |
 
 ```cdo
-VAR plain    = "hello\nworld";          // 11-byte string with a newline
+VAR plain    = "hello world";           // literal text
 VAR raw      = 'multi
 line literal';
 VAR template = `2 + 2 = ${2 + 2}`;
 ```
 
-`#s` returns the byte length of `s`.  Strings are immutable; methods
-that "transform" a string return a new string.
+To embed a real newline, use the `'…'` form or splice one in via
+template interpolation.  `#s` returns the byte length of `s`.  Strings
+are immutable; methods that "transform" a string return a new string.
 
 ### Array literals
 

--- a/docs/language/types.md
+++ b/docs/language/types.md
@@ -211,6 +211,7 @@ CanDo does **very little implicit coercion**.
 - Equality between objects is **identity-based** (same handle).  Two
   separate objects with the same fields compare unequal.
 
-The `__add`, `__concat`, `__eq`, `__lt`, `__le` metamethods let
-user-defined types opt in to operator overloading; see
-[classes.md](classes.md).
+The `__add`, `__eq`, `__lt`, `__le` (and other operator) metamethods
+let user-defined types opt in to operator overloading; see
+[classes.md](classes.md).  String concatenation uses `+`; there is no
+separate `__concat` metamethod.

--- a/docs/libraries/app.md
+++ b/docs/libraries/app.md
@@ -45,9 +45,11 @@ windowing module — increments while a window is open and decrements
 when it closes).  Embedders can use it to tell whether the script is
 still doing useful work or just waiting on a closed event loop.
 
-### `app.exitCode() → number`
+### `app.exitCode(code*) → number`
 
-The exit code that has been set so far (default `0`).
+With no argument, returns the exit code currently set (default `0`).
+With a numeric argument, updates the exit code and returns the new
+value.  This is the value the embedder will see when the script ends.
 
 ## Examples
 

--- a/docs/libraries/array.md
+++ b/docs/libraries/array.md
@@ -8,9 +8,10 @@ arr:push(42)               // method form
 array.push(arr, 42)         // function form — same body
 ```
 
-Indices are **0-based**.  Methods that mutate `arr` return either the
-new length or the receiver itself; methods that derive a new array
-return that array, leaving the receiver unchanged.
+Indices are **0-based**.  Mutating methods typically return a status
+value (`TRUE` on success) or the removed element; derived-array methods
+(`map`, `filter`, `splice`, `copy`) return a new array and leave the
+receiver unchanged.
 
 ## Reference
 
@@ -24,9 +25,10 @@ print(xs:length());        // 3
 print(#xs);                // 3 — same value via the # operator
 ```
 
-### `a:push(v) → number`
+### `a:push(v) → bool`
 
-Append `v` to the array; return the new length.
+Append `v` to the array.  Returns `TRUE` on success, `FALSE` if `a`
+isn't a writable array.
 
 ```cdo
 VAR xs = [];
@@ -36,10 +38,10 @@ xs:push(3);
 print(inspect(xs));        // [1, 2, 3]
 ```
 
-### `a:push(i, v) → number`
+### `a:push(i, v) → bool`
 
-Insert `v` at index `i`, shifting existing elements right.  Return the
-new length.
+Insert `v` at index `i`, shifting existing elements right.  Returns
+`TRUE` on success, `FALSE` otherwise.
 
 ```cdo
 VAR xs = [1, 2, 4];

--- a/docs/libraries/eval.md
+++ b/docs/libraries/eval.md
@@ -4,11 +4,24 @@ Compile and run a string of CanDo source in the current VM.
 
 ## Reference
 
-### `eval(source) → any`
+### `eval(source, options*) → any`
 
 Compile `source` as a CanDo expression (or block of statements) and
 execute it in the calling VM.  The last expression is the return
-value.  The evaluated code has full access to the calling globals.
+value.  The evaluated code has full access to the calling globals
+(unless `sandbox` is set — see below).
+
+The optional second argument is an options object:
+
+| Field      | Type   | Effect                                                 |
+|------------|--------|--------------------------------------------------------|
+| `name`     | string | Chunk name used in error messages (default `"<eval>"`).|
+| `sandbox`  | bool   | Run with an isolated global environment.               |
+
+```cdo
+print(eval("1 + 2", { name: "math-cell" }));
+print(eval("x", { sandbox: TRUE }));   // throws: 'x' is undefined here
+```
 
 Parse or runtime errors are thrown — wrap in `TRY` / `CATCH` to handle.
 

--- a/docs/libraries/file.md
+++ b/docs/libraries/file.md
@@ -78,6 +78,8 @@ FOR name OF file.list(".") { print(name); }
 ### `file.mkdir(path) → bool`
 
 Create a directory.  **Non-recursive** — the parent must exist.
+Returns `TRUE` if the directory was created **or already existed**
+(`EEXIST` is treated as success); other failures return `FALSE`.
 
 ### `file.open(path, mode) → stream | null`
 
@@ -93,7 +95,7 @@ Returns a stream handle, or `NULL` on failure.
 
 ```cdo
 VAR f = file.open("data.bin", "wb");
-f:writeAll("\x00\x01\x02");
+f:writeAll(payload);             // payload is a string of bytes
 f:close();
 ```
 
@@ -126,7 +128,7 @@ FUNCTION walk(dir, fn) {
     }
 }
 
-walk(".", (p) => print(p));
+walk(".", FUNCTION(p) { print(p); });
 ```
 
 ### Streaming a large file

--- a/docs/libraries/gc.md
+++ b/docs/libraries/gc.md
@@ -6,13 +6,13 @@ never need to touch it manually.
 
 ## Reference
 
-### `gc.collect()`
+### `gc.collect() → number`
 
-Run a full GC cycle synchronously.  Returns when the cycle has
-finished.
+Run a full GC cycle synchronously.  Returns the number of objects
+swept during the cycle.
 
 ```cdo
-gc.collect();
+print(gc.collect());               // e.g. 47 — objects reclaimed
 ```
 
 Useful in tests that want deterministic finalization, or after a known
@@ -28,16 +28,16 @@ precise measurement.
 print(gc.count());                 // some integer
 ```
 
-### `gc.threshold(bytes*)`
+### `gc.threshold(count*) → number`
 
-With no argument, returns the current allocation threshold for an
-automatic minor GC.  With one numeric argument, sets the threshold.
-Setting it to `0` disables automatic GC (you must then call
-`gc.collect()` yourself).
+With no argument, returns the current **live-object count** threshold
+for automatic GC.  With one numeric argument, sets the threshold (in
+objects, not bytes).  Setting it to `0` disables automatic GC (you
+must then call `gc.collect()` yourself).
 
 ```cdo
 print(gc.threshold());             // current value
-gc.threshold(64 * 1024 * 1024);    // 64 MiB
+gc.threshold(100000);              // trigger when live count crosses 100k
 ```
 
 ## When to call this

--- a/docs/libraries/http.md
+++ b/docs/libraries/http.md
@@ -26,7 +26,7 @@ Arbitrary request.  `options` is an object:
 | `method`   | string | `"GET"` | `"GET"`, `"POST"`, `"PUT"`, `"DELETE"`, `"PATCH"`, `"HEAD"`. |
 | `headers`  | object | `{}`    | Request headers. |
 | `body`     | string | `""`    | Request body. |
-| `timeout`  | number | `0`     | Per-request timeout in ms. |
+| `timeout`  | number | `30000` | Per-request timeout in ms (default 30 seconds). |
 | `stream`   | bool   | `FALSE` | If `TRUE`, the response body is read lazily through `res:stream()` instead of buffered. |
 
 ```cdo
@@ -93,7 +93,7 @@ Stop accepting new connections; in-flight ones finish.
 ### Request object (`req`)
 
 Inherits from `_meta.http_request`.  Carries `method`, `url`, `path`,
-`query`, `headers`, `body` fields.
+`query`, `headers`, `body`, and `httpVersion` fields.
 
 ### Response object (`res`)
 
@@ -102,8 +102,8 @@ Inherits from `_meta.http_response`.  Default methods:
 | Method                    | Description |
 |---------------------------|-------------|
 | `res:status(code)`        | Set status code; returns the receiver for chaining. |
-| `res:setHeader(name, v)`  | Add a response header. |
-| `res:send(body*)`         | Flush the response.  If `body` is omitted, the receiver's `body` field (a string accumulator that defaults to `""`) is used. |
+| `res:setHeader(name, v)`  | Add a response header; returns the receiver for chaining. |
+| `res:send(body*)`         | Flush the response.  If `body` is omitted, the receiver's `body` field (a string accumulator that defaults to `""`) is used.  When no `Content-Type` header has been set, defaults to `text/html; charset=utf-8`. |
 | `res:json(value)`         | JSON-encode `value` and send with `Content-Type: application/json`. |
 | `res:stream() → stream`   | Writable view; `:end()` flushes the buffered response. |
 

--- a/docs/libraries/https.md
+++ b/docs/libraries/https.md
@@ -37,15 +37,20 @@ with `https://`.  See [http.md](http.md).
 
 ## Server
 
-### `https.createServer(handler, keyPath, certPath) → server`
+### `https.createServer(opts, handler) → server`
 
-Identical to `http.createServer`, plus required `keyPath` and
-`certPath` arguments pointing to PEM files.
+Like `http.createServer`, but the first argument is an options object
+containing PEM-encoded `cert` and `key` **strings** (not file paths):
 
 ```cdo
-https.createServer(FUNCTION(req, res) {
+VAR opts = {
+    cert: file.read("server.crt"),
+    key:  file.read("server.key"),
+};
+
+https.createServer(opts, FUNCTION(req, res) {
     res:json({ secure: TRUE });
-}, "server.key", "server.crt"):listen(8443);
+}):listen(8443);
 ```
 
 For more control over the TLS configuration (cipher suites, mutual

--- a/docs/libraries/json.md
+++ b/docs/libraries/json.md
@@ -6,8 +6,8 @@ JSON parsing and serialization.
 
 ### `json.parse(text) → any`
 
-Decode a JSON string into CanDo values.  Returns `NULL` on malformed
-input.
+Decode a JSON string into CanDo values.  **Throws** on malformed input
+— wrap in `TRY` / `CATCH` to recover.
 
 | JSON           | CanDo value          |
 |----------------|----------------------|
@@ -23,7 +23,11 @@ VAR data = json.parse('{"name":"Alice","scores":[10,20,30]}');
 print(data.name);                  // Alice
 print(inspect(data.scores));       // [10, 20, 30]
 
-print(json.parse("not json"));     // null
+TRY {
+    json.parse("not json");
+} CATCH (e) {
+    print("bad json:", e);
+}
 ```
 
 ### `json.stringify(value) → string`
@@ -58,12 +62,17 @@ print(loaded.port);                // 8080
 ### Defensive parsing
 
 ```cdo
-VAR data = json.parse(input) || {};
+VAR data;
+TRY {
+    data = json.parse(input);
+} CATCH (e) {
+    data = {};
+}
 VAR token = data?.auth?.token || "anonymous";
 ```
 
-`json.parse` returns `NULL` rather than throwing, so chaining `||` is
-safe.
+Wrap parsing in `TRY` / `CATCH` whenever the input may be untrusted —
+malformed JSON throws.
 
 ### Pretty printing
 

--- a/docs/libraries/json.md
+++ b/docs/libraries/json.md
@@ -30,9 +30,12 @@ TRY {
 }
 ```
 
-### `json.stringify(value) → string`
+### `json.stringify(value, indent*) → string`
 
-Encode a CanDo value as JSON text.
+Encode a CanDo value as JSON text.  The optional `indent` argument
+controls pretty-printing: `0` (the default) produces compact output;
+any value from `1` to `16` is taken as the number of spaces per
+nesting level.  Values outside that range are clamped.
 
 - Numbers use the shortest representation that round-trips.
 - Objects serialize in **FIFO insertion order**.
@@ -76,12 +79,15 @@ malformed JSON throws.
 
 ### Pretty printing
 
-`json.stringify` always produces compact output.  For indented JSON,
-use the YAML library instead, or implement formatting yourself:
+Pass `indent` to `json.stringify`:
 
 ```cdo
-FUNCTION pretty(v, indent) {
-    indent = indent || "  ";
-    // ... user implementation
-}
+print(json.stringify({ a: 1, b: [2, 3] }, 2));
+// {
+//   "a": 1,
+//   "b": [
+//     2,
+//     3
+//   ]
+// }
 ```

--- a/docs/libraries/net.md
+++ b/docs/libraries/net.md
@@ -8,16 +8,16 @@ resolution internally and accept hostnames directly.
 
 ## Reference
 
-### `net.lookup(hostname) → string | null`
+### `net.lookup(hostname) → array | null`
 
-Resolve a hostname to an IPv4 address string, or `NULL` if resolution
-fails.
+Resolve a hostname to an array of IPv4 address strings, or `NULL` if
+resolution fails.  Every address returned by the host resolver is
+included.
 
 ```cdo
-print(net.lookup("example.com"));     // "93.184.216.34"
-print(net.lookup("nope.invalid"));    // null
+print(inspect(net.lookup("example.com")));   // ["93.184.216.34", ...]
+print(net.lookup("nope.invalid"));           // null
 ```
 
-For multiple addresses or IPv6 results, use [`socket.resolve`](socket.md)
-instead — it returns an array of up to 16 numeric addresses (IPv4 and
-IPv6).
+For IPv6 results, use [`socket.resolve`](socket.md) instead — it
+returns up to 16 numeric addresses across both address families.

--- a/docs/libraries/object.md
+++ b/docs/libraries/object.md
@@ -87,9 +87,9 @@ print(inspect(custom));             // { theme: "dark", lang: "fr" }
 
 Return `o.__index` if it points at an object, else `NULL`.
 
-### `object.setPrototype(o, proto) → object`
+### `object.setPrototype(o, proto)`
 
-Set `__index` on `o`.  `proto = NULL` removes it.  Returns `o`.
+Set `__index` on `o`.  `proto = NULL` removes it.  Returns `NULL`.
 
 ```cdo
 VAR base = { greet: FUNCTION(self) { RETURN `hi ${self.name}`; } };
@@ -98,17 +98,17 @@ object.setPrototype(a, base);
 print(a:greet());                   // hi Alice
 ```
 
-### `object.lock(o) → object`
+### `object.lock(o)`
 
-Acquire `o`'s **re-entrant script lock**.  Returns `o`.  Blocks if
-another thread holds the lock.
+Acquire `o`'s **re-entrant script lock**.  Blocks if another thread
+holds the lock.  Returns `NULL`.
 
 The same thread can call `lock` multiple times on the same object as
 long as it later calls `unlock` the same number of times.
 
 ### `object.unlock(o)`
 
-Release one level of `o`'s lock.
+Release one level of `o`'s lock.  Returns `NULL`.
 
 ### `object.locked(o) → bool`
 

--- a/docs/libraries/os.md
+++ b/docs/libraries/os.md
@@ -32,13 +32,19 @@ Read an environment variable.  Returns `NULL` if unset.
 VAR home = os.getenv("HOME") || "/tmp";
 ```
 
-### `os.setenv(name, value) → bool`
+### `os.setenv(name, value, overwrite*) → bool`
 
-Set or overwrite an environment variable for the current process and
-its descendants.
+Set an environment variable for the current process and its
+descendants.  Returns `TRUE` on success, `FALSE` if `name` or `value`
+is not a string.
+
+If `overwrite` is omitted or truthy (the default), an existing value
+is replaced.  Pass `FALSE` (or `0`) to leave a pre-existing value
+untouched:
 
 ```cdo
-os.setenv("LANG", "C.UTF-8");
+os.setenv("LANG", "C.UTF-8");          // always overwrites
+os.setenv("LANG", "C.UTF-8", FALSE);   // only set if LANG is unset
 ```
 
 ### `os.execute(cmd) → number`

--- a/docs/libraries/os.md
+++ b/docs/libraries/os.md
@@ -41,18 +41,21 @@ its descendants.
 os.setenv("LANG", "C.UTF-8");
 ```
 
-### `os.execute(cmd) → string | null`
+### `os.execute(cmd) → number`
 
 Run `cmd` via the host shell (`/bin/sh -c` on POSIX, `cmd.exe /c` on
-Windows) and return its captured stdout.  Returns `NULL` on failure.
+Windows) and return the shell's **exit status** as a number.  Returns
+`-1` if the shell could not be launched.  Stdout and stderr go to the
+parent process's standard streams; they are *not* captured.
 
 ```cdo
-VAR who = os.execute("whoami"):trim();
-print(who);
+VAR status = os.execute("ls /tmp > /dev/null");
+print(status);                     // 0
 ```
 
-For more control over stdin/stdout/stderr, working directory, and
-arguments, use [`process.spawn`](process.md) instead.
+To capture output, set working directory, redirect streams, or pass
+arguments without shell quoting, use [`process.spawn`](process.md)
+instead.
 
 ### `os.exit(code*)`
 

--- a/docs/libraries/stream.md
+++ b/docs/libraries/stream.md
@@ -51,7 +51,10 @@ await consumer;
 ### `stream.transform(fn) → stream`
 
 Pipes every chunk through `fn(chunk) → chunk`.  Returning `NULL` (or a
-non-string) drops the chunk.
+non-string) drops the chunk.  Errors thrown inside `fn` are **logged
+and swallowed**, not surfaced to the writer or reader — the offending
+chunk is simply dropped.  Use a regular function call (not
+`stream.transform`) if you need errors to propagate.
 
 ```cdo
 VAR upcase = stream.transform(FUNCTION(chunk) { RETURN chunk:toUpper(); });

--- a/docs/libraries/stream.md
+++ b/docs/libraries/stream.md
@@ -15,6 +15,7 @@ is dropped — `:close()` is idempotent.
 
 Duplex in-memory buffer.  Auto-compacts as the reader drains.  Useful
 as a glue between producers and consumers in the same thread.
+`initialBytes` is clamped to `[64, 64 MiB]`.
 
 ```cdo
 VAR buf = stream.memory();
@@ -25,7 +26,7 @@ print(buf:read(5));            // hello
 ### `stream.channel(capacity*) → stream`
 
 Bounded thread channel.  Reads block while empty; writes block while
-full.  `capacity = 0` is unbounded.
+full.  `capacity` is clamped to `[64, 64 MiB]`.
 
 ```cdo
 VAR ch = stream.channel(100);
@@ -60,11 +61,11 @@ print(upcase:read(11));         // HELLO WORLD
 
 ## Methods (`_meta.stream`)
 
-### `s:read(maxLen, timeoutMs*) → string`
+### `s:read(maxLen*) → string`
 
-Read up to `maxLen` bytes.  Returns `""` on clean EOF.  When
-`timeoutMs` is given and elapses before any data arrives, throws a
-timeout error.
+Read up to `maxLen` bytes (default `4096`, capped at 16 MiB).  Returns
+`""` on clean EOF.  Throws if the stream is not readable or has been
+closed with an error.
 
 ### `s:readAll() → string`
 

--- a/docs/libraries/string.md
+++ b/docs/libraries/string.md
@@ -103,33 +103,30 @@ print("price: $9.50":find("[0-9]+"));    // 8     (regex)
 print("a.b.c":find(".", TRUE));          // 1     (literal: first '.')
 ```
 
-### `s:split(sep) → array`
+### `s:split(pattern, no_regex*) → array`
 
-Split `s` on `sep`.  Returns an array of parts (the separator itself is
-excluded).  An empty `sep` splits into individual characters.
+Split `s` on `pattern`.  Returns an array of parts (the separator
+itself is excluded).  `pattern` is treated as a POSIX extended regex
+by default; pass `TRUE` as the optional second argument for a literal
+substring split.  An empty pattern returns a single-element array
+containing `s` unchanged.
 
 ```cdo
-print(inspect("a,b,c":split(",")));   // ["a", "b", "c"]
-print(inspect("hello":split("")));    // ["h", "e", "l", "l", "o"]
-print(inspect(",a,":split(",")));     // ["", "a", ""]
+print(inspect("a,b,c":split(",")));         // ["a", "b", "c"]
+print(inspect("a, b,  c":split(", *")));    // ["a", "b", "c"]   (regex)
+print(inspect("a.b.c":split(".", TRUE)));   // ["a", "b", "c"]   (literal)
 ```
 
-### `s:join(parts) → string`
+### `s:replace(pattern, repl, no_regex*) → string`
 
-Concatenate the `parts` array using `s` as a separator between elements.
-
-```cdo
-print(", ":join(["a", "b", "c"])); // a, b, c
-print("/":join(["usr", "local"])); // usr/local
-```
-
-### `s:replace(old, new) → string`
-
-Replace **every** occurrence of `old` with `new`.
+Replace **every** occurrence of `pattern` in `s` with `repl`.
+`pattern` is treated as a POSIX extended regex by default; pass
+`TRUE` as the optional fourth argument for literal replacement.
 
 ```cdo
-print("hello world":replace("o", "0"));   // hell0 w0rld
-print("a b c":replace(" ", "-"));         // a-b-c
+print("hello world":replace("o", "0"));         // hell0 w0rld
+print("hello 42":replace("[0-9]+", "N"));        // hello N        (regex)
+print("a.b.c":replace(".", "/", TRUE));          // a/b/c          (literal)
 ```
 
 ### `s:startsWith(prefix) → bool`, `s:endsWith(suffix) → bool`

--- a/docs/libraries/string.md
+++ b/docs/libraries/string.md
@@ -89,13 +89,18 @@ print("ab":repeat(3));             // ababab
 print("-":repeat(10));             // ----------
 ```
 
-### `s:find(needle) → number`
+### `s:find(pattern, no_regex*) → number | null`
 
-Byte index of the first occurrence of `needle`, or `-1` if not found.
+Byte index of the first occurrence of `pattern`, or `NULL` if not
+found.  `pattern` is treated as a POSIX extended regex by default; pass
+`TRUE` as the optional `no_regex` argument to perform a literal
+substring search instead.
 
 ```cdo
-print("hello":find("ll"));         // 2
-print("hello":find("xx"));         // -1
+print("hello":find("ll"));               // 2     (regex; "ll" matches)
+print("hello":find("xx"));               // null
+print("price: $9.50":find("[0-9]+"));    // 8     (regex)
+print("a.b.c":find(".", TRUE));          // 1     (literal: first '.')
 ```
 
 ### `s:split(sep) → array`
@@ -142,21 +147,20 @@ argument from the right.
 
 ```cdo
 print("hello, %s!":format("world"));            // hello, world!
-print("%d items, $%.2f total":format(3, 9.5));  // 3 items, $9.50
+print("%d items, $%f total":format(3, 9.5));    // 3 items, $9.500000 total
 print("100%% done":format());                   // 100% done
 ```
 
 Supported conversions:
 
 - `%s` — `toString(arg)`
-- `%d` / `%i` — integer (truncates non-integer numeric input)
-- `%f` — float; precision via `%.Nf`
-- `%x` / `%X` — hexadecimal integer (lower / upper case)
-- `%c` — single byte from an integer code point
+- `%d` — integer (truncates non-integer numeric input)
+- `%f` — float (host `printf`'s default precision)
 - `%%` — literal `%`
 
-Width and precision flags use the host's `printf` semantics (left-align
-with `-`, zero-pad with `0`, etc.).
+Any other `%`-token (including `%x`, `%X`, `%c`, `%i`, and width or
+precision flags) is currently passed through verbatim — the formatter
+does **not** implement the full `printf` syntax.
 
 ### `s:match(pattern, start*, end*) → bool, array`
 

--- a/docs/libraries/thread.md
+++ b/docs/libraries/thread.md
@@ -27,15 +27,14 @@ Numeric ID of the current thread.  Useful for diagnostics and logging.
 
 Current thread handle, or `NULL` on the main thread.
 
-### `thread.spawn(fn, ...args) → thread`
-
-Spawn a new thread that calls `fn(...args)`.  Equivalent to
-`thread fn(...args)` at the language level; use the function form when
-the function is computed.
+Note that spawning is a **language construct**, not a library
+function — use `thread expr(args)` or `thread { … }` (see
+[../language/threading.md](../language/threading.md)).  When the
+function value is computed, just call it inside the language form:
 
 ```cdo
 VAR fn = workers[0];
-VAR t = thread.spawn(fn, payload);
+VAR t  = thread fn(payload);
 ```
 
 ### `thread.done(t) → bool`


### PR DESCRIPTION
This PR updates documentation across multiple modules to reflect actual API behavior, fix misleading examples, and clarify implementation details.

## Summary
Comprehensive documentation corrections and clarifications covering the string, JSON, class system, OS, GC, array, eval, net, stream, parser, JIT, error handling, object, thread, expression, pipe, VM, HTTP, type system, app, and file libraries/internals. Changes range from correcting return types and parameter descriptions to removing references to unimplemented features and updating examples to match current behavior.

## Key Changes

**String library (`docs/libraries/string.md`)**
- `find()` and `split()` now document regex support (POSIX extended) with optional `no_regex` parameter for literal matching
- `replace()` updated to show regex examples and clarify the `no_regex` parameter
- `format()` documentation corrected: removed unsupported `%d`, `%i`, `%x`, `%X`, `%c` conversions and precision flags; clarified that only `%s`, `%d`, `%f`, and `%%` are supported

**JSON library (`docs/libraries/json.md`)**
- `json.parse()` now documents that it **throws** on malformed input (not returns `NULL`)
- `json.stringify()` now accepts optional `indent` parameter for pretty-printing
- Updated examples to use `TRY`/`CATCH` for error handling

**Class system (`docs/language/classes.md`)**
- Removed `__concat` metamethod documentation; string concatenation uses `+` operator
- Clarified that `STATIC` and `PRIVATE` are reserved but not currently parsed as modifiers
- Field-level flags (immutable/hidden) are available only through `object` and `_meta` libraries

**OS library (`docs/libraries/os.md`)**
- `os.setenv()` now documents `overwrite` parameter (default `TRUE`)
- `os.execute()` corrected to return exit status (number), not captured stdout; clarified that output goes to parent streams

**GC library (`docs/libraries/gc.md`)**
- `gc.collect()` now documents return value (number of objects swept)
- `gc.threshold()` parameter corrected from bytes to live-object count

**Array library (`docs/libraries/array.md`)**
- `push()` return type corrected to `bool` (success indicator) instead of new length
- Clarified that mutating methods return status/removed element; derived methods return new arrays

**Eval library (`docs/libraries/eval.md`)**
- Added `options` parameter documentation with `name` and `sandbox` fields
- Updated examples to show options usage

**Net library (`docs/libraries/net.md`)**
- `net.lookup()` return type corrected to array of addresses (not single string)

**Stream library (`docs/libraries/stream.md`)**
- `stream.memory()` and `stream.channel()` now document capacity clamping to `[64, 64 MiB]`
- `stream.transform()` clarified: errors are logged/swallowed, not propagated
- `read()` timeout parameter removed from documentation

**Parser internals (`docs/internals/parser.md`)**
- Clarified that scope tracking, emit helpers live in `parser.c` (no separate `scope.c` or `emit.c`)

**JIT internals (`docs/internals/jit.md`)**
- Reorganized file layout: `hot.c`/`hot.h` added; `recorder.c` and `cache.c` responsibilities moved into `jit.c`

**Error handling (`docs/language/error-handling.md`)**
- Removed `RERAISE` keyword documentation (not implemented); clarified re-throwing via `THROW`

**Object library (`docs/libraries/object.md`)**
- `object.setPrototype()` and `object.lock()` return type corrected to `NULL` (not the object)

**Thread library (`docs/libraries/thread.md`)**
- Removed `thread.spawn()` function documentation; clarified that spawning is a language construct

**Expressions (`docs/language/expressions.

https://claude.ai/code/session_01SGDXXnxyKm9acJmNfe8R2Y