### PR TITLE
Document console library control and CLI flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -206,7 +206,8 @@ A complete language tour and reference is in
 - Core data: `array`, `string`, `math`, `object`
 - Serialization: `json`, `yaml`, `csv`
 - I/O: `file`, `stream`, `os`, `process`
-- Crypto and time: `crypto`, `datetime`
+- Console / TUI: `console` (cursor, colour, raw input, mouse, async dispatcher)
+- Crypto and time: `crypto` (full `node:crypto` parity), `datetime`
 - Networking: `net`, `socket`, `secure_socket`, `http`, `https`
 - Concurrency: `thread`
 - Runtime control: `gc`, `jit`, `app`, `eval`, `include`, `_meta`
@@ -220,6 +221,7 @@ A complete language tour and reference is in
 - `window` — Cross-platform OS window with an OpenGL context.
 - `draw` — 2D drawing primitives layered on `window`.
 - `forms` — Native widget tree (Win32 today; stub elsewhere).
+- `cffi` — C foreign-function interface: load `.so`/`.dylib`/`.dll` and call into them via libffi.
 
 Each module is documented next to its source in
 [`modules/`](modules/README.md).  Per-function reference for each stdlib

--- a/docs/AI-GUIDE.md
+++ b/docs/AI-GUIDE.md
@@ -22,6 +22,8 @@ source/
   vm/                 vm.c (dispatch loop), bridge.c, chunk.c, debug.c
   jit/                trace recorder + IR + native codegen (gated by `--jit`)
   lib/                <name>.c + <name>.h per stdlib namespace
+                      (a few larger libs split into <name>_*.c -- see
+                       console_term.c / console_input.c / ...)
   natives.c, natives.h        print, type, toString, inspect
   cando_lib.c                 cando_open / cando_dofile / cando_openlibs
   main.c                      CLI entry point

--- a/docs/api/embedding.md
+++ b/docs/api/embedding.md
@@ -116,6 +116,45 @@ if (cando_dofile(vm, path) != CANDO_OK) {
 }
 ```
 
+## Disabling the console library
+
+Embedded hosts that own the terminal — windowed GUI apps, services,
+plug-in hosts inside an IDE — usually don't want scripts to start
+emitting ANSI escape sequences into the host's stdio.  Flip the
+console library off before running the script:
+
+```c
+CandoVM *vm = cando_open();
+cando_openlibs(vm);
+cando_console_set_enabled(vm, false);    // throw on any console.* call
+cando_dofile(vm, "user-script.cdo");
+cando_close(vm);
+```
+
+Inside the script, every `console.*` call now throws `"console is
+disabled"`, which `TRY`/`CATCH` handles cleanly.  The flag is
+inherited by VMs spawned via `thread { … }`, so child threads see
+the same disabled state.
+
+The three public symbols:
+
+```c
+void cando_console_set_enabled(CandoVM *vm, bool enabled);
+bool cando_console_is_enabled(const CandoVM *vm);
+void cando_console_detach(void);   /* process-wide */
+```
+
+`cando_console_detach()` is the heavy hammer — it calls `FreeConsole()`
+on Windows and `dup2`'s `/dev/null` over fd 0/1/2 on POSIX, so even
+host code that calls `fputs(stdout, …)` after this won't write to a
+real terminal.  Most embedders want both: detach to drop the
+inherited console window AND set-enabled-false so the script can't
+re-engage it.
+
+The same controls are exposed from script code via `console.disable()`
+/ `console.enable()` / `console.enabled()`, and from the CLI as
+`cando --no-console <script>`.
+
 ## Threading model
 
 The VM is **thread-aware**.  Multiple OS threads can execute script

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -59,6 +59,7 @@ void cando_open_threadlib(CandoVM *vm);
 void cando_open_oslib(CandoVM *vm);
 void cando_open_datetimelib(CandoVM *vm);
 void cando_open_cryptolib(CandoVM *vm);
+void cando_open_consolelib(CandoVM *vm);
 void cando_open_processlib(CandoVM *vm);
 void cando_open_netlib(CandoVM *vm);
 void cando_open_socketlib(CandoVM *vm);
