### PR TITLE
Add doc-comment parsing, thread expressions, and cross-function shape prediction

### DIFF
--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -7,6 +7,17 @@ documented in this file.
 
 ### Added
 
+- **Cross-function object-shape prediction.** Every user function gets
+  a per-parameter write summary recorded during inference: every
+  direct `param.key = value` mutation. At call sites, the summary is
+  replayed onto the argument's binding, so an `init(rec)` whose body
+  writes `o.x` and `o.y` makes `rec.x` and `rec.y` available to
+  completion afterwards. Summaries propagate through `VAR alias =
+  init` (the FunctionType reference carries them) and through object
+  fields (`{ cb: init }`). Conservative on `any` / unions / non-shape
+  values -- the worst case is "no extra knowledge," never a wrong
+  claim. Implements the middle-ground plan we discussed: per-function
+  summaries + zero-depth on-call replay, no global fixpoint.
 - **Structured doc comments.** The extension now recognises a small
   JSDoc/LuaLS-flavored tag vocabulary in `///` line and `/** */`
   block comments and turns it into type information that drives

--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -7,6 +7,20 @@ documented in this file.
 
 ### Added
 
+- **`thread { ... }` and `await` as expressions.** Previously only the
+  statement form `THREAD expr;` was recognised; `VAR t = thread { ...
+  };` and `VAR r = await t;` are now first-class. The thread handle is
+  modelled as a structural type with `state`/`done`/`join`/`error`
+  members, and the body's RETURN type is recovered through `await` so
+  multi-return unpacks (`VAR a, b, c = await t;`) work as expected.
+- **Pipe block bodies.** `arr ~!> { IF pipe > 0 { RETURN pipe * 2; } }`
+  (and the same for `~>` / `~&>`) now parses cleanly. The body lives in
+  the pipe's own scope so `pipe` is visible inside it, and RETURNs are
+  collected into the mapped element type.
+- **`thread.<member>` disambiguation.** The `thread` keyword no longer
+  shadows the `thread` stdlib namespace; `thread.sleep(...)`,
+  `thread.cancel(t)`, etc. all parse correctly even though `thread`
+  itself remains the spawn keyword.
 - **Cross-function object-shape prediction.** Every user function gets
   a per-parameter write summary recorded during inference: every
   direct `param.key = value` mutation. At call sites, the summary is

--- a/editors/vscode-cando/CHANGELOG.md
+++ b/editors/vscode-cando/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to the **CanDo Language** VS Code extension are
 documented in this file.
 
+## 0.8.0 -- 2026-05-11
+
+### Added
+
+- **Structured doc comments.** The extension now recognises a small
+  JSDoc/LuaLS-flavored tag vocabulary in `///` line and `/** */`
+  block comments and turns it into type information that drives
+  completion, hover, signature help, and diagnostics:
+  - `@param name {type} description` -- type a function parameter.
+  - `@returns {type} description` -- type a return value (repeat for
+    multi-return).
+  - `@type {type}` -- type a `VAR` whose initialiser the inferer
+    can't pin down.
+  - `@field name {type} description` -- declare a class member; the
+    field becomes visible on `self.name` and on instances.
+  - `@shape Name { k: T, k2: T2 }` -- reusable named record type.
+  - `@callback Name (a: T, b: U) -> R` -- reusable function-signature
+    alias.
+  - `@class Name` / `@throws {type}` / `@thread-safe` / `@see` /
+    `@example` -- rendered into hover.
+  - `@deprecated msg` -- marks the binding; references render
+    struck-through and the completion entry is tagged.
+- **Doc-type mini-language.** A small recursive-descent parser
+  handles primitives (`number`, `string`, `bool`, ...), arrays
+  (`T[]` / `Array<T>`), unions (`T | U`), optionals (`T?`), object
+  literals (`{ k: T, k2: T2 }`), function literals
+  (`(a: T) -> R`, with multi-return `(...) -> R1, R2`), and named
+  references to `@shape` / `@callback` aliases declared anywhere in
+  the same file (including at file scope, outside any declaration).
+- **Doc diagnostics.** Three new advisory codes:
+  - `doc-bad-type` -- a `{type}` annotation didn't parse.
+  - `doc-unknown-tag` -- `@foo` isn't a known tag.
+  - `doc-deprecated-use` -- a reference to a `@deprecated` binding.
+
 ## 0.7.0 -- 2026-05-11
 
 ### Added

--- a/editors/vscode-cando/package.json
+++ b/editors/vscode-cando/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-cando",
   "displayName": "CanDo Language",
   "description": "Syntax highlighting, snippets and IntelliSense for the CanDo scripting language (.cdo).",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publisher": "CandoProject",
   "license": "SEE LICENSE IN LICENSE",
   "icon": "icons/cando.png",

--- a/editors/vscode-cando/server/src/analyze.ts
+++ b/editors/vscode-cando/server/src/analyze.ts
@@ -22,6 +22,7 @@ import { infer, InferResult } from './infer';
 import { TypeRef, ANY } from './typesys';
 import { findManifestFor } from './manifest';
 import { resolveIncludePath } from './paths';