@@ -107,6 +108,34 @@ const char *cando_errmsg(CandoVM *vm);
 Returns a formatted error message describing the most recent failure.
 Valid until the next entry-point call.  After a successful run, the
 message is `""`.
+
+## Console library control
+
+The `console` standard library is always linked into `libcando`, but
+embedders can disable it (and detach the host process from its
+inherited console) before running user scripts.  See
+[embedding.md § Disabling the console library](embedding.md#disabling-the-console-library)
+for the full embedder walkthrough.
+
+```c
+void cando_console_set_enabled(CandoVM *vm, bool enabled);
+bool cando_console_is_enabled(const CandoVM *vm);
+void cando_console_detach(void);
+```
+
+- `cando_console_set_enabled` flips a per-VM flag.  Default is `true`.
+  When `false`, every script call into `console.*` throws
+  `"console is disabled"`.  Child VMs spawned by `thread { … }`
+  inherit the flag from their parent.
+- `cando_console_is_enabled` reads the flag.
+- `cando_console_detach` is process-wide: `FreeConsole()` on Windows,
+  `dup2(/dev/null)` over fd 0/1/2 on POSIX.  Idempotent; safe to call
+  before any VM exists.  Does **not** implicitly disable the
+  library — call `cando_console_set_enabled(vm, false)` as well.
+
+The CLI flag `cando --no-console <script>` is implemented in terms of
+these symbols: it calls `cando_console_detach()` before `cando_open`
+and `cando_console_set_enabled(vm, false)` afterwards.
 
 ## Included sub-APIs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,10 +22,18 @@ parsed by `cando` itself and are **not** forwarded.
 | `--no-jit` | Force-disable the JIT.  Wins over both `--jit` and the `CANDO_JIT` environment variable. |
 | `--jit-stats` | Print a one-line summary of JIT activity to stderr at exit (back-edges, function entries, traces compiled, traces aborted, last abort reason). |
 | `--jit-dump` | Pretty-print the IR of every compiled trace.  Implies `--jit-stats`. |
+| `--no-console` | Detach the inherited console at startup and disable the `console` standard library for the script's lifetime.  Useful for launching CanDo scripts from a GUI shortcut or as a service.  See [libraries/console.md](libraries/console.md#cli-flag----no-console) for the precise behaviour. |
 
-Flag order does not matter, but all flags must come **after** the script
-path.  This is parsed left to right; the first non-flag argument after
-the script is treated as the start of `args[]`.
+Flag order is free: interpreter flags can appear **before or after** the
+script path.  The first non-flag argument is treated as the script;
+everything after it that isn't a recognised flag becomes part of
+`args[]`.
+
+```bash
+cando script.cdo --jit              # flag after script
+cando --jit script.cdo              # flag before script -- equivalent
+cando --no-console --jit script.cdo arg1 arg2
+```
 
 ## Script arguments
 

--- a/docs/libraries/README.md
+++ b/docs/libraries/README.md
@@ -29,18 +29,19 @@ These are not in any namespace; they live as plain global functions.
 
 | Namespace        | Page                                | What it covers |
 |------------------|-------------------------------------|----------------|
-| `array`          | [array.md](array.md)               | Array prototype methods (`push`, `pop`, `map`, `filter`, `reduce`, …). |
-| `string`         | [string.md](string.md)             | String prototype methods and `string.format`. |
-| `math`           | [math.md](math.md)                 | Trig, exponentials, rounding, random, constants. |
-| `object`         | [object.md](object.md)             | Object utilities, prototypes, locks. |
+| `array`          | [array.md](array.md)               | Array prototype methods — `push`/`pop`/`splice`/`map`/`filter`/`reduce` plus the full JS-style surface (`indexOf`, `includes`, `find`, `some`, `every`, `flat`, `concat`, `slice`, `join`, `sort`, `unique`, set ops, …). |
+| `string`         | [string.md](string.md)             | String prototype methods, `string.format`, padding (`padStart`/`padEnd`), substring search (`indexOf`/`includes`), UTF-8 codepoint helpers. |
+| `math`           | [math.md](math.md)                 | Trig, hyperbolic, log/exp, rounding (`floor`/`ceil`/`trunc`), `hypot`, `cbrt`, `log2`, random, constants. |
+| `object`         | [object.md](object.md)             | Object utilities, prototypes, locks, JS-style `entries`/`fromEntries`/`has`/`freeze`/`seal`. |
+| `console`        | [console.md](console.md)           | Terminal control — cursor, colour, raw-mode keyboard and mouse, line editing, async dispatcher, `attach`/`detach`/`hide`/`show` for GUI / service scripts. |
 | `json`           | [json.md](json.md)                 | JSON parse and stringify. |
 | `yaml`           | [yaml.md](yaml.md)                 | YAML parse and stringify. |
 | `csv`            | [csv.md](csv.md)                   | CSV parse and stringify. |
-| `file`           | [file.md](file.md)                 | Synchronous filesystem I/O. |
-| `os`             | [os.md](os.md)                     | Time, environment, process exit. |
+| `file`           | [file.md](file.md)                 | Synchronous filesystem I/O, `stat`, path helpers (`basename`, `dirname`, `extname`, `join`, `resolve`, `realpath`). |
+| `os`             | [os.md](os.md)                     | Time, environment, process exit, system info (`hostname`, `tmpdir`, `homedir`, `arch`, `platform`, `cpus`, memory). |
 | `process`        | [process.md](process.md)           | Spawning child processes, pipes. |
-| `datetime`       | [datetime.md](datetime.md)         | Time formatting and parsing. |
-| `crypto`         | [crypto.md](crypto.md)             | Hashes, base64. |
+| `datetime`       | [datetime.md](datetime.md)         | Formatting, parsing, component accessors, date math, calendar helpers. |
+| `crypto`         | [crypto.md](crypto.md)             | Full Node.js `node:crypto` parity — hashes (md5/sha1-2/sha3/blake2), HMAC, KDFs (pbkdf2/scrypt/hkdf), random, symmetric ciphers (AES/ChaCha20-Poly1305), asymmetric (RSA / EC / Ed25519 / X25519), X.509, encoding helpers, `timingSafeEqual`. |
 | `net`            | [net.md](net.md)                   | DNS lookup. |
 | `socket`         | [socket.md](socket.md)             | TCP client and server. |
 | `secure_socket`  | [secure_socket.md](secure_socket.md) | TLS client and server. |


### PR DESCRIPTION
This PR adds comprehensive documentation for the console library control features and updates related API references.

## Summary
Documents the new console library disable/enable functionality for embedded hosts, including the C API, script-level controls, and CLI flag. Also updates library documentation to reflect expanded feature coverage across multiple stdlib namespaces.

## Key changes

- **New embedding guide section**: "Disabling the console library" in `docs/api/embedding.md` with practical examples showing how to disable console output before running user scripts, including the three public C symbols (`cando_console_set_enabled`, `cando_console_is_enabled`, `cando_console_detach`)

- **API reference updates** in `docs/api/reference.md`:
  - Added `cando_open_consolelib` to the library list
  - New "Console library control" section documenting the three control functions, their behavior, and inheritance by child VMs

- **CLI documentation** in `docs/cli.md`:
  - Added `--no-console` flag documentation
  - Clarified that interpreter flags can appear before or after the script path
  - Added examples showing flag ordering flexibility

- **Library table updates** in `docs/libraries/README.md`:
  - Added `console` namespace entry with description of terminal control features
  - Expanded descriptions for existing namespaces (`array`, `string`, `math`, `object`, `file`, `os`, `datetime`, `crypto`) to better reflect their actual capabilities

- **README updates** in `Readme.md`:
  - Added `console` to the stdlib list with TUI capabilities
  - Added `cffi` module to the optional modules list
  - Enhanced descriptions of `crypto` and `datetime` modules

- **Developer guide** in `docs/AI-GUIDE.md`:
  - Noted that larger libraries like console are split across multiple source files

## Notable details

The documentation emphasizes that `cando_console_detach()` is a process-wide operation (using `FreeConsole()` on Windows and `dup2(/dev/null)` on POSIX), while `cando_console_set_enabled()` is per-VM and inherited by child threads. The CLI flag `--no-console` combines both operations for convenience.

https://claude.ai/code/session_01JnNf2mFMSW5NpFthiTZmwR