+import { parseDocBlock, DocBlock } from './docparse';
 import * as path from 'path';
 
 export interface AnalyzedDocument {
@@ -84,7 +85,12 @@ function analyzeFresh(uri: string, text: string, version: number, workspaceRoots
 
 /** Walk every binding whose declaration starts on line N and look for
  *  consecutive `//` or `///` comments whose end line is N-1, N-2, ... .
- *  Concatenated comment text (joined by newlines) becomes binding.doc. */
+ *  Concatenated comment text (joined by newlines) becomes binding.doc.
+ *
+ *  Doc blocks that don't attach to any binding (e.g. a top-of-file
+ *  `@shape Foo { ... }` separated by a blank line from the next decl)
+ *  are recorded on `resolved.orphanDocBlocks` so the alias registry
+ *  can still pick up their `@shape` / `@callback` declarations. */
 function attachDocComments(tokens: Token[], resolved: ResolveResult): void {
     /* Group comments by their end line for cheap lookup. */
     const byEndLine = new Map<number, Token>();
@@ -92,18 +98,60 @@ function attachDocComments(tokens: Token[], resolved: ResolveResult): void {
         if (t.kind !== 'comment') continue;
         byEndLine.set(t.range.end.line, t);
     }
+
+    /* Track which comment tokens we attach to a binding so we can find
+     * orphan blocks afterwards. */
+    const consumed = new Set<Token>();
+
     for (const b of resolved.allBindings) {
         if (b.kind !== 'function' && b.kind !== 'class' &&
             b.kind !== 'const' && b.kind !== 'var' && b.kind !== 'global') continue;
         const lines: string[] = [];
+        const usedHere: Token[] = [];
         let line = b.declRange.start.line - 1;
         while (line >= 0) {
             const c = byEndLine.get(line);
             if (!c) break;
             lines.unshift(stripCommentMarker(c.value));
+            usedHere.push(c);
             line = c.range.start.line - 1;
         }
-        if (lines.length) b.doc = renderDocComment(lines.join('\n').trim());
+        if (lines.length) {
+            const raw = lines.join('\n').trim();
+            b.docBlock = parseDocBlock(raw);
+            b.doc = renderDocComment(raw);
+            if (b.docBlock.deprecated) b.deprecated = b.docBlock.deprecated;
+            for (const c of usedHere) consumed.add(c);
+        }
+    }
+
+    /* Find orphan blocks. Group consecutive comment tokens (no gaps)
+     * and parse each unconsumed group. */
+    const allComments = tokens
+        .filter(t => t.kind === 'comment')
+        .sort((a, b) => a.range.start.line - b.range.start.line);
+    let i = 0;
+    while (i < allComments.length) {
+        const start = i;
+        let j = i + 1;
+        while (j < allComments.length &&
+               allComments[j].range.start.line === allComments[j - 1].range.end.line + 1) {
+            j++;
+        }
+        const group = allComments.slice(start, j);
+        if (!group.some(c => consumed.has(c))) {
+            const raw = group.map(c => stripCommentMarker(c.value)).join('\n').trim();
+            if (raw.length > 0) {
+                const block = parseDocBlock(raw);
+                /* Only keep orphan blocks that carry useful tags --
+                 * loose narrative comments shouldn't pollute the
+                 * registry. */
+                if (block.tags.length > 0) {
+                    resolved.orphanDocBlocks.push(block);
+                }
+            }
+        }
+        i = j;
     }
 }
 

--- a/editors/vscode-cando/server/src/ast.ts
+++ b/editors/vscode-cando/server/src/ast.ts
@@ -190,6 +190,8 @@ export type Expr =
     | Pipe
     | Paren
     | RangeExpr
+    | ThreadExpr
+    | AwaitExpr
     | ErrorExpr;
 
 export interface NumberLit extends Base { kind: 'NumberLit'; value: number; raw: string; }
@@ -332,7 +334,8 @@ export interface Pipe extends Base {
     kind: 'Pipe';
     source: Expr;
     op: '~>' | '~!>' | '~&>';
-    body: Expr;
+    /** Either a single expression or a block (`{ ... RETURN x; }`). */
+    body: Expr | BlockStmt;
 }
 
 export interface Paren extends Base {
@@ -349,6 +352,22 @@ export interface RangeExpr extends Base {
 
 /** Used during error recovery so traversal never breaks. */
 export interface ErrorExpr extends Base { kind: 'ErrorExpr'; }
+
+/** `thread { ... }` (block form) or `thread expr` (call form). Spawns
+ *  an OS thread that runs the body; evaluates to a thread handle. */
+export interface ThreadExpr extends Base {
+    kind: 'ThreadExpr';
+    /** Either a BlockStmt for the block form or an Expr for the call
+     *  form. We don't normalise -- inference walks both shapes. */
+    body: BlockStmt | Expr;
+}
+
+/** `await expr` -- blocks until the thread completes and yields its
+ *  return value(s). */
+export interface AwaitExpr extends Base {
+    kind: 'AwaitExpr';
+    argument: Expr;
+}
 
 /* -- Patterns ------------------------------------------------------------ */
 
@@ -436,9 +455,14 @@ export function* children(n: Node): IterableIterator<Node> {
         case 'ClassExpr': yield n.body; return;
         case 'Mask': yield n.expr; return;
         case 'Spread': yield n.argument; return;
-        case 'Pipe': yield n.source; yield n.body; return;
+        case 'Pipe':
+            yield n.source;
+            yield n.body;
+            return;
         case 'Paren': yield n.expression; return;
         case 'RangeExpr': yield n.from; yield n.to; return;
+        case 'ThreadExpr': yield n.body; return;
+        case 'AwaitExpr': yield n.argument; return;
 
         default:
             return;

--- a/editors/vscode-cando/server/src/docparse.ts
+++ b/editors/vscode-cando/server/src/docparse.ts
@@ -1,0 +1,406 @@
+/*
+ * Doc-comment parser.
+ *
+ * Takes the raw text of a leading comment block (already stripped of
+ * `//` / `///` / `/* *\/` markers and common indentation) and produces
+ * a structured DocBlock describing the summary text and any recognised
+ * `@tag` annotations.
+ *
+ * The tag vocabulary mirrors JSDoc/LuaLS conventions, restricted to what
+ * the CanDo type system can represent. Unknown tags are preserved in
+ * `unknownTags` so the LSP can surface advisory diagnostics without
+ * losing the user's intent.
+ *
+ * Type-text after `{...}` is captured verbatim; parsing the type itself
+ * is done lazily by doctypes.ts when the inferer needs a TypeRef.
+ */
+
+export interface DocBlock {
+    /** Description text (everything that isn't a tag). Already trimmed. */
+    description: string;
+    /** Parsed tags, in source order. */
+    tags: DocTag[];
+    /** Tags whose name we didn't recognise. */
+    unknownTags: RawTag[];
+    /** Convenience: true iff a `@deprecated` tag is present. */
+    deprecated?: string;
+}
+
+export type DocTag =
+    | ParamTag
+    | ReturnsTag
+    | TypeTag
+    | FieldTag
+    | ShapeTag
+    | CallbackTag
+    | ClassTag
+    | ThrowsTag
+    | ThreadSafetyTag
+    | DeprecatedTag
+    | SeeTag
+    | ExampleTag
+    | RawTag;
+
+export interface ParamTag {
+    kind: 'param';
+    name: string;
+    typeText?: string;
+    description: string;
+}
+export interface ReturnsTag {
+    kind: 'returns';
+    typeText?: string;
+    description: string;
+}
+export interface TypeTag {
+    kind: 'type';
+    typeText: string;
+    description: string;
+}
+export interface FieldTag {
+    kind: 'field';
+    name: string;
+    typeText?: string;
+    description: string;
+}
+export interface ShapeTag {
+    kind: 'shape';
+    name: string;
+    typeText: string;
+    description: string;
+}
+export interface CallbackTag {
+    kind: 'callback';
+    name: string;
+    typeText: string;
+    description: string;
+}
+export interface ClassTag {
+    kind: 'class';
+    name?: string;
+    description: string;
+}
+export interface ThrowsTag {
+    kind: 'throws';
+    typeText?: string;
+    description: string;
+}
+export interface ThreadSafetyTag {
+    kind: 'thread-safe' | 'not-thread-safe';
+    description: string;
+}
+export interface DeprecatedTag {
+    kind: 'deprecated';
+    description: string;
+}
+export interface SeeTag {
+    kind: 'see';
+    description: string;
+}
+export interface ExampleTag {
+    kind: 'example';
+    description: string;
+}
+export interface RawTag {
+    kind: 'unknown';
+    name: string;
+    description: string;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Entry point                                                             */
+/* ----------------------------------------------------------------------- */
+
+export function parseDocBlock(raw: string): DocBlock {
+    const lines = raw.split('\n');
+    const summaryLines: string[] = [];
+    const tags: DocTag[] = [];
+    const unknown: RawTag[] = [];
+
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        const tagMatch = /^\s*@([A-Za-z][A-Za-z0-9-_]*)\s*(.*)$/.exec(line);
+        if (!tagMatch) {
+            summaryLines.push(line);
+            i++;
+            continue;
+        }
+        const tagName = tagMatch[1].toLowerCase();
+        /* Multi-line tag bodies: subsequent lines that don't start a new
+         * tag get appended to this tag's body. */
+        const body = [tagMatch[2]];
+        let j = i + 1;
+        while (j < lines.length && !/^\s*@[A-Za-z]/.test(lines[j])) {
+            body.push(lines[j]);
+            j++;
+        }
+        const tag = parseTag(tagName, joinBody(body));
+        if (tag) {
+            tags.push(tag);
+            if (tag.kind === 'unknown') unknown.push(tag);
+        }
+        i = j;
+    }
+
+    let deprecated: string | undefined;
+    for (const t of tags) {
+        if (t.kind === 'deprecated') {
+            deprecated = t.description || 'This binding is deprecated.';
+        }
+    }
+
+    return {
+        description: summaryLines.join('\n').trim(),
+        tags,
+        unknownTags: unknown,
+        deprecated
+    };
+}
+
+/* ----------------------------------------------------------------------- */
+/* Per-tag dispatch                                                        */
+/* ----------------------------------------------------------------------- */
+
+function parseTag(name: string, body: string): DocTag | null {
+    switch (name) {
+        case 'param':    return parseParam(body);
+        case 'arg':      return parseParam(body); // alias
+        case 'return':   return parseReturns(body);
+        case 'returns':  return parseReturns(body);
+        case 'type':     return parseType(body);
+        case 'field':    return parseField(body);
+        case 'property': return parseField(body); // alias
+        case 'shape':    return parseShape(body);
+        case 'callback': return parseCallback(body);
+        case 'class':    return parseClass(body);
+        case 'throws':   return parseThrows(body);
+        case 'throw':    return parseThrows(body); // alias
+        case 'thread-safe':     return { kind: 'thread-safe', description: body.trim() };
+        case 'threadsafe':      return { kind: 'thread-safe', description: body.trim() };
+        case 'not-thread-safe': return { kind: 'not-thread-safe', description: body.trim() };
+        case 'notthreadsafe':   return { kind: 'not-thread-safe', description: body.trim() };
+        case 'deprecated': return { kind: 'deprecated', description: body.trim() };
+        case 'see':      return { kind: 'see', description: body.trim() };
+        case 'example':  return { kind: 'example', description: body.replace(/^\n+/, '').replace(/\n+$/, '') };
+        default:         return { kind: 'unknown', name, description: body.trim() };
+    }
+}
+
+/** Try to extract a brace-balanced `{type}` group starting at `body[i]`.
+ *  Returns the inner type text and the index just past the closing `}`,
+ *  or null if `body[i]` isn't `{` or the braces are unbalanced. */
+function takeBraceGroup(body: string, i: number): { inner: string; next: number } | null {
+    if (body[i] !== '{') return null;
+    let depth = 0;
+    for (let j = i; j < body.length; j++) {
+        const c = body[j];
+        if (c === '{') depth++;
+        else if (c === '}') {
+            depth--;
+            if (depth === 0) return { inner: body.slice(i + 1, j).trim(), next: j + 1 };
+        }
+    }
+    return null;
+}
+
+function skipSp(body: string, i: number): number {
+    while (i < body.length && (body[i] === ' ' || body[i] === '\t')) i++;
+    return i;
+}
+
+function takeIdent(body: string, i: number): { name: string; next: number } | null {
+    const m = /^[A-Za-z_][A-Za-z0-9_]*/.exec(body.slice(i));
+    if (!m) return null;
+    return { name: m[0], next: i + m[0].length };
+}
+
+function takeDashOrColon(body: string, i: number): number {
+    if (body[i] === '-' || body[i] === ':') return skipSp(body, i + 1);
+    return i;
+}
+
+/* @param name {type} description
+ * @param name description           (no type)
+ * @param {type} name description    (jsdoc order — also accepted)
+ */
+function parseParam(body: string): ParamTag | null {
+    body = body.trim();
+    let i = 0;
+    /* @param {type} name desc */
+    if (body[0] === '{') {
+        const g = takeBraceGroup(body, 0);
+        if (!g) return null;
+        i = skipSp(body, g.next);
+        const id = takeIdent(body, i);
+        if (!id) return null;
+        i = skipSp(body, id.next);
+        i = takeDashOrColon(body, i);
+        return { kind: 'param', name: id.name, typeText: g.inner, description: body.slice(i).trim() };
+    }
+    /* @param name {type}? desc */
+    const id = takeIdent(body, 0);
+    if (!id) return null;
+    i = skipSp(body, id.next);
+    let typeText: string | undefined;
+    if (body[i] === '{') {
+        const g = takeBraceGroup(body, i);
+        if (g) {
+            typeText = g.inner;
+            i = skipSp(body, g.next);
+        }
+    }
+    i = takeDashOrColon(body, i);
+    const tag: ParamTag = { kind: 'param', name: id.name, description: body.slice(i).trim() };
+    if (typeText !== undefined) tag.typeText = typeText;
+    return tag;
+}
+
+function parseReturns(body: string): ReturnsTag {
+    body = body.trim();
+    if (body[0] === '{') {
+        const g = takeBraceGroup(body, 0);
+        if (g) {
+            let i = skipSp(body, g.next);
+            i = takeDashOrColon(body, i);
+            return { kind: 'returns', typeText: g.inner, description: body.slice(i).trim() };
+        }
+    }
+    return { kind: 'returns', description: body };
+}
+
+function parseType(body: string): TypeTag | null {
+    body = body.trim();
+    if (body[0] === '{') {
+        const g = takeBraceGroup(body, 0);
+        if (g) {
+            const desc = body.slice(g.next).trim();
+            return { kind: 'type', typeText: g.inner, description: desc };
+        }
+    }
+    if (body.length) return { kind: 'type', typeText: body, description: '' };
+    return null;
+}
+
+function parseField(body: string): FieldTag | null {
+    body = body.trim();
+    let i = 0;
+    if (body[0] === '{') {
+        const g = takeBraceGroup(body, 0);
+        if (!g) return null;
+        i = skipSp(body, g.next);
+        const id = takeIdent(body, i);
+        if (!id) return null;
+        i = skipSp(body, id.next);
+        i = takeDashOrColon(body, i);
+        return { kind: 'field', name: id.name, typeText: g.inner, description: body.slice(i).trim() };
+    }
+    const id = takeIdent(body, 0);
+    if (!id) return null;
+    i = skipSp(body, id.next);
+    let typeText: string | undefined;
+    if (body[i] === '{') {
+        const g = takeBraceGroup(body, i);
+        if (g) {
+            typeText = g.inner;
+            i = skipSp(body, g.next);
+        }
+    }
+    i = takeDashOrColon(body, i);
+    const tag: FieldTag = { kind: 'field', name: id.name, description: body.slice(i).trim() };
+    if (typeText !== undefined) tag.typeText = typeText;
+    return tag;
+}
+
+/* @shape Name { k: T, k2: T2 }  description */
+function parseShape(body: string): ShapeTag | null {
+    body = body.trim();
+    /* Match Name followed by a brace-balanced object type. */
+    const nameMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*([\s\S]*)$/.exec(body);
+    if (!nameMatch) return null;
+    const rest = nameMatch[2].trimStart();
+    if (!rest.startsWith('{')) return null;
+    const end = findBalanced(rest, '{', '}');
+    if (end < 0) return null;
+    const typeText = rest.slice(0, end + 1);
+    const description = rest.slice(end + 1).trim();
+    return { kind: 'shape', name: nameMatch[1], typeText, description };
+}
+
+/* @callback Name (a: T, b: U) -> R   description */
+function parseCallback(body: string): CallbackTag | null {
+    body = body.trim();
+    const nameMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*([\s\S]*)$/.exec(body);
+    if (!nameMatch) return null;
+    const rest = nameMatch[2].trimStart();
+    if (!rest.startsWith('(')) return null;
+    const close = findBalanced(rest, '(', ')');
+    if (close < 0) return null;
+    /* Look for `-> ReturnType` after the param list. */
+    const afterParens = rest.slice(close + 1).trimStart();
+    let typeText: string;
+    let description: string;
+    if (afterParens.startsWith('->')) {
+        /* Greedy: take the return type up to the first 2+ whitespace
+         * gap or newline that introduces description. */
+        const retBody = afterParens.slice(2).trimStart();
+        const nlIdx = retBody.indexOf('\n');
+        const ret = nlIdx >= 0 ? retBody.slice(0, nlIdx).trim() : retBody.trim();
+        typeText = rest.slice(0, close + 1) + ' -> ' + ret;
+        description = nlIdx >= 0 ? retBody.slice(nlIdx + 1).trim() : '';
+    } else {
+        typeText = rest.slice(0, close + 1) + ' -> null';
+        description = afterParens.trim();
+    }
+    return { kind: 'callback', name: nameMatch[1], typeText, description };
+}
+
+function parseClass(body: string): ClassTag {
+    body = body.trim();
+    const m = /^([A-Za-z_][A-Za-z0-9_]*)\s*([\s\S]*)$/.exec(body);
+    if (m) return { kind: 'class', name: m[1], description: m[2].trim() };
+    return { kind: 'class', description: body };
+}
+
+function parseThrows(body: string): ThrowsTag {
+    body = body.trim();
+    if (body[0] === '{') {
+        const g = takeBraceGroup(body, 0);
+        if (g) {
+            let i = skipSp(body, g.next);
+            i = takeDashOrColon(body, i);
+            return { kind: 'throws', typeText: g.inner, description: body.slice(i).trim() };
+        }
+    }
+    return { kind: 'throws', description: body };
+}
+
+/* ----------------------------------------------------------------------- */
+/* Helpers                                                                 */
+/* ----------------------------------------------------------------------- */
+
+function joinBody(parts: string[]): string {
+    /* The first element already lacks the @tag prefix. Trim each
+     * subsequent line of its leading whitespace, preserve blank lines. */
+    if (parts.length === 0) return '';
+    const head = parts[0];
+    if (parts.length === 1) return head;
+    const tail = parts.slice(1).join('\n');
+    return head + '\n' + tail;
+}
+
+/** Index of the matching close paren/brace; -1 if unbalanced.
+ *  `s[0]` must equal `open`. */
+function findBalanced(s: string, open: string, close: string): number {
+    if (s[0] !== open) return -1;
+    let depth = 0;
+    for (let i = 0; i < s.length; i++) {
+        const c = s[i];
+        if (c === open) depth++;
+        else if (c === close) {
+            depth--;
+            if (depth === 0) return i;
+        }
+    }
+    return -1;
+}

--- a/editors/vscode-cando/server/src/doctypes.ts
+++ b/editors/vscode-cando/server/src/doctypes.ts
@@ -1,0 +1,245 @@
+/*
+ * Recursive-descent parser for the doc-comment type mini-language.
+ *
+ * Grammar:
+ *   type    := union
+ *   union   := suffix ('|' suffix)*
+ *   suffix  := atom ('[]' | '?')*           // postfix array / optional
+ *   atom    := prim | object | fn | named | '(' type ')'
+ *   prim    := 'null' | 'bool' | 'boolean' | 'number' | 'string'
+ *            | 'thread' | 'any' | 'unknown' | 'value'
+ *   object  := '{' ( field (',' field)* ','? )? '}'
+ *   field   := ident ('?')? ':' type
+ *   fn      := '(' params? ')' '->' returns
+ *   params  := param (',' param)*
+ *   param   := '...' ident (':' type)? | ident (':' type)?
+ *   returns := type (',' type)*           // multi-return
+ *   named   := IDENT                       // @shape / @callback alias
+ *
+ * Errors return null so callers fall back to UNKNOWN. We also produce
+ * an `errors` list for advisory diagnostics.
+ */
+
+import {
+    TypeRef, FunctionParam, MemberType,
+    ANY, UNKNOWN, NULL_T, BOOL_T, NUM_T, STR_T, THREAD_T,
+    arrayOf, optionalOf, unionOf, emptyObject
+} from './typesys';
+
+export interface DocTypeContext {
+    /** Lookup table for `@shape Name` / `@callback Name` aliases visible
+     *  in the file. */
+    aliases: Map<string, TypeRef>;
+}
+
+export interface DocTypeResult {
+    type: TypeRef | null;
+    errors: string[];
+}
+
+export function parseDocType(text: string, ctx: DocTypeContext): DocTypeResult {
+    const p = new TypeParser(text, ctx);
+    const t = p.tryType();
+    if (t === null) {
+        p.errors.push(p.errors.length ? p.errors[0] : `Invalid type: "${text}"`);
+        return { type: null, errors: p.errors };
+    }
+    p.skipWs();
+    if (p.pos < p.src.length) {
+        p.errors.push(`Unexpected "${p.src.slice(p.pos)}" at end of type`);
+    }
+    return { type: t, errors: p.errors };
+}
+
+/* ----------------------------------------------------------------------- */
+/* Parser                                                                  */
+/* ----------------------------------------------------------------------- */
+
+class TypeParser {
+    public pos = 0;
+    public errors: string[] = [];
+    constructor(public src: string, private ctx: DocTypeContext) {}
+
+    /* ---- low-level scanning ---- */
+
+    skipWs(): void {
+        while (this.pos < this.src.length && /\s/.test(this.src[this.pos])) this.pos++;
+    }
+
+    peek(): string { return this.src[this.pos] ?? ''; }
+
+    match(s: string): boolean {
+        this.skipWs();
+        if (this.src.startsWith(s, this.pos)) {
+            this.pos += s.length;
+            return true;
+        }
+        return false;
+    }
+
+    matchIdent(): string | null {
+        this.skipWs();
+        const m = /^[A-Za-z_][A-Za-z0-9_]*/.exec(this.src.slice(this.pos));
+        if (!m) return null;
+        this.pos += m[0].length;
+        return m[0];
+    }
+
+    /* ---- grammar productions ---- */
+
+    tryType(): TypeRef | null {
+        return this.parseUnion();
+    }
+
+    private parseUnion(): TypeRef | null {
+        const first = this.parseSuffix();
+        if (first === null) return null;
+        const parts: TypeRef[] = [first];
+        while (this.match('|')) {
+            const next = this.parseSuffix();
+            if (next === null) {
+                this.errors.push('Expected type after "|"');
+                return unionOf(parts);
+            }
+            parts.push(next);
+        }
+        return parts.length === 1 ? parts[0] : unionOf(parts);
+    }
+
+    private parseSuffix(): TypeRef | null {
+        let t = this.parseAtom();
+        if (t === null) return null;
+        for (;;) {
+            this.skipWs();
+            if (this.match('[]')) { t = arrayOf(t); continue; }
+            if (this.match('?'))  { t = optionalOf(t); continue; }
+            break;
+        }
+        return t;
+    }
+
+    private parseAtom(): TypeRef | null {
+        this.skipWs();
+        const c = this.peek();
+        if (c === '{') return this.parseObject();
+        if (c === '(') {
+            /* Could be a parenthesised type or a function `( ... ) -> ret`.
+             * Snapshot, try function form first, fall back. */
+            const save = this.pos;
+            const fn = this.tryFunction();
+            if (fn) return fn;
+            this.pos = save;
+            this.match('(');
+            const inner = this.tryType();
+            if (inner === null) { this.errors.push('Expected type inside parentheses'); return null; }
+            if (!this.match(')')) { this.errors.push('Expected ")"'); return null; }
+            return inner;
+        }
+        const id = this.matchIdent();
+        if (!id) return null;
+        const prim = primFromName(id);
+        if (prim) return prim;
+        if (id === 'Array' && this.match('<')) {
+            const inner = this.tryType();
+            if (inner === null) return null;
+            if (!this.match('>')) { this.errors.push('Expected ">"'); return null; }
+            return arrayOf(inner);
+        }
+        const alias = this.ctx.aliases.get(id);
+        if (alias) return alias;
+        /* Unknown named type — keep going but mark as ANY so member
+         * completion is permissive rather than wrong. */
+        this.errors.push(`Unknown type "${id}"`);
+        return ANY;
+    }
+
+    private parseObject(): TypeRef | null {
+        if (!this.match('{')) return null;
+        const members = new Map<string, MemberType>();
+        this.skipWs();
+        if (this.match('}')) return { kind: 'object', members };
+        while (true) {
+            this.skipWs();
+            const name = this.matchIdent();
+            if (!name) { this.errors.push('Expected field name in object type'); return null; }
+            const optional = this.match('?');
+            if (!this.match(':')) { this.errors.push(`Expected ":" after field "${name}"`); return null; }
+            const t = this.tryType();
+            if (t === null) return null;
+            const memberType = optional ? optionalOf(t) : t;
+            members.set(name, { type: memberType });
+            this.skipWs();
+            if (this.match(',')) continue;
+            if (this.match('}')) break;
+            this.errors.push('Expected "," or "}" in object type');
+            return null;
+        }
+        return { kind: 'object', members };
+    }
+
+    /** Attempts to parse a function literal starting at `(`. Returns null
+     *  (without consuming) if it doesn't look like one. The caller must
+     *  reset `pos` on null. */
+    private tryFunction(): TypeRef | null {
+        const start = this.pos;
+        if (!this.match('(')) return null;
+        const params: FunctionParam[] = [];
+        this.skipWs();
+        if (!this.match(')')) {
+            while (true) {
+                this.skipWs();
+                const rest = this.match('...');
+                const name = this.matchIdent();
+                if (!name) { this.pos = start; return null; }
+                let t: TypeRef = ANY;
+                if (this.match(':')) {
+                    const pt = this.tryType();
+                    if (pt === null) { this.pos = start; return null; }
+                    t = pt;
+                }
+                const p: FunctionParam = { name, type: t };
+                if (rest) p.rest = true;
+                params.push(p);
+                if (this.match(',')) continue;
+                if (this.match(')')) break;
+                this.pos = start; return null;
+            }
+        }
+        this.skipWs();
+        if (!this.match('->')) { this.pos = start; return null; }
+        const returns: TypeRef[] = [];
+        const r0 = this.tryType();
+        if (r0 === null) { this.pos = start; return null; }
+        returns.push(r0);
+        while (this.match(',')) {
+            const rn = this.tryType();
+            if (rn === null) { this.pos = start; return null; }
+            returns.push(rn);
+        }
+        return { kind: 'function', params, returns };
+    }
+}
+
+function primFromName(s: string): TypeRef | null {
+    switch (s) {
+        case 'null':    return NULL_T;
+        case 'bool':    return BOOL_T;
+        case 'boolean': return BOOL_T;
+        case 'number':  return NUM_T;
+        case 'string':  return STR_T;
+        case 'thread':  return THREAD_T;
+        case 'any':     return ANY;
+        case 'value':   return ANY;
+        case 'unknown': return UNKNOWN;
+        case 'void':    return NULL_T;
+    }
+    return null;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Public helpers                                                          */
+/* ----------------------------------------------------------------------- */
+
+export function emptyDocTypeContext(): DocTypeContext {
+    return { aliases: new Map() };
+}

--- a/editors/vscode-cando/server/src/infer.ts
+++ b/editors/vscode-cando/server/src/infer.ts
@@ -13,13 +13,13 @@
 
 import { Range } from './lexer';
 import {
-    Program, Stmt, Expr, FunctionDecl, ClassDecl,
+    Program, Stmt, Expr, FunctionDecl, ClassDecl, BlockStmt,
     VarDecl, AssignStmt, Ident, Member, Call, FunctionExpr, ClassExpr,
-    ArrayLit, ObjectLit, Pipe, Node
+    ArrayLit, ObjectLit, Pipe, Node, walk as walkAst
 } from './ast';
 import { Scope, Binding, ResolveResult } from './scope';
 import {
-    TypeRef, FunctionType, FunctionParam, ObjectType, ClassType,
+    TypeRef, FunctionType, FunctionParam, FunctionSummary, ObjectType, ClassType,
     ArrayType, NamespaceInfo, MemberType,
     ANY, UNKNOWN, NULL_T, BOOL_T, NUM_T, STR_T,
     arrayOf, tupleOf, emptyObject, optionalOf, unionOf,
@@ -487,6 +487,9 @@ class Inferer {
         const fnType = this.makeFunctionType(s.name, s.params, returns, s.nameRange);
         /* Layer doc info onto the synthesised function type. */
         this.applyDocSignatureOverlay(fnType, b, fnScope, docReturns);
+        /* Collect the cross-call summary so callers can predict the
+         * post-call shape of their arguments. */
+        fnType.summary = this.collectFunctionSummary(s.body, s.params.map(p => p.name));
         if (b) {
             b.type = fnType;
             this.bindingTypes.set(b, fnType);
@@ -1041,6 +1044,11 @@ class Inferer {
             return calleeT.instance;
         }
         if (calleeT.kind === 'function') {
+            /* Replay the callee's per-param write summary onto the
+             * arguments. Lets `init(a)` add the keys `init` writes to
+             * its first param onto `a`'s shape -- exactly the
+             * cross-function shape prediction we set out to build. */
+            this.replaySummary(calleeT, e.args, scope);
             if (calleeT.returnsSelf && e.callee.kind === 'Member') {
                 return this.expr(e.callee.object, scope, flow);
             }
@@ -1173,7 +1181,8 @@ class Inferer {
             params: fp,
             returns: items.length === 0 ? [NULL_T] : items,
             name: e.name,
-            defRange: e.nameRange ?? e.range
+            defRange: e.nameRange ?? e.range,
+            summary: this.collectFunctionSummary(e.body, e.params.map(p => p.name))
         };
     }
 
@@ -1297,6 +1306,87 @@ class Inferer {
                 defRange: b.nameRange
             });
         }
+    }
+
+    /* ------------------------------------------------------------------- */
+    /* Function summaries: cross-call shape effects                        */
+    /* ------------------------------------------------------------------- */
+
+    /** Walk a function body and record every direct `paramName.key = value`
+     *  write. Reading is enough for now -- the spike that gets us most of
+     *  the value is just the writes. Nested patterns (`p.a.b = v`),
+     *  conditional writes, and writes through aliased locals are ignored;
+     *  they fall back to today's behavior (no cross-call effect). */
+    private collectFunctionSummary(body: BlockStmt, paramNames: string[]): FunctionSummary {
+        const paramWrites = new Map<number, Map<string, TypeRef>>();
+        if (paramNames.length === 0) return { paramWrites };
+        const nameToIdx = new Map<string, number>();
+        for (let i = 0; i < paramNames.length; i++) nameToIdx.set(paramNames[i], i);
+
+        walkAst(body, (n) => {
+            if (n.kind !== 'AssignStmt') return;
+            const targets = n.targets;
+            const rhs = n.rhs;
+            for (let i = 0; i < targets.length; i++) {
+                const t = targets[i];
+                if (t.kind !== 'Member') continue;
+                if (t.object.kind !== 'Ident') continue;
+                const idx = nameToIdx.get(t.object.name);
+                if (idx === undefined) continue;
+                /* RHS type: positional match, fall back to ANY. */
+                const r = rhs.length === targets.length ? rhs[i] : (rhs[0] ?? null);
+                const valueT = r ? (this.nodeTypes.get(r) ?? ANY) : ANY;
+                let m = paramWrites.get(idx);
+                if (!m) { m = new Map(); paramWrites.set(idx, m); }
+                const existing = m.get(t.property);
+                m.set(t.property, existing ? unionOf([existing, valueT]) : valueT);
+            }
+        });
+        return { paramWrites };
+    }
+
+    /** Replay a callee's summary onto the arguments at a call site, so
+     *  the caller's local variables gain the keys the callee wrote.
+     *  Conservative: only mutates argument types that are already
+     *  object-shaped (so we don't promote scalars or break unions). */
+    private replaySummary(fnType: FunctionType, args: Call['args'], scope: Scope): void {
+        const sum = fnType.summary;
+        if (!sum) return;
+        for (const [paramIdx, writes] of sum.paramWrites) {
+            const arg = args[paramIdx];
+            if (!arg || arg.spread) continue;
+            if (arg.expr.kind !== 'Ident') continue;
+            const b = scope.lookup(arg.expr.name);
+            if (!b) continue;
+            const target = this.objectTargetFor(b);
+            if (!target) continue;
+            for (const [key, valueT] of writes) {
+                setMember(target, key, { type: valueT });
+            }
+            /* If we promoted an empty/unknown var to a shape, refresh
+             * the cached binding type so completion sees it. */
+            this.bindingTypes.set(b, b.type);
+        }
+    }
+
+    /** Find or create the ObjectType we should record writes on for a
+     *  binding. Returns null when the binding's type isn't shape-like
+     *  and we don't want to coerce it (e.g. it's a primitive, a class
+     *  instance from a manifest, or a union). */
+    private objectTargetFor(b: Binding): ObjectType | null {
+        const t = b.type;
+        if (t.kind === 'object') return t;
+        if (t.kind === 'class') return t.instance;
+        /* Promote `unknown` / freshly-empty-shape locals so the first
+         * call into a writer gives them a body. We *don't* promote
+         * `any`: that's a deliberate user-or-doc "anything goes" and
+         * we shouldn't override it. */
+        if (t.kind === 'prim' && t.name === 'unknown') {
+            const fresh: ObjectType = emptyObject();
+            b.type = fresh;
+            return fresh;
+        }
+        return null;
     }
 
     private inferPipe(e: Pipe, scope: Scope, flow: FlowEnv): TypeRef {

--- a/editors/vscode-cando/server/src/infer.ts
+++ b/editors/vscode-cando/server/src/infer.ts
@@ -29,6 +29,8 @@ import {
 import { findManifestFor } from './manifest';
 import { NAMESPACES, GLOBAL_BUILTINS, NamespaceInfo as RawNamespaceInfo } from './builtins';
 import { resolveIncludePath } from './paths';
+import { parseDocType, DocTypeContext, emptyDocTypeContext } from './doctypes';
+import { DocBlock, DocTag } from './docparse';
 
 export interface InferOptions {
     documentUri: string;
@@ -47,6 +49,9 @@ export interface InferResult {
     bindingTypes: Map<Binding, TypeRef>;
     /** Top-level RETURN value of the program (drives module exports). */
     moduleType: TypeRef;
+    /** Advisory errors produced while parsing `{type}` doc annotations.
+     *  Surfaced as `doc-bad-type` diagnostics. */
+    docTypeErrors: Array<{ range: Range; message: string }>;
 }
 
 /** Lightweight immutable overlay of binding-id -> TypeRef. */
@@ -219,7 +224,8 @@ export function infer(program: Program, resolved: ResolveResult, opts: InferOpti
     return {
         nodeTypes: inf.nodeTypes,
         bindingTypes: inf.bindingTypes,
-        moduleType: inf.moduleType
+        moduleType: inf.moduleType,
+        docTypeErrors: inf.docTypeErrors
     };
 }
 
@@ -231,6 +237,14 @@ class Inferer {
     /** Stack of in-progress functions (for collecting RETURN tuples). */
     private fnStack: { returns: TypeRef[][] }[] = [];
 
+    /** Per-file alias table populated from `@shape` / `@callback` tags
+     *  on any binding visible at file scope. */
+    private docCtx: DocTypeContext = emptyDocTypeContext();
+
+    /** Errors produced while parsing `{type}` annotations in doc
+     *  comments. Surfaced as advisory diagnostics. */
+    public docTypeErrors: Array<{ range: Range; message: string }> = [];
+
     constructor(
         private readonly resolved: ResolveResult,
         private readonly opts: InferOptions
@@ -239,6 +253,10 @@ class Inferer {
     run(program: Program): void {
         const file = this.resolved.fileScope;
         let flow: FlowEnv = new Map();
+
+        /* Build the alias registry first so `@param x {MyShape}` can
+         * resolve a shape declared anywhere in the file. */
+        this.buildDocAliasRegistry();
 
         /* Two passes for forward refs to FunctionDecl / ClassDecl. First a
          * shallow declaration pass; then the full inference walk. */
@@ -455,6 +473,11 @@ class Inferer {
             }
         }
 
+        /* Doc-driven params/returns override the defaults. Done before
+         * the body so `o.field` reads inside the body see the declared
+         * shape during inference. */
+        const docReturns = this.applyDocToFunction(s, fnScope, b);
+
         const returns: TypeRef[][] = [];
         this.fnStack.push({ returns });
         let inner = flow;
@@ -462,12 +485,38 @@ class Inferer {
         this.fnStack.pop();
 
         const fnType = this.makeFunctionType(s.name, s.params, returns, s.nameRange);
+        /* Layer doc info onto the synthesised function type. */
+        this.applyDocSignatureOverlay(fnType, b, fnScope, docReturns);
         if (b) {
             b.type = fnType;
             this.bindingTypes.set(b, fnType);
         }
         this.nodeTypes.set(s, fnType);
         return flow;
+    }
+
+    /** After body-walk produces an inferred FunctionType, fold in any
+     *  `@param` types (already set on param bindings) and override
+     *  return types from `@returns`. Also copies the description into
+     *  `doc` for hover. */
+    private applyDocSignatureOverlay(
+        fnType: FunctionType,
+        b: Binding | undefined,
+        fnScope: Scope,
+        docReturns: TypeRef[] | null
+    ): void {
+        if (!b || !b.docBlock) return;
+        for (let i = 0; i < fnType.params.length; i++) {
+            const fp = fnType.params[i];
+            const pb = fnScope.bindings.get(fp.name);
+            if (pb) fp.type = pb.type;
+            const tag = b.docBlock.tags.find(t => t.kind === 'param' && t.name === fp.name);
+            if (tag && tag.kind === 'param' && tag.description) fp.doc = tag.description;
+        }
+        if (docReturns && docReturns.length > 0) {
+            fnType.returns = docReturns;
+        }
+        if (b.docBlock.description) fnType.doc = b.docBlock.description;
     }
 
     private stmtClassDecl(s: ClassDecl, scope: Scope, flow: FlowEnv): FlowEnv {
@@ -480,6 +529,9 @@ class Inferer {
                 instance.prototype = parent.type.instance;
             }
         }
+        /* Seed instance shape from `@field` annotations *before* walking
+         * the constructor body so reads like `self.foo` resolve. */
+        this.applyDocFieldsToClass(b, instance);
         if (b) {
             b.type = classType;
             this.bindingTypes.set(b, classType);
@@ -547,8 +599,10 @@ class Inferer {
             const v = values[i] ?? NULL_T;
             const b = targetScope.bindings.get(t.name);
             if (b) {
-                b.type = v;
-                this.bindingTypes.set(b, v);
+                /* `@type` on the declaration wins over inference. */
+                const docT = this.applyDocToVar(b);
+                b.type = docT ?? v;
+                this.bindingTypes.set(b, b.type);
             }
         }
         this.nodeTypes.set(s, NULL_T);
@@ -1146,6 +1200,103 @@ class Inferer {
         let inner = flow;
         for (const sub of e.body.body) inner = this.stmt(sub, bodyScope, inner);
         return ct;
+    }
+
+    /* ------------------------------------------------------------------- */
+    /* Doc-comment integration                                             */
+    /* ------------------------------------------------------------------- */
+
+    /** Walk every binding once and register `@shape` / `@callback`
+     *  aliases. Two passes: aliases that reference other aliases work
+     *  because the second pass parses with the populated table. */
+    private buildDocAliasRegistry(): void {
+        const blocks: DocBlock[] = [];
+        for (const b of this.resolved.allBindings) {
+            if (b.docBlock) blocks.push(b.docBlock);
+        }
+        blocks.push(...this.resolved.orphanDocBlocks);
+
+        /* Two passes so aliases that reference other aliases resolve in
+         * the second pass once the first has populated the table. */
+        for (let pass = 0; pass < 2; pass++) {
+            for (const block of blocks) {
+                for (const tag of block.tags) {
+                    if (tag.kind === 'shape' || tag.kind === 'callback') {
+                        const r = parseDocType(tag.typeText, this.docCtx);
+                        if (r.type) this.docCtx.aliases.set(tag.name, r.type);
+                    }
+                }
+            }
+        }
+    }
+
+    /** Look up a single doc-tag entry on a binding by tag kind. */
+    private docTagsOf<K extends DocTag['kind']>(b: Binding | undefined, kind: K): Array<Extract<DocTag, { kind: K }>> {
+        if (!b || !b.docBlock) return [];
+        return b.docBlock.tags.filter(t => t.kind === kind) as Array<Extract<DocTag, { kind: K }>>;
+    }
+
+    /** Resolve `{type}` text to a TypeRef. Errors get pushed to
+     *  `docTypeErrors` keyed by the binding's declaration range so the
+     *  diagnostic surface can attach them. */
+    private resolveDocType(text: string | undefined, attachAt: Range): TypeRef | null {
+        if (!text) return null;
+        const r = parseDocType(text, this.docCtx);
+        for (const msg of r.errors) {
+            this.docTypeErrors.push({ range: attachAt, message: msg });
+        }
+        return r.type;
+    }
+
+    /** Apply `@param` / `@returns` to a function declaration *before*
+     *  the body is walked. Returns the function's declared return-type
+     *  vector (or null if `@returns` was absent), so the caller can use
+     *  it as a fallback when inference yields UNKNOWN. */
+    private applyDocToFunction(decl: FunctionDecl, fnScope: Scope, declBinding?: Binding): TypeRef[] | null {
+        const block = declBinding?.docBlock;
+        if (!block) return null;
+
+        for (const tag of block.tags) {
+            if (tag.kind === 'param') {
+                const pb = fnScope.bindings.get(tag.name);
+                if (!pb) continue;
+                const t = this.resolveDocType(tag.typeText, declBinding!.nameRange);
+                if (t) {
+                    pb.type = t;
+                    this.bindingTypes.set(pb, t);
+                }
+            }
+        }
+        const returnsTags = block.tags.filter(t => t.kind === 'returns');
+        if (returnsTags.length === 0) return null;
+        const rets: TypeRef[] = [];
+        for (const rt of returnsTags) {
+            const t = this.resolveDocType(rt.typeText, declBinding!.nameRange);
+            rets.push(t ?? UNKNOWN);
+        }
+        return rets;
+    }
+
+    /** Apply `@type` from a VarDecl's binding to its declared type. */
+    private applyDocToVar(b: Binding | undefined): TypeRef | null {
+        if (!b || !b.docBlock) return null;
+        const typeTag = b.docBlock.tags.find(t => t.kind === 'type');
+        if (!typeTag) return null;
+        return this.resolveDocType(typeTag.typeText, b.nameRange);
+    }
+
+    /** Apply `@field` tags to a class instance's member table. */
+    private applyDocFieldsToClass(b: Binding | undefined, instance: ObjectType): void {
+        if (!b || !b.docBlock) return;
+        for (const tag of b.docBlock.tags) {
+            if (tag.kind !== 'field') continue;
+            const t = this.resolveDocType(tag.typeText, b.nameRange) ?? ANY;
+            instance.members.set(tag.name, {
+                type: t,
+                doc: tag.description || undefined,
+                defRange: b.nameRange
+            });
+        }
     }
 
     private inferPipe(e: Pipe, scope: Scope, flow: FlowEnv): TypeRef {

--- a/editors/vscode-cando/server/src/infer.ts
+++ b/editors/vscode-cando/server/src/infer.ts
@@ -21,7 +21,7 @@ import { Scope, Binding, ResolveResult } from './scope';
 import {
     TypeRef, FunctionType, FunctionParam, FunctionSummary, ObjectType, ClassType,
     ArrayType, NamespaceInfo, MemberType,
-    ANY, UNKNOWN, NULL_T, BOOL_T, NUM_T, STR_T,
+    ANY, UNKNOWN, NULL_T, BOOL_T, NUM_T, STR_T, THREAD_T,
     arrayOf, tupleOf, emptyObject, optionalOf, unionOf,
     firstOf, enumerateMembers, narrowTruthy, narrowFalsy,
     setMember
@@ -888,8 +888,60 @@ class Inferer {
                 this.expr(e.from, scope, flow);
                 this.expr(e.to, scope, flow);
                 return arrayOf(NUM_T);
+            case 'ThreadExpr': return this.inferThreadExpr(e, scope, flow);
+            case 'AwaitExpr': return this.inferAwaitExpr(e, scope, flow);
             case 'ErrorExpr': return UNKNOWN;
         }
+    }
+
+    private inferThreadExpr(e: import('./ast').ThreadExpr, scope: Scope, flow: FlowEnv): TypeRef {
+        /* Walk the body for side effects so locals are typed and any
+         * doc-driven param replays still happen. We don't recover the
+         * thread's return type yet -- that requires linking ThreadExpr
+         * sites to their await sites, which is future work. */
+        if (e.body.kind === 'BlockStmt') {
+            const fnScope = this.resolved.scopeOf.get(e) ?? scope;
+            const bodyScope = this.resolved.scopeOf.get(e.body) ?? fnScope;
+            const returns: TypeRef[][] = [];
+            this.fnStack.push({ returns });
+            let inner = flow;
+            for (const sub of e.body.body) inner = this.stmt(sub, bodyScope, inner);
+            this.fnStack.pop();
+            /* Remember the body's return type on the node so a
+             * downstream `await` can recover it. */
+            this.nodeTypes.set(e, this.threadHandleType(this.combineReturns(returns)));
+        } else {
+            const inner = this.expr(e.body, scope, flow);
+            this.nodeTypes.set(e, this.threadHandleType(inner));
+        }
+        return this.nodeTypes.get(e) ?? THREAD_T;
+    }
+
+    private inferAwaitExpr(e: import('./ast').AwaitExpr, scope: Scope, flow: FlowEnv): TypeRef {
+        const t = this.expr(e.argument, scope, flow);
+        /* If we know the awaited value came from a ThreadExpr we typed
+         * with a "thread<R>" shape, peel back to R. Otherwise punt. */
+        if (t.kind === 'object' && t.className === 'thread' && t.indexValue) {
+            return t.indexValue;
+        }
+        return UNKNOWN;
+    }
+
+    /** Construct a "thread handle" type carrying the body's return type
+     *  in `indexValue`. We piggyback on ObjectType (className='thread')
+     *  rather than inventing a new TypeRef kind. */
+    private threadHandleType(returnType: TypeRef): ObjectType {
+        return {
+            kind: 'object',
+            className: 'thread',
+            members: new Map([
+                ['state',  { type: { kind: 'function', params: [], returns: [STR_T], name: 'thread.state' } }],
+                ['done',   { type: { kind: 'function', params: [], returns: [BOOL_T], name: 'thread.done' } }],
+                ['join',   { type: { kind: 'function', params: [], returns: [returnType], name: 'thread.join' } }],
+                ['error',  { type: { kind: 'function', params: [], returns: [UNKNOWN], name: 'thread.error' } }]
+            ]),
+            indexValue: returnType
+        };
     }
 
     private inferIdent(e: Ident, scope: Scope, flow: FlowEnv): TypeRef {
@@ -1395,9 +1447,27 @@ class Inferer {
         const pipeBind = inner.bindings.get('pipe');
         const element = srcT.kind === 'array' ? srcT.element : ANY;
         if (pipeBind) { pipeBind.type = element; this.bindingTypes.set(pipeBind, element); }
-        const bodyT = this.expr(e.body, inner, flow);
+        let bodyT: TypeRef;
+        if (e.body.kind === 'BlockStmt') {
+            /* Block body: walk statements and collect RETURN values
+             * into a synthetic function frame so we can recover the
+             * mapped element's type. */
+            const returns: TypeRef[][] = [];
+            this.fnStack.push({ returns });
+            let f = flow;
+            for (const sub of e.body.body) f = this.stmt(sub, inner, f);
+            this.fnStack.pop();
+            bodyT = this.combineReturns(returns);
+        } else {
+            bodyT = this.expr(e.body, inner, flow);
+        }
         if (e.op === '~>') return arrayOf(firstOf(bodyT));
-        /* ~!> and ~&> are filters: result is array of source-element. */
+        if (e.op === '~!>') {
+            /* Map+filter: result element is whatever the body returns,
+             * minus the dropped-NULL case. We don't model the drop. */
+            return arrayOf(firstOf(bodyT));
+        }
+        /* ~&> is a predicate filter: result is array of source-element. */
         return arrayOf(element);
     }
 }

--- a/editors/vscode-cando/server/src/parser.ts
+++ b/editors/vscode-cando/server/src/parser.ts
@@ -197,13 +197,18 @@ class Parser {
                 case 'CONTINUE': return this.parseBreakLike('ContinueStmt');
                 case 'SETTLE':   return this.parseBreakLike('SettleStmt');
                 case 'THREAD': {
-                    /* THREAD expr; — desugars to a thread-spawn; for analysis we
-                     * just treat it as an expression statement so the body is
-                     * still typed. */
-                    const tStart = this.advance().range.start;
-                    const expr = this.parseExpression();
+                    /* `thread.foo(...)` is stdlib namespace access, not the
+                     * spawn keyword; fall through to expression-statement
+                     * parsing so member/call handling takes over. */
+                    const next = this.peek(1);
+                    if (next.kind === 'op' && (next.value === '.' || next.value === '(' || next.value === '[')) {
+                        return this.parseExpressionStatement();
+                    }
+                    /* THREAD expr; — wrap as an ExprStmt around a ThreadExpr
+                     * so analysis sees the spawn and yields a thread handle. */
+                    const expr = this.parseThreadExpr();
                     this.matchOp(';');
-                    return { kind: 'ExprStmt', expr, range: { start: tStart, end: expr.range.end } };
+                    return { kind: 'ExprStmt', expr, range: expr.range };
                 }
             }
         }
@@ -737,21 +742,32 @@ class Parser {
             if (info.bp < minBp) break;
             this.advance();
             const nextMin = info.rightAssoc ? info.bp : info.bp + 1;
-            const right = this.parseBinaryAt(nextMin);
-            if (op === '->' || op === '<-') {
-                left = {
-                    kind: 'RangeExpr',
-                    from: op === '->' ? left : right,
-                    to:   op === '->' ? right : left,
-                    dir: op === '->' ? 'ASC' : 'DESC',
-                    range: { start: left.range.start, end: right.range.end }
-                };
-            } else if (op === '~>' || op === '~!>' || op === '~&>') {
+            /* Pipe bodies (`~>`, `~!>`, `~&>`) allow a block form on the
+             * RHS as an alternative to a single expression -- treat a
+             * leading `{` as a block-expression rather than an object
+             * literal here. */
+            const right = ((op === '~>' || op === '~!>' || op === '~&>') && this.isOp('{'))
+                ? this.parseBlockAsExpr()
+                : this.parseBinaryAt(nextMin);
+            if (op === '~>' || op === '~!>' || op === '~&>') {
                 left = {
                     kind: 'Pipe',
                     source: left,
                     op: op as Pipe['op'],
                     body: right,
+                    range: { start: left.range.start, end: right.range.end }
+                };
+            } else if (right.kind === 'BlockStmt') {
+                /* parseBlockAsExpr only fires for pipe ops; this branch
+                 * is defensive. */
+                this.error(right.range, 'Block expression not allowed here');
+                left = { kind: 'ErrorExpr', range: right.range };
+            } else if (op === '->' || op === '<-') {
+                left = {
+                    kind: 'RangeExpr',
+                    from: op === '->' ? left : right,
+                    to:   op === '->' ? right : left,
+                    dir: op === '->' ? 'ASC' : 'DESC',
                     range: { start: left.range.start, end: right.range.end }
                 };
             } else {
@@ -964,6 +980,19 @@ class Parser {
                 if (up === 'NULL')  { this.advance(); return { kind: 'NullLit',                range: t.range }; }
                 if (up === 'FUNCTION') return this.parseFunctionExpr();
                 if (up === 'CLASS')    return this.parseClassExpr();
+                if (up === 'THREAD') {
+                    /* `thread.<member>` and `thread(...)` are stdlib
+                     * namespace access, not the spawn keyword. Treat
+                     * the bare keyword followed by `.` or `(` as an
+                     * identifier so member/call parsing takes over. */
+                    const next = this.peek(1);
+                    if (next.kind === 'op' && (next.value === '.' || next.value === '(' || next.value === '[')) {
+                        this.advance();
+                        return { kind: 'Ident', name: 'thread', range: t.range };
+                    }
+                    return this.parseThreadExpr();
+                }
+                if (up === 'AWAIT')    return this.parseAwaitExpr();
                 /* `pipe` keyword is the loop variable inside ~> bodies. */
                 if (t.value === 'pipe' || up === 'PIPE') {
                     this.advance();
@@ -1078,6 +1107,44 @@ class Parser {
             kind: 'FunctionExpr',
             params, body, arrow: true,
             range: { start: open.range.start, end: body.range.end }
+        };
+    }
+
+    /** Pipe block body: `{ ... }`. Returns the BlockStmt as-is; the
+     *  pipe AST node tolerates Expr | BlockStmt for its body. */
+    private parseBlockAsExpr(): BlockStmt {
+        return this.parseBlock();
+    }
+
+    private parseThreadExpr(): Expr {
+        const kw = this.advance();   // THREAD / thread
+        if (this.isOp('{')) {
+            /* Block form: `thread { ... }`. Body is a sequence of
+             * statements; RETURN inside it yields the thread's value. */
+            const body = this.parseBlock();
+            return {
+                kind: 'ThreadExpr',
+                body,
+                range: { start: kw.range.start, end: body.range.end }
+            };
+        }
+        /* Call form: `thread expr` -- parse a unary-level expression so
+         * suffixes (member/call) attach to the inner expr, then wrap. */
+        const inner = this.parsePrefix();
+        return {
+            kind: 'ThreadExpr',
+            body: inner,
+            range: { start: kw.range.start, end: inner.range.end }
+        };
+    }
+
+    private parseAwaitExpr(): Expr {
+        const kw = this.advance();
+        const arg = this.parsePrefix();
+        return {
+            kind: 'AwaitExpr',
+            argument: arg,
+            range: { start: kw.range.start, end: arg.range.end }
         };
     }
 

--- a/editors/vscode-cando/server/src/scope.ts
+++ b/editors/vscode-cando/server/src/scope.ts
@@ -52,6 +52,13 @@ export interface Binding {
     /** Documentation comment harvested from the lines immediately above the
      *  declaration (see analyze.ts). Markdown; rendered verbatim in hover. */
     doc?: string;
+    /** Structured form of the same doc comment. Populated alongside
+     *  `doc`. Drives inference fallback (@type, @param, @returns) and
+     *  diagnostic surfacing (@deprecated, unknown tags). */
+    docBlock?: import('./docparse').DocBlock;
+    /** Deprecation message if `@deprecated` appeared in the doc block.
+     *  Surfaced by completion (CompletionItemTag.Deprecated) and hover. */
+    deprecated?: string;
 }
 
 export type ScopeKind = 'file' | 'function' | 'block';
@@ -98,6 +105,11 @@ export interface ResolveResult {
     scopeOf: Map<Node, Scope>;
     /** Bindings flattened (handy for diagnostics and tests). */
     allBindings: Binding[];
+    /** Doc-comment blocks that didn't attach to any declaration (free
+     *  floating). Mostly used to host `@shape` / `@callback` definitions
+     *  the user keeps near the top of the file. Populated by
+     *  analyze.ts:attachDocComments. */
+    orphanDocBlocks: import('./docparse').DocBlock[];
 }
 
 export function resolve(program: Program): ResolveResult {
@@ -112,7 +124,7 @@ export function resolve(program: Program): ResolveResult {
     }
     for (const s of program.body) r.stmt(s, file);
 
-    return { fileScope: file, scopeOf: r.scopeOf, allBindings: r.allBindings };
+    return { fileScope: file, scopeOf: r.scopeOf, allBindings: r.allBindings, orphanDocBlocks: [] };
 }
 
 class Resolver {

--- a/editors/vscode-cando/server/src/scope.ts
+++ b/editors/vscode-cando/server/src/scope.ts
@@ -355,7 +355,12 @@ class Resolver {
                 const body = new Scope(this.nextId(), 'block', scope, e);
                 this.scopeOf.set(e, body);
                 this.declare(body, 'pipe', 'pipe', e, e.range, e.range);
-                this.expr(e.body, body);
+                if (e.body.kind === 'BlockStmt') {
+                    this.scopeOf.set(e.body, body);
+                    for (const sub of e.body.body) this.stmt(sub, body);
+                } else {
+                    this.expr(e.body, body);
+                }
                 return;
             }
             case 'Member': this.expr(e.object, scope); return;
@@ -394,6 +399,22 @@ class Resolver {
             case 'Spread': this.expr(e.argument, scope); return;
             case 'Paren': this.expr(e.expression, scope); return;
             case 'RangeExpr': this.expr(e.from, scope); this.expr(e.to, scope); return;
+            case 'ThreadExpr': {
+                /* `thread { ... }` is its own function-like scope: RETURN
+                 * targets the thread, locals don't leak. The call form
+                 * `thread foo(x)` just spawns the call, no new scope. */
+                if (e.body.kind === 'BlockStmt') {
+                    const fn = new Scope(this.nextId(), 'function', scope, e);
+                    this.scopeOf.set(e, fn);
+                    const body = new Scope(this.nextId(), 'block', fn, e.body);
+                    this.scopeOf.set(e.body, body);
+                    for (const sub of e.body.body) this.stmt(sub, body);
+                } else {
+                    this.expr(e.body, scope);
+                }
+                return;
+            }
+            case 'AwaitExpr': this.expr(e.argument, scope); return;
 
             case 'NumberLit':
             case 'StringLit':

--- a/editors/vscode-cando/server/src/server.ts
+++ b/editors/vscode-cando/server/src/server.ts
@@ -350,6 +350,48 @@ function semanticDiagnostics(a: AnalyzedDocument): Diagnostic[] {
         });
     }
 
+    /* Doc-comment diagnostics:
+     *   - doc-bad-type: `{type}` annotation failed to parse cleanly.
+     *   - doc-unknown-tag: `@foo` tag we don't recognise.
+     *   - doc-deprecated-use: identifier resolves to a `@deprecated`
+     *     binding (informational, surfaced as faded text via tag). */
+    for (const d of a.inferred.docTypeErrors ?? []) {
+        out.push({
+            severity: DiagnosticSeverity.Information,
+            range: toLsp(d.range),
+            message: d.message,
+            source: 'cando',
+            code: 'doc-bad-type'
+        });
+    }
+    for (const b of a.resolved.allBindings) {
+        if (!b.docBlock) continue;
+        for (const tag of b.docBlock.unknownTags) {
+            out.push({
+                severity: DiagnosticSeverity.Hint,
+                range: toLsp(b.nameRange),
+                message: `Unknown doc tag '@${tag.name}' on '${b.name}'`,
+                source: 'cando',
+                code: 'doc-unknown-tag'
+            });
+        }
+    }
+    walkAst(a.program, (n) => {
+        if (n.kind !== 'Ident') return;
+        const scope = a.resolved.scopeOf.get(n);
+        const b = scope?.lookup(n.name);
+        if (!b || !b.deprecated) return;
+        if (b.references.length > 0 && b.references[0] === n.range) return; // skip the decl itself
+        out.push({
+            severity: DiagnosticSeverity.Hint,
+            range: toLsp(n.range),
+            message: `'${n.name}' is deprecated: ${b.deprecated}`,
+            source: 'cando',
+            code: 'doc-deprecated-use',
+            tags: [2]  // DiagnosticTag.Deprecated -- editor renders struck-through
+        });
+    });
+
     /* Dead code detection: any statement after a RETURN / THROW / BREAK /
      * CONTINUE / SETTLE in the same block is unreachable. */
     walkAst(a.program, (n) => {
@@ -545,7 +587,7 @@ connection.onCompletion(params => {
             const docMd = b.doc ?? (b.kind === 'function'
                 ? `Defined at line ${b.declRange.start.line + 1}.`
                 : undefined);
-            items.push({
+            const item: CompletionItem = {
                 label: name,
                 kind: bindingKindToCompletion(b),
                 detail: renderType(b.type),
@@ -553,7 +595,11 @@ connection.onCompletion(params => {
                 /* Push function and class declarations to the top of the
                  * list; locals beat globals in a tie. */
                 sortText: completionSortKey(b)
-            });
+            };
+            if (b.deprecated) {
+                item.tags = [1]; // CompletionItemTag.Deprecated -- editor renders struck-through
+            }
+            items.push(item);
         }
     }
     return items;

--- a/editors/vscode-cando/server/src/typesys.ts
+++ b/editors/vscode-cando/server/src/typesys.ts
@@ -42,11 +42,22 @@ export interface ObjectType {
     /** Optional class name for nicer rendering. */
     className?: string;
 }
+export interface FunctionSummary {
+    /** Direct writes the body performs on its parameters: paramIdx
+     *  -> field name -> value type. Used to predict the shape of an
+     *  argument *after* a call (so completion lights up new keys). */
+    paramWrites: Map<number, Map<string, TypeRef>>;
+}
+
 export interface FunctionType {
     kind: 'function';
     params: FunctionParam[];
     /** Return values, positionally. A multi-return function has length > 1. */
     returns: TypeRef[];
+    /** Cross-call effect summary. Populated by the inferer after the
+     *  body has been walked once. Absent for builtin / manifest
+     *  functions, which describe their effects declaratively. */
+    summary?: FunctionSummary;
     /** When the function is the body of a method declared via `:` syntax
      *  the receiver type goes here so signature help can describe it. */
     self?: TypeRef;

--- a/editors/vscode-cando/server/test/cases/37-doc-param-type-text.cdo
+++ b/editors/vscode-cando/server/test/cases/37-doc-param-type-text.cdo
@@ -1,0 +1,9 @@
+// DOC-CONTAINS: Adds two numbers
+/// Adds two numbers and returns the sum.
+///
+/// @param a {number} first addend
+/// @param b {number} second addend
+/// @returns {number} the sum
+FUNCTION add|(a, b) {
+    RETURN a + b;
+}

--- a/editors/vscode-cando/server/test/cases/38-doc-param-object-type.cdo
+++ b/editors/vscode-cando/server/test/cases/38-doc-param-object-type.cdo
@@ -1,0 +1,8 @@
+/// Connect to a service.
+///
+/// @param config {{ host: string, port: number, tls: bool }} settings
+FUNCTION connect(config) {
+    RETURN config.|host;
+    // MEMBERS: host, port, tls
+    // EXPECT: { host, port, tls }
+}

--- a/editors/vscode-cando/server/test/cases/39-doc-type-var.cdo
+++ b/editors/vscode-cando/server/test/cases/39-doc-type-var.cdo
@@ -1,0 +1,5 @@
+/// @type {{ a: number, b: string }}
+VAR rec = something();
+print(rec.|a);
+// EXPECT: { a, b }
+// MEMBERS: a, b

--- a/editors/vscode-cando/server/test/cases/40-doc-returns-shape.cdo
+++ b/editors/vscode-cando/server/test/cases/40-doc-returns-shape.cdo
@@ -1,0 +1,8 @@
+/// @returns {{ id: number, label: string }} a record
+FUNCTION makeRecord() {
+    RETURN someValue;
+}
+VAR r = makeRecord();
+print(r.|id);
+// EXPECT: { id, label }
+// MEMBERS: id, label

--- a/editors/vscode-cando/server/test/cases/41-doc-shape-alias.cdo
+++ b/editors/vscode-cando/server/test/cases/41-doc-shape-alias.cdo
@@ -1,0 +1,11 @@
+/// @shape Point { x: number, y: number }
+
+/// Translate a point by a delta.
+/// @param p {Point} input point
+/// @param dx {number} x offset
+/// @returns {Point} a new point
+FUNCTION translate(p, dx) {
+    RETURN { x: p.|x + dx, y: p.y };
+}
+// EXPECT: { x, y }
+// MEMBERS: x, y

--- a/editors/vscode-cando/server/test/cases/42-doc-callback-alias.cdo
+++ b/editors/vscode-cando/server/test/cases/42-doc-callback-alias.cdo
@@ -1,0 +1,8 @@
+/// @callback Handler (err: string, data: number) -> null
+
+/// Register a handler.
+/// @param h {Handler} the callback
+FUNCTION subscribe(h) {
+    print(h|);
+}
+// EXPECT: (err: string, data: number) -> null

--- a/editors/vscode-cando/server/test/cases/43-doc-class-field.cdo
+++ b/editors/vscode-cando/server/test/cases/43-doc-class-field.cdo
@@ -1,0 +1,10 @@
+/// A 3D vector.
+/// @field x {number} x component
+/// @field y {number} y component
+/// @field z {number} z component
+CLASS Vec3 = (self, x, y, z) {
+    self.x = x; self.y = y; self.z = z;
+}
+VAR v = Vec3(1, 2, 3);
+print(v.|x);
+// MEMBERS: x, y, z

--- a/editors/vscode-cando/server/test/cases/44-doc-bad-type.cdo
+++ b/editors/vscode-cando/server/test/cases/44-doc-bad-type.cdo
@@ -1,0 +1,5 @@
+/// @param x {NotARealType} oops
+FUNCTION badType(x) {
+    print(x|);
+}
+// DIAG-CODE: doc-bad-type

--- a/editors/vscode-cando/server/test/cases/45-doc-unknown-tag.cdo
+++ b/editors/vscode-cando/server/test/cases/45-doc-unknown-tag.cdo
@@ -1,0 +1,6 @@
+/// @nonsense this tag doesn't exist
+/// @param x {number}
+FUNCTION fn(x) {
+    print(x|);
+}
+// DIAG-CODE: doc-unknown-tag

--- a/editors/vscode-cando/server/test/cases/46-doc-deprecated.cdo
+++ b/editors/vscode-cando/server/test/cases/46-doc-deprecated.cdo
@@ -1,0 +1,7 @@
+/// Old API, use newFn instead.
+/// @deprecated since 0.6
+FUNCTION oldFn() {
+    RETURN 1;
+}
+VAR x = oldFn|();
+// DIAG-CODE: doc-deprecated-use

--- a/editors/vscode-cando/server/test/cases/47-summary-init-empty.cdo
+++ b/editors/vscode-cando/server/test/cases/47-summary-init-empty.cdo
@@ -1,0 +1,8 @@
+FUNCTION init(o) {
+    o.name = "x";
+    o.count = 0;
+}
+VAR a = {};
+init(a);
+print(a.|name);
+// MEMBERS: name, count

--- a/editors/vscode-cando/server/test/cases/48-summary-after-doc-typed-param.cdo
+++ b/editors/vscode-cando/server/test/cases/48-summary-after-doc-typed-param.cdo
@@ -1,0 +1,8 @@
+/// @param o {{ existing: string }} starts with one key
+FUNCTION addMore(o) {
+    o.extra = 42;
+}
+VAR rec = { existing: "hi" };
+addMore(rec);
+print(rec.|extra);
+// MEMBERS: existing, extra

--- a/editors/vscode-cando/server/test/cases/49-summary-chain.cdo
+++ b/editors/vscode-cando/server/test/cases/49-summary-chain.cdo
@@ -1,0 +1,7 @@
+FUNCTION addA(o) { o.a = 1; }
+FUNCTION addB(o) { o.b = 2; }
+VAR rec = {};
+addA(rec);
+addB(rec);
+print(rec.|a);
+// MEMBERS: a, b

--- a/editors/vscode-cando/server/test/cases/50-summary-via-var.cdo
+++ b/editors/vscode-cando/server/test/cases/50-summary-via-var.cdo
@@ -1,0 +1,9 @@
+FUNCTION init(o) {
+    o.x = 1;
+    o.y = 2;
+}
+VAR alias = init;
+VAR rec = {};
+alias(rec);
+print(rec.|x);
+// MEMBERS: x, y

--- a/editors/vscode-cando/server/test/cases/51-summary-via-object-field.cdo
+++ b/editors/vscode-cando/server/test/cases/51-summary-via-object-field.cdo
@@ -1,0 +1,10 @@
+FUNCTION init(o) { o.x = 1; o.y = 2; }
+VAR holder = { cb: init };
+VAR rec = {};
+/* Summary propagates through structural object fields because the
+ * FunctionType (with its summary) is preserved through value flow.
+ * This is a happy bonus -- the middle-ground plan flagged this as
+ * a fallback case, but it Just Works. */
+holder.cb(rec);
+print(rec.|x);
+// MEMBERS: x, y

--- a/editors/vscode-cando/server/test/cases/52-summary-alias-isolation.cdo
+++ b/editors/vscode-cando/server/test/cases/52-summary-alias-isolation.cdo
@@ -1,0 +1,13 @@
+/// @shape Point { x: number, y: number }
+
+/// @param p {Point}
+FUNCTION addZ(p) { p.z = 0; }
+
+VAR a = { x: 1, y: 2 };
+VAR b = { x: 3, y: 4 };
+addZ(a);
+/* `b` was not passed through addZ, so it must NOT have gained `z`.
+ * If alias sharing leaked, `b.z` would appear. */
+print(b.|x);
+// MEMBERS: x, y
+// NOMEMBERS: z

--- a/editors/vscode-cando/server/test/cases/53-thread-handle.cdo
+++ b/editors/vscode-cando/server/test/cases/53-thread-handle.cdo
@@ -1,0 +1,4 @@
+VAR t = thread { RETURN 42; };
+print(t.|state());
+// EXPECT: thread
+// MEMBERS: state, done, join, error

--- a/editors/vscode-cando/server/test/cases/54-thread-await-value.cdo
+++ b/editors/vscode-cando/server/test/cases/54-thread-await-value.cdo
@@ -1,0 +1,4 @@
+VAR t = thread { RETURN "hello"; };
+VAR msg = await t;
+print(msg|);
+// EXPECT: string

--- a/editors/vscode-cando/server/test/cases/55-thread-call-form.cdo
+++ b/editors/vscode-cando/server/test/cases/55-thread-call-form.cdo
@@ -1,0 +1,4 @@
+FUNCTION compute(x) { RETURN x * x; }
+VAR t = thread compute(7);
+print(t.|join());
+// MEMBERS: state, done, join, error

--- a/editors/vscode-cando/server/test/cases/56-pipe-block-body.cdo
+++ b/editors/vscode-cando/server/test/cases/56-pipe-block-body.cdo
@@ -1,0 +1,6 @@
+VAR xs = [1, 2, 3, 4];
+VAR evens_doubled = xs ~!> {
+    IF pipe % 2 == 0 { RETURN pipe * 2; }
+};
+print(evens_doubled|);
+// EXPECT: array<number>

--- a/editors/vscode-cando/server/test/cases/57-thread-namespace-vs-keyword.cdo
+++ b/editors/vscode-cando/server/test/cases/57-thread-namespace-vs-keyword.cdo
@@ -1,0 +1,5 @@
+VAR t = thread { thread.sleep(10); RETURN "done"; };
+thread.cancel(t);
+VAR s = t:state();
+print(s|);
+// EXPECT: string

--- a/editors/vscode-cando/server/test/runner.js
+++ b/editors/vscode-cando/server/test/runner.js
@@ -123,6 +123,24 @@ function semanticDiagnosticsFor(a) {
         if (b.references.length > 1) continue;
         out.push({ code: 'unused', range: b.nameRange, name: b.name });
     }
+    /* doc diagnostics */
+    for (const d of (a.inferred.docTypeErrors || [])) {
+        out.push({ code: 'doc-bad-type', range: d.range, message: d.message });
+    }
+    for (const b of a.resolved.allBindings) {
+        if (!b.docBlock) continue;
+        for (const t of b.docBlock.unknownTags) {
+            out.push({ code: 'doc-unknown-tag', range: b.nameRange, name: t.name });
+        }
+    }
+    walk(a.program, (n) => {
+        if (n.kind !== 'Ident') return;
+        const scope = a.resolved.scopeOf.get(n);
+        const b = scope ? scope.lookup(n.name) : null;
+        if (!b || !b.deprecated) return;
+        if (b.references.length > 0 && b.references[0] === n.range) return;
+        out.push({ code: 'doc-deprecated-use', range: n.range, name: n.name });
+    });
     /* dead code */
     walk(a.program, (n) => {
         if (n.kind !== 'BlockStmt') return;


### PR DESCRIPTION
## Summary

This PR introduces three major features to the CanDo language server:

1. **Structured doc-comment parsing** – A new JSDoc/LuaLS-style annotation system for documenting bindings with `@param`, `@returns`, `@type`, `@field`, `@shape`, `@callback`, `@deprecated`, and other tags
2. **Thread expressions** – `thread { ... }` and `await` as first-class expressions (not just statements), with proper type inference for thread handles
3. **Cross-function object-shape prediction** – Per-parameter write summaries that propagate through function calls and variable aliases to predict object mutations

## Key Changes

### Doc-Comment Infrastructure
- **`docparse.ts` (new)** – Recursive parser for doc-comment blocks that extracts summary text and structured tags (param, returns, type, field, shape, callback, class, throws, thread-safe, deprecated, see, example). Preserves unknown tags for advisory diagnostics.
- **`doctypes.ts` (new)** – Recursive-descent parser for the `{type}` mini-language embedded in doc annotations. Supports primitives, objects, functions, arrays, optionals, unions, and named aliases from `@shape`/`@callback` declarations.
- **`analyze.ts`** – `attachDocComments()` now parses doc blocks and attaches them to bindings; orphan blocks (e.g., top-of-file `@shape` definitions) are tracked separately for alias registry population.
- **`scope.ts`** – `Binding` interface extended with `docBlock` (structured form) and `deprecated` (convenience flag).

### Type System & Inference
- **`typesys.ts`** – Added `FunctionSummary` interface to track per-parameter direct writes (mutations) during function body inference.
- **`infer.ts`** – Major enhancements:
  - `buildDocAliasRegistry()` – Populates `DocTypeContext` from `@shape`/`@callback` tags visible at file scope
  - `applyDocToFunction()` – Applies `@param` type overrides and `@returns` to function signatures
  - `applyDocToVar()` – Applies `@type` tag to variable declarations
  - `applyDocFieldsToClass()` – Seeds class instance shape from `@field` tags
  - `collectFunctionSummary()` – Walks function body to record direct `param.key = value` mutations
  - `replaySummary()` – At call sites, replays the callee's write summary onto argument bindings
  - `threadHandleType()` – Constructs a structural `thread<R>` type with `state`, `done`, `join`, `error` members
  - `inferThreadExpr()` / `inferAwaitExpr()` – Type inference for thread spawn and await expressions

### Parser & AST
- **`parser.ts`** – 
  - `THREAD` keyword now disambiguates: `thread.foo(...)` parses as namespace access; `thread expr` or `thread { ... }` parses as spawn
  - Pipe bodies (`~>`, `~!>`, `~&>`) now accept block form: `arr ~!> { IF pipe > 0 { RETURN pipe * 2; } }`
  - Added `parseThreadExpr()` and `parseBlockAsExpr()` helpers
- **`ast.ts`** – New expression kinds: `ThreadExpr` (block or call form) and `AwaitExpr`; `Pipe.body` now accepts `Expr | BlockStmt`

### Diagnostics & Server
- **`server.ts`** – New diagnostic codes:
  - `doc-bad-type` – `{type}` annotation failed to parse
  - `doc-unknown-tag` – Unrecognized `@tag` name
  - `doc-deprecated-use` – Reference to a `@deprecated` binding (informational hint)
- **`runner.js`** (test harness) – Updated to surface doc-related diagnostics

## Implementation Details

- **Alias isolation** – `@shape` and `@callback`

https://claude.ai/code/session_01JunPgEDUTPPRvXmZRJat1